### PR TITLE
feat(config): persistent default execution policy for fresh starts

### DIFF
--- a/.claude-plugin/skills/auto/SKILL.md
+++ b/.claude-plugin/skills/auto/SKILL.md
@@ -62,7 +62,11 @@ When the user types `ooo auto` with CLI-style flags inside chat, translate to MC
 
 `--pipeline-timeout-seconds` is accepted only when starting a session. Passing it with `--resume` is rejected because the original deadline is preserved across process restarts.
 
-Before a fresh start with no user choice, ask in outcome language: **Efficient
+Before a fresh start with no user choice, first check the persistent default:
+when `execution.default_policy` in `~/.ouroboros/config.yaml` is `efficient` or
+`quality_first`, do not ask — omit both arguments and the server applies the
+configured default (the handoff still reports the resolved policy). Otherwise
+ask in outcome language: **Efficient
 execution** maps to `adaptive/observe`; **Quality-first execution** maps to
 `quality_first/off`. `strict` assurance is separate explicit consent because it
 may spend extra work on proof. Do not send these arguments on resume; the server

--- a/.claude-plugin/skills/run/SKILL.md
+++ b/.claude-plugin/skills/run/SKILL.md
@@ -72,7 +72,11 @@ fallback instead of retrying the failing call.
    - If inline YAML: Use directly
    - If neither: Check conversation history for a recently generated seed
 
-   Before a fresh start, when no efficiency choice is already known, ask in
+   Before a fresh start, when no efficiency choice is already known, first
+   check the persistent default: when `execution.default_policy` in
+   `~/.ouroboros/config.yaml` is `efficient` or `quality_first`, do not ask —
+   omit both arguments and the server applies the configured default (the
+   start handoff still reports the resolved policy). Otherwise ask in
    user-outcome language: **Efficient execution** maps to
    `efficiency_mode="adaptive"` plus `frugality_assurance="observe"`;
    **Quality-first execution** maps to `efficiency_mode="quality_first"` plus

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -374,6 +374,7 @@ execution:
 | `auto_evolve_max_generations` | `int` | `3` | Maximum generations for automatically chained Ralph work. Values are clamped to Ralph's supported `1..10` range. |
 | `default_model` | `string \| null` | `null` | Optional Execute-stage model pin. `null`, an empty value, `"default"`, or `"current"` means Ouroboros does not pass a concrete `--model`; the selected runtime keeps its own current/default model. `OUROBOROS_EXECUTION_MODEL` has highest precedence, and a present empty env var explicitly clears the saved pin for that process. |
 | `project_guidance` | `list[string]` | `[]` | Guidance IDs loaded from `<project-root>/.ouroboros/guidance/<id>/GUIDANCE.md` and appended to execution system prompts. This option is config-only and has no environment-variable override. |
+| `default_policy` | `"ask"` \| `"efficient"` \| `"quality_first"` | `"ask"` | Persistent default execution policy for fresh runs. `ask` preserves the host's interactive efficiency prompt exactly. `efficient` resolves omitted arguments to `adaptive`/`observe` and `quality_first` to `quality_first`/`off` without asking. Explicit invocation arguments always win, resumed sessions keep their persisted immutable contract, and `strict` frugality assurance never derives from this setting. |
 
 ### Project Execution Guidance
 

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -84,7 +84,11 @@ When the user types `ooo auto` with CLI-style flags inside chat, translate to MC
 `--pipeline-timeout-seconds` is accepted only when starting a session. Passing it with `--resume` is rejected because the original deadline is preserved across process restarts.
 
 Before a fresh Auto start, if the user did not already choose an efficiency
-policy, ask in outcome language: **Efficient execution** maps to
+policy, first check the persistent default: when `execution.default_policy` in
+`~/.ouroboros/config.yaml` is `efficient` or `quality_first`, do not ask — omit
+both arguments and the server applies the configured default (the handoff still
+reports the resolved policy). Otherwise ask in outcome language:
+**Efficient execution** maps to
 `adaptive/observe`; **Quality-first execution** maps to `quality_first/off`.
 `strict` assurance is a separate explicit opt-in because it may spend extra
 work on proof. Never infer strict from the efficiency choice. On resume, do not

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -76,7 +76,11 @@ fallback instead of retrying the failing call.
    - If neither: Check conversation history for a recently generated seed
 
    Before a fresh start, when the user has not already chosen an efficiency
-   policy, ask in outcome language:
+   policy, first check the persistent default: when `execution.default_policy`
+   in `~/.ouroboros/config.yaml` is `efficient` or `quality_first`, do not ask —
+   omit both arguments and the server applies the configured default (the start
+   handoff still reports the resolved policy). When it is `ask` or unset, ask
+   in outcome language:
 
    - **Efficient execution** — start parallel/decomposed work economically and
      strengthen the route only when recovery requires it. Send

--- a/src/ouroboros/config/__init__.py
+++ b/src/ouroboros/config/__init__.py
@@ -28,6 +28,7 @@ from ouroboros.config.loader import (
     config_exists,
     create_default_config,
     credentials_file_secure,
+    default_execution_efficiency_mode,
     ensure_config_dir,
     get_agent_permission_mode,
     get_agent_reasoning_effort,
@@ -136,6 +137,7 @@ __all__ = [
     "OrchestratorConfig",
     "RuntimeProfileConfig",
     # Loader functions
+    "default_execution_efficiency_mode",
     "load_config",
     "load_credentials",
     "create_default_config",

--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -1103,6 +1103,28 @@ def get_auto_evolve_enabled() -> bool:
         return True
 
 
+def default_execution_efficiency_mode() -> str | None:
+    """Map ``execution.default_policy`` to a fresh-start efficiency mode.
+
+    ``None`` — for ``ask`` or an unreadable config — preserves the
+    interactive-prompt contract exactly (#1733). ``efficient`` and
+    ``quality_first`` return the efficiency mode whose documented coupling
+    supplies the paired frugality default (adaptive/observe and
+    quality_first/off); strict assurance never derives from here. Explicit
+    invocation arguments take precedence at the call sites, and resumed
+    sessions never consult this.
+    """
+    try:
+        policy = load_config().execution.default_policy
+    except ConfigError:
+        return None
+    if policy == "efficient":
+        return "adaptive"
+    if policy == "quality_first":
+        return "quality_first"
+    return None
+
+
 def get_auto_evolve_max_generations() -> int:
     """Return the bounded generation budget for automatic Ralph chaining."""
 

--- a/src/ouroboros/config/models.py
+++ b/src/ouroboros/config/models.py
@@ -256,6 +256,13 @@ class ExecutionConfig(BaseModel, frozen=True):
             (stack, verify commands, layout) to run worker system prompts.
         project_guidance: Allowlist of project guidance ids to resolve from
             fixed project-local paths under ``.ouroboros/guidance/<id>/GUIDANCE.md``.
+        default_policy: Persistent default execution policy for FRESH runs
+            (#1733). ``ask`` (the default) preserves the host's interactive
+            prompt exactly; ``efficient`` resolves to adaptive/observe and
+            ``quality_first`` to quality_first/off without asking. Explicit
+            invocation arguments always win, resumed sessions keep their
+            persisted immutable contract, and strict frugality assurance
+            never derives from this setting.
     """
 
     max_iterations_per_ac: int = Field(default=10, ge=1)
@@ -273,6 +280,7 @@ class ExecutionConfig(BaseModel, frozen=True):
     decomposition_mode: Literal["bounce_only", "off"] = "bounce_only"
     context_pack: bool = True
     project_guidance: tuple[str, ...] = ()
+    default_policy: Literal["ask", "efficient", "quality_first"] = "ask"
 
     @field_validator("decomposition_mode", mode="before")
     @classmethod

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -74,7 +74,7 @@ from ouroboros.auto.worktree import (
     ensure_auto_worktree,
     release_auto_worktree,
 )
-from ouroboros.config import get_opencode_mode
+from ouroboros.config import default_execution_efficiency_mode, get_opencode_mode
 from ouroboros.core.execution_preferences import resolve_execution_preferences
 from ouroboros.core.file_lock import file_lock
 from ouroboros.core.types import Result
@@ -250,7 +250,9 @@ class AutoHandler:
                     (
                         "Execution efficiency policy: adaptive may use lower-cost child "
                         "tiers with recovery escalation; quality_first keeps child ACs "
-                        "at the parent starting tier. Default: adaptive."
+                        "at the parent starting tier. When omitted on a fresh start, a "
+                        "configured execution.default_policy supplies it; otherwise "
+                        "defaults to adaptive."
                     ),
                     required=False,
                     enum=("adaptive", "quality_first"),
@@ -468,7 +470,7 @@ class AutoHandler:
             goal_text = goal.strip()
             state = AutoPipelineState(goal=goal_text, cwd=cwd)
             preferences = resolve_execution_preferences(
-                requested_efficiency_mode,
+                requested_efficiency_mode or default_execution_efficiency_mode(),
                 requested_frugality_assurance,
             )
             state.efficiency_mode = preferences.efficiency_mode.value
@@ -1043,7 +1045,7 @@ class StartAutoHandler:
         cwd = str(_resolve_cwd(arguments.get("cwd")))
         state = AutoPipelineState(goal=goal, cwd=cwd)
         preferences = resolve_execution_preferences(
-            _optional_text_arg(arguments, "efficiency_mode"),
+            _optional_text_arg(arguments, "efficiency_mode") or default_execution_efficiency_mode(),
             _optional_text_arg(arguments, "frugality_assurance"),
         )
         state.efficiency_mode = preferences.efficiency_mode.value

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -19,6 +19,7 @@ import structlog
 import yaml
 
 from ouroboros.config.loader import (
+    default_execution_efficiency_mode,
     get_auto_evaluate_enabled,
     get_auto_evolve_enabled,
     get_max_parallel_workers,
@@ -236,6 +237,12 @@ def _resolve_execution_preferences_request(
         raise ValueError("efficiency_mode must be adaptive or quality_first")
     if raw_assurance is not None and not isinstance(raw_assurance, str):
         raise ValueError("frugality_assurance must be off, observe, or strict")
+    if raw_efficiency is None and not is_resume:
+        # Persistent default policy fills the fresh-start gap (#1733):
+        # explicit arguments won above, resume keeps its persisted contract,
+        # and the coupled frugality default still derives from the mode, so
+        # strict can never appear implicitly.
+        raw_efficiency = default_execution_efficiency_mode()
     preferences = resolve_execution_preferences(raw_efficiency, raw_assurance)
     return (
         preferences,
@@ -1075,7 +1082,9 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     description=(
                         "Execution efficiency policy. adaptive may start decomposed ACs "
                         "on lower-cost tiers and escalate on recovery; quality_first keeps "
-                        "children at the parent starting tier. Default: adaptive."
+                        "children at the parent starting tier. When omitted on a fresh "
+                        "start, a configured execution.default_policy supplies it; "
+                        "otherwise defaults to adaptive."
                     ),
                     required=False,
                     enum=("adaptive", "quality_first"),

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -17,6 +17,7 @@ from ouroboros.config.loader import (
     config_exists,
     create_default_config,
     credentials_file_secure,
+    default_execution_efficiency_mode,
     ensure_config_dir,
     get_agent_permission_mode,
     get_agent_runtime_backend,
@@ -2576,3 +2577,28 @@ class TestConfigEncodingLocaleIndependence:
 
         with pytest.raises(ValueError, match="invalid EventStore configuration"):
             resolve_event_store_path(config_path)
+
+
+class TestDefaultExecutionEfficiencyMode:
+    """#1733: persistent default execution policy for fresh starts."""
+
+    @pytest.mark.parametrize(
+        ("policy", "expected"),
+        [("ask", None), ("efficient", "adaptive"), ("quality_first", "quality_first")],
+    )
+    def test_policy_maps_to_fresh_start_efficiency_mode(
+        self, policy: str, expected: str | None
+    ) -> None:
+        config = OuroborosConfig(execution=ExecutionConfig(default_policy=policy))
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("ouroboros.config.loader.load_config", return_value=config),
+        ):
+            assert default_execution_efficiency_mode() == expected
+
+    def test_unreadable_config_preserves_the_ask_contract(self) -> None:
+        with patch(
+            "ouroboros.config.loader.load_config",
+            side_effect=ConfigError("unreadable"),
+        ):
+            assert default_execution_efficiency_mode() is None

--- a/tests/unit/config/test_models.py
+++ b/tests/unit/config/test_models.py
@@ -345,6 +345,18 @@ class TestExecutionConfig:
             ExecutionConfig(auto_evolve_max_generations=raw).auto_evolve_max_generations == expected
         )
 
+    def test_default_policy_defaults_to_ask_and_validates(self) -> None:
+        """#1733: the persistent fresh-run policy defaults to ask, accepts the
+        two documented alternatives, and rejects everything else — strict can
+        never be configured as a default policy."""
+        assert ExecutionConfig().default_policy == "ask"
+        assert ExecutionConfig(default_policy="efficient").default_policy == "efficient"
+        assert ExecutionConfig(default_policy="quality_first").default_policy == "quality_first"
+        with pytest.raises(ValidationError):
+            ExecutionConfig(default_policy="strict")  # type: ignore[arg-type]
+        with pytest.raises(ValidationError):
+            ExecutionConfig(default_policy="adaptive")  # type: ignore[arg-type]
+
     def test_execution_config_migrates_legacy_preflight_to_bounce_only(self) -> None:
         """Stored preflight settings cannot re-enable pre-execution splitting."""
         config = ExecutionConfig(decomposition_mode="preflight")  # type: ignore[arg-type]

--- a/tests/unit/mcp/tools/test_execution_preference_defaults.py
+++ b/tests/unit/mcp/tools/test_execution_preference_defaults.py
@@ -1,0 +1,94 @@
+"""Fresh-start execution preferences honor the persistent default policy (#1733)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ouroboros.mcp.tools.execution_handlers import _resolve_execution_preferences_request
+
+_CONFIG_TARGET = "ouroboros.mcp.tools.execution_handlers.default_execution_efficiency_mode"
+
+
+class TestFreshStartDefaultPolicy:
+    def test_config_default_fills_omitted_arguments(self) -> None:
+        """A configured quality_first policy resolves omitted arguments to
+        quality_first/off and flows into the raw efficiency value the runner
+        receives."""
+        with patch(_CONFIG_TARGET, return_value="quality_first"):
+            preferences, raw_efficiency, raw_assurance = _resolve_execution_preferences_request(
+                {}, is_resume=False
+            )
+
+        assert preferences.efficiency_mode.value == "quality_first"
+        assert preferences.frugality_assurance.value == "off"
+        assert preferences.frugality_assurance_explicit is False
+        assert raw_efficiency == "quality_first"
+        assert raw_assurance is None
+
+    def test_config_efficient_maps_to_adaptive_observe(self) -> None:
+        with patch(_CONFIG_TARGET, return_value="adaptive"):
+            preferences, raw_efficiency, _raw_assurance = _resolve_execution_preferences_request(
+                {}, is_resume=False
+            )
+
+        assert preferences.efficiency_mode.value == "adaptive"
+        assert preferences.frugality_assurance.value == "observe"
+        assert preferences.frugality_assurance_explicit is False
+        assert raw_efficiency == "adaptive"
+
+    def test_explicit_argument_beats_the_configured_default(self) -> None:
+        with patch(_CONFIG_TARGET, return_value="quality_first"):
+            preferences, raw_efficiency, _raw_assurance = _resolve_execution_preferences_request(
+                {"efficiency_mode": "adaptive"}, is_resume=False
+            )
+
+        assert preferences.efficiency_mode.value == "adaptive"
+        assert preferences.frugality_assurance.value == "observe"
+        assert raw_efficiency == "adaptive"
+
+    def test_explicit_assurance_composes_with_the_configured_mode(self) -> None:
+        """An explicitly supplied assurance stays explicit — the configured
+        default supplies only the efficiency mode, so strict remains a
+        deliberate opt-in."""
+        with patch(_CONFIG_TARGET, return_value="adaptive"):
+            preferences, raw_efficiency, raw_assurance = _resolve_execution_preferences_request(
+                {"frugality_assurance": "strict"}, is_resume=False
+            )
+
+        assert preferences.efficiency_mode.value == "adaptive"
+        assert preferences.frugality_assurance.value == "strict"
+        assert preferences.frugality_assurance_explicit is True
+        assert raw_efficiency == "adaptive"
+        assert raw_assurance == "strict"
+
+    def test_ask_or_unset_config_preserves_the_engine_default(self) -> None:
+        with patch(_CONFIG_TARGET, return_value=None):
+            preferences, raw_efficiency, _raw_assurance = _resolve_execution_preferences_request(
+                {}, is_resume=False
+            )
+
+        assert preferences.efficiency_mode.value == "adaptive"
+        assert preferences.frugality_assurance.value == "observe"
+        assert raw_efficiency is None
+
+    def test_resume_never_consults_the_configured_default(self) -> None:
+        """A resumed session keeps its persisted immutable contract; the
+        persistent policy is not even read."""
+        config_reader = MagicMock(return_value="quality_first")
+        with patch(_CONFIG_TARGET, config_reader):
+            preferences, raw_efficiency, _raw_assurance = _resolve_execution_preferences_request(
+                {}, is_resume=True
+            )
+
+        config_reader.assert_not_called()
+        assert preferences.efficiency_mode.value == "adaptive"
+        assert raw_efficiency is None
+
+    def test_resume_still_rejects_supplied_arguments(self) -> None:
+        with (
+            patch(_CONFIG_TARGET, return_value="quality_first"),
+            pytest.raises(ValueError, match="cannot be changed on resume"),
+        ):
+            _resolve_execution_preferences_request({"efficiency_mode": "adaptive"}, is_resume=True)

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -531,6 +531,66 @@ class TestBackgroundJobPath:
         fake_inner_auto.handle.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_fresh_start_applies_configured_default_policy(
+        self, event_store, fake_inner_auto, tmp_path
+    ) -> None:
+        """#1733: a configured quality_first default reaches a fresh Auto
+        start when the host omits both preference arguments."""
+        job_manager = MagicMock()
+        job_manager.allocate_job_id = AsyncMock(return_value="job_alloc")
+        snapshot = MagicMock()
+        snapshot.job_id = "job_auto_policy"
+
+        async def _start_job(*, runner, **_):
+            if inspect.iscoroutine(runner):
+                runner.close()
+            return snapshot
+
+        job_manager.start_job = AsyncMock(side_effect=_start_job)
+        store = AutoStore(tmp_path)
+        h = StartAutoHandler(event_store=event_store, job_manager=job_manager, store=store)
+        h._inner_auto = fake_inner_auto
+
+        with patch(
+            "ouroboros.mcp.tools.auto_handler.default_execution_efficiency_mode",
+            return_value="quality_first",
+        ):
+            result = await h.handle({"goal": "build a CLI"})
+
+        assert result.is_ok
+        assert result.value.meta["efficiency_mode"] == "quality_first"
+        assert result.value.meta["frugality_assurance"] == "off"
+
+    @pytest.mark.asyncio
+    async def test_fresh_start_explicit_argument_beats_configured_default(
+        self, event_store, fake_inner_auto, tmp_path
+    ) -> None:
+        job_manager = MagicMock()
+        job_manager.allocate_job_id = AsyncMock(return_value="job_alloc")
+        snapshot = MagicMock()
+        snapshot.job_id = "job_auto_policy2"
+
+        async def _start_job(*, runner, **_):
+            if inspect.iscoroutine(runner):
+                runner.close()
+            return snapshot
+
+        job_manager.start_job = AsyncMock(side_effect=_start_job)
+        store = AutoStore(tmp_path)
+        h = StartAutoHandler(event_store=event_store, job_manager=job_manager, store=store)
+        h._inner_auto = fake_inner_auto
+
+        with patch(
+            "ouroboros.mcp.tools.auto_handler.default_execution_efficiency_mode",
+            return_value="quality_first",
+        ):
+            result = await h.handle({"goal": "build a CLI", "efficiency_mode": "adaptive"})
+
+        assert result.is_ok
+        assert result.value.meta["efficiency_mode"] == "adaptive"
+        assert result.value.meta["frugality_assurance"] == "observe"
+
+    @pytest.mark.asyncio
     async def test_now_binds_durable_job_scoped_cancel_key(
         self, event_store, fake_inner_auto, tmp_path, monkeypatch
     ) -> None:


### PR DESCRIPTION
Closes #1733.

## What

Adds the proposed `execution.default_policy` configuration surface with the ask-preserving default:

```yaml
execution:
  default_policy: ask   # or: efficient | quality_first
```

`ask` (the default) preserves the current interactive prompt exactly. `efficient` resolves omitted preference arguments to `adaptive`/`observe`, and `quality_first` to `quality_first`/`off` — implemented by mapping the policy to a fresh-start efficiency mode and letting the existing documented coupling supply the paired frugality default, so `strict` structurally cannot appear implicitly (the config value never touches assurance).

## Precedence, as suggested in the issue

1. Explicit MCP/CLI arguments win: the policy fills the gap only when `efficiency_mode` is omitted, and an explicitly supplied `frugality_assurance` composes with the configured mode while keeping its explicitness (so a deliberate `strict` still works with a configured `efficient`).
2. The persistent configuration is consulted at both fresh-start resolution seams — the run handlers' shared preference resolver (where the resolved value also flows into the runner construction) and both Auto state builders — and never on resume: the resolver's resume guard sits before the config read, pinned by a regression asserting the config is not even consulted.
3. When the policy is `ask` or unset (or the config is unreadable), behavior is byte-identical to today, including the engine fallback for direct callers.

The resolved policy still appears in the execution-start handoff and Auto briefing, which read the resolved preferences.

## Exposure

`config show` and `config set execution.default_policy quality_first` work through the existing schema-validated generic paths (the key validates against the pydantic schema; invalid values are rejected at load with a field-level error). The run and auto skill contracts — canonical and bundled plugin copies, which are intentionally worded differently and were edited in place rather than overwritten — now instruct hosts to skip the prompt and omit both arguments when a policy is configured. Tool parameter descriptions document the fallback order, and `docs/config-reference.md` gains the field row. The repository currently has no TUI or web settings editor surface, so there is nothing further to wire there; if one lands, the field is an ordinary `ExecutionConfig` member.

## Tests

Model validation (default, both alternatives, rejection of `strict`/raw modes), loader mapping (all three policies plus unreadable-config fail-open to ask), seven resolver-level regressions (fill, both mappings, explicit-argument precedence, explicit-assurance composition, ask passthrough, resume-never-consults, resume-still-rejects-arguments), and two Auto handler regressions (configured policy reaches a fresh start's persisted state and meta; explicit argument beats it). Affected suites (config 344, start-auto and resolver 71, definitions, skill artifacts) pass — the only local failures are the two known environment-dependent path-poison cases that fail identically on origin/main. ruff, ruff format, mypy, and the module-size check pass (`auto_handler.py` stays within its grandfathered budget).
