### PR TITLE
feat: add activation and workflow recovery telemetry

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -133,23 +133,18 @@ Ouroboros는 이 철학을 **Double Diamond** 구조로 풀어냅니다:
 curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | OUROBOROS_INSTALL_REF=readme-ko bash
 ```
 
-**처음 사용** — AI 코딩 에이전트를 열고 입력하세요:
+**첫 명령** — AI 코딩 에이전트를 열고 아래 두 명령을 순서대로 입력하세요:
 
 ```
-> ooo
-```
-
-한 번만 필요한 설정이 있다면, Ouroboros가 변경하기 전에 먼저 물어봅니다.
-설정이 끝나면 Codex는 현재 선택한 모델을 따르고, Claude Code는 권장 기본
-모델 설정으로 시작합니다. 특정 단계의 모델을 고정하고 싶을 때만 **직접 모델
-설정하기**를 선택하세요. 내 컴퓨터의 브라우저에 로컬 설정 화면이 열립니다.
-나중에 `ooo config`로 언제든 다시 바꿀 수 있습니다.
-
-**시작** — 이후 바로 작업할 수 있습니다:
-
-```
+> ooo setup
 > ooo interview "I want to build a task management CLI"
 ```
+
+`ooo setup`은 한 번만 하는 실행 환경 설정이고, `ooo interview`가 설치 후
+처음 실행할 워크플로우 명령입니다. 설정이 끝나면 Codex는 현재 선택한 모델을
+따르고, Claude Code는 권장 기본 모델 설정으로 시작합니다. 특정 단계의 모델을
+고정하고 싶을 때만 **직접 모델 설정하기**를 선택하세요. 내 컴퓨터의 브라우저에
+로컬 설정 화면이 열립니다. 나중에 `ooo config`로 언제든 다시 바꿀 수 있습니다.
 
 에이전트 호스트 없이 터미널에서 바로 쓸 수도 있습니다:
 
@@ -183,10 +178,16 @@ codex plugin marketplace add Q00/ouroboros
 codex plugin add ouroboros@ouroboros
 ```
 
-새 Codex 세션을 연 뒤 `ooo`를 입력하세요. 처음 사용할 때는 Ouroboros가
-변경하기 전에 실행 환경 설정을 제안합니다. 준비가 끝나면 Codex의 현재 기본
-모델을 따릅니다. 특정 단계의 모델을 고정하고 싶을 때만 **직접 모델 설정하기**를
-선택하세요.
+새 Codex 세션을 연 뒤 아래 명령을 순서대로 입력하세요:
+
+```
+ooo setup
+ooo interview "Build a task management CLI"
+```
+
+`ooo setup`은 한 번만 하는 실행 환경 설정입니다. 준비가 끝나면 Codex의 현재
+기본 모델을 따릅니다. 특정 단계의 모델을 고정하고 싶을 때만 **직접 모델
+설정하기**를 선택하세요.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -134,23 +134,19 @@ Most AI coding fails at the **input**, not the output. The bottleneck is not AI 
 curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | OUROBOROS_INSTALL_REF=readme bash
 ```
 
-**First use** — open your AI coding agent and type:
+**First command** — open your AI coding agent and run these in order:
 
 ```
-> ooo
-```
-
-If a one-time setup is needed, Ouroboros asks before it makes changes. After
-setup, Codex follows its currently selected model and Claude Code starts with
-its recommended model settings. Choose **Directly configure models** only when
-you want to pin a stage to a specific model; it opens the local settings screen
-in your browser. You can return to those settings any time with `ooo config`.
-
-**Build** — then go:
-
-```
+> ooo setup
 > ooo interview "I want to build a task management CLI"
 ```
+
+`ooo setup` is a one-time configuration step. `ooo interview` is the first
+workflow command and starts the Socratic interview. After setup, Codex follows
+its currently selected model and Claude Code starts with its recommended model
+settings. Choose **Directly configure models** only when you want to pin a
+stage to a specific model; it opens the local settings screen in your browser.
+You can return to those settings any time with `ooo config`.
 
 Or from a plain terminal, without an agent host:
 
@@ -184,10 +180,16 @@ codex plugin marketplace add Q00/ouroboros
 codex plugin add ouroboros@ouroboros
 ```
 
-Start a new Codex session, then enter `ooo`. On first use, Ouroboros offers to
-prepare the runtime before it changes anything. Once ready, it follows Codex's
-current default model; choose **Directly configure models** only when you want
-to pin a specific model for a pipeline stage.
+Start a new Codex session, then run these commands in order:
+
+```
+ooo setup
+ooo interview "Build a task management CLI"
+```
+
+`ooo setup` is the one-time runtime preparation. Once ready, Ouroboros follows
+Codex's current default model; choose **Directly configure models** only when
+you want to pin a specific model for a pipeline stage.
 
 </details>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -109,11 +109,15 @@ Ouroboros 是面向 AI 编码的 Agent OS：一层本地优先的运行时，把
 curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | OUROBOROS_INSTALL_REF=readme-zh bash
 ```
 
-**开始** —— 打开你的 AI 编码 agent，直接上：
+**第一条命令** —— 打开你的 AI 编码 agent，按顺序运行：
 
 ```
+> ooo setup
 > ooo interview "I want to build a task management CLI"
 ```
+
+`ooo setup` 只需运行一次，用来配置运行环境；`ooo interview` 才是安装后
+启动第一个工作流的命令。
 
 也可以不经过 agent 宿主，直接在终端里跑：
 
@@ -147,7 +151,15 @@ codex plugin marketplace add Q00/ouroboros
 codex plugin add ouroboros@ouroboros
 ```
 
-打开一个新的 Codex 会话，输入 `ooo`。首次使用时，Ouroboros 会在改动任何内容之前，先询问是否准备运行环境。准备就绪后，它会沿用 Codex 当前的默认模型；只有在需要为某个流水线阶段固定特定模型时，才选择**直接配置模型**。
+打开一个新的 Codex 会话，按顺序运行：
+
+```
+ooo setup
+ooo interview "Build a task management CLI"
+```
+
+`ooo setup` 只需运行一次，用来准备运行环境。准备就绪后，它会沿用 Codex
+当前的默认模型；只有在需要为某个流水线阶段固定特定模型时，才选择**直接配置模型**。
 
 </details>
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -90,10 +90,10 @@ together, always.
 |---|---|---|
 | `install_started` | `install.sh` begins | source, os, arch, version, is_local, pre, ref |
 | `install_completed` | `install.sh` finishes | source, os, arch, method (uv/pipx/pip), runtime, detected_runtimes (count), version, ref |
-| `command_run` (source=mcp) | An `ouroboros_*` MCP tool is invoked from any host CLI (Claude Code, Codex, OpenCode, …) | command (interview/seed/run/evolve/auto/evaluate/qa/…), tool, source, is_funnel, phase (`submission` or `completion`), accepted (submission only), ok (completion only), duration_ms, error_type, sample_rate (polling tools only), runtime_backend, execute_runtime_backend, interview_llm_backend, evaluate_llm_backend, frontdoor, app_version, os, python_version, ci |
+| `command_run` (source=mcp) | An `ouroboros_*` MCP tool is invoked from any host CLI (Claude Code, Codex, OpenCode, …) | command (interview/seed/run/evolve/auto/evaluate/qa/…), tool, source, is_funnel, phase (`submission` or `completion`), accepted (submission only), ok (completion only), duration_ms, error_type, sample_rate (polling tools only), runtime_backend, execute_runtime_backend, interview_llm_backend, evaluate_llm_backend, frontdoor, first_command_surface, app_version, os, python_version, ci |
 | `command_run` (source=cli) | A direct `ooo <subcommand>` invocation in a terminal | command, source, is_funnel, app_version, os, python_version, frontdoor, ci — no tool, phase, duration/outcome fields, or backend context: those are mcp-only |
-| `workflow_outcome` | Two producers (never both for the same evaluation — see Notes): a background MCP job reaches a durable terminal event, **or** a direct (non-job) `ouroboros_evaluate` / `ouroboros_checklist_verify` completion | command, phase (`terminal`), terminal_status, ok, verified, final_approved, `$insert_id` (job-derived variant only — one-way event deduplication digest), runtime_backend, execute_runtime_backend, interview_llm_backend, evaluate_llm_backend, app_version, os, python_version, frontdoor, ci |
-| `mcp_serve_started` | A host CLI attaches the Ouroboros MCP server for a session | transport, tool_count, frontdoor, app_version, os, ci — no python_version, no backend/provider context |
+| `workflow_outcome` | Two producers (never both for the same evaluation — see Notes): a background MCP job reaches a durable terminal event, **or** a direct (non-job) `ouroboros_evaluate` / `ouroboros_checklist_verify` completion | command, phase (`terminal`), terminal_status, ok, verified, final_approved, failure_reason_code (failed/cancelled/interrupted outcomes only), recovery_action (failed/cancelled/interrupted outcomes only), `$insert_id` (job-derived variant only — one-way event deduplication digest), runtime_backend, execute_runtime_backend, interview_llm_backend, evaluate_llm_backend, app_version, os, python_version, frontdoor, ci |
+| `mcp_serve_started` | A host CLI attaches the Ouroboros MCP server for a session | transport, tool_count, frontdoor, first_command_surface, app_version, os, ci — no python_version, no backend/provider context |
 
 Notes:
 
@@ -103,6 +103,13 @@ Notes:
   the command was copied from; it is chosen by us, never derived from the
   machine, defaults to `direct`, and is discarded unless it matches
   `[A-Za-z0-9._-]{1,32}`.
+- `first_command_surface` is a fixed enum (`readme_quickstart`,
+  `getting_started`, `setup_complete`, or `unknown`) carried only on MCP
+  session/command events. README and Getting Started installers persist the
+  enum locally before setup; the hint remains preferred after setup so the
+  first-command cohort still represents the page that brought the user in.
+  A missing hint with an existing `~/.ouroboros/config.yaml` is attributed to
+  `setup_complete`. It contains no URL, prompt, path, or user identifier.
 
 - `source` separates the two entry surfaces cleanly: `cli` means the user typed
   the command in a terminal; `mcp` means it arrived from inside an AI agent
@@ -132,6 +139,14 @@ Notes:
   `extension_command` value.
 - `error_type` is only the Python exception class name (e.g. `TimeoutError`),
   never a message or traceback.
+- `failure_reason_code` and `recovery_action` are fixed enums emitted only for
+  non-success terminal outcomes. The classifier reads terminal status and
+  structured machine metadata only; it never reads exception messages, result
+  text, prompts, paths, or identifiers. Current reason codes are `config`,
+  `auth`, `timeout`, `model`, `tool`, `validation`, `cancelled`, and `unknown`.
+  Current recovery actions are `retry`, `setup`, `login`, `update`,
+  `inspect_logs`, and `none`. An unclassified failure is always `unknown` with
+  `inspect_logs`, so the failure denominator remains measurable.
 - Start-tool `command_run` events are submission receipts. They intentionally
   have `accepted`, not `ok`; queue acceptance is never a completed or verified
   run. `workflow_outcome` is the durable/direct terminal boundary described

--- a/docs/first-command-activation/architecture.md
+++ b/docs/first-command-activation/architecture.md
@@ -1,0 +1,56 @@
+# First-command activation architecture
+
+> Generated: 2026-08-13
+> Approach: install hint plus setup fallback
+
+## Overview
+
+The installer translates a documented `OUROBOROS_INSTALL_REF` token into a
+coarse enum and stores it at `~/.ouroboros/first_command_surface` with a
+restrictive umask. Telemetry reads the enum for MCP events. If no hint exists,
+an existing `~/.ouroboros/config.yaml` indicates `setup_complete`; otherwise it
+uses `unknown`.
+
+## Data flow
+
+```text
+README / Getting Started
+        │  OUROBOROS_INSTALL_REF
+        ▼
+scripts/install.sh ──► ~/.ouroboros/first_command_surface
+        │                         │
+        └──────────────┐          ▼
+                       │   telemetry detector
+                       ▼          │
+                 MCP startup ─────┴──► first_command_surface
+                                      │
+                                      └──► MCP command_run
+```
+
+## Components
+
+| Component | Responsibility | Location |
+|---|---|---|
+| Installer mapping | Convert README/guide tokens to fixed enum and persist a local hint | `scripts/install.sh` |
+| Detector | Resolve explicit trusted process value, hint, setup fallback, or unknown | `src/ouroboros/telemetry.py` |
+| Trust boundary | Prevent a cloned project's `.env` from overriding attribution | `src/ouroboros/config/untrusted_env.py` |
+| Event contract | Allow the enum only on MCP command and server-start events | `TELEMETRY.md`, `src/ouroboros/telemetry.py` |
+| Onboarding surfaces | Show the same setup → first-command sequence | README files, `docs/getting-started.md`, runtime guides |
+
+## Privacy and failure behavior
+
+- Values outside the four enum members are discarded as `unknown`.
+- A missing or unreadable hint never blocks installation or telemetry.
+- The hint contains no URL, prompt, filesystem path, machine data, or user ID.
+- Direct and marketplace installs without a known documented surface remain
+  `unknown` unless setup fallback is available.
+- Telemetry continues to fail closed when disabled or when no durable identity
+  is available.
+
+## Measurement query contract
+
+The next PostHog comparison should cohort on `mcp_serve_started`, order by the
+same distinct ID, and group by `first_command_surface` plus OS and frontdoor.
+Use the existing `./ops/posthog.sh activation` report as the baseline, then
+repeat after seven full days of production exposure. Do not mix MCP-started and
+non-MCP users in the denominator.

--- a/docs/first-command-activation/implementation.md
+++ b/docs/first-command-activation/implementation.md
@@ -1,0 +1,56 @@
+# First-command activation implementation
+
+> Completed: 2026-08-13
+> Branch: `main` worktree
+
+## Summary
+
+Added privacy-safe onboarding-surface attribution and clarified the first-run
+commands across the primary onboarding surfaces.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `scripts/install.sh` | Maps README and Getting Started install refs and persists a restrictive local hint without relabeling an existing first surface. |
+| `src/ouroboros/telemetry.py` | Adds the fixed enum detector and MCP event allowlist fields; preserves hints after setup. |
+| `src/ouroboros/config/untrusted_env.py` | Blocks project `.env` from overriding the attribution field. |
+| `TELEMETRY.md` | Documents the exact event contract and enum behavior. |
+| `tests/unit/test_telemetry.py` | Covers exact keys, enum validation, setup fallback, and hint preservation. |
+| `tests/unit/scripts/test_install_runtime_selection.py` | Covers installer mapping and protection against relabeling on reinstall. |
+| `docs/getting-started.md` | Makes setup → first interview copyable for Claude, standalone CLI, and Codex. |
+| `README.md`, `README.ko.md`, `README.zh-CN.md` | Aligns the first command and Codex plugin instructions. |
+| `docs/runtime-guides/codex.md` | Adds plugin and standalone first-command paths. |
+| `docs/runtime-guides/opencode.md` | Adds setup-before-first-interview path. |
+
+## Runtime behavior
+
+Resolution order:
+
+1. Explicit fixed enum from the trusted process environment.
+2. Installer hint at `~/.ouroboros/first_command_surface`.
+3. Existing `~/.ouroboros/config.yaml` → `setup_complete`.
+4. `unknown`.
+
+The project `.env` loader denylist includes
+`OUROBOROS_FIRST_COMMAND_SURFACE`, so a checked-out repository cannot silently
+relabel an activation cohort.
+
+## Verification
+
+```text
+uv run pytest tests/unit/test_telemetry.py \
+  tests/unit/scripts/test_install_runtime_selection.py \
+  tests/unit/test_install_ref_docs_contract.py \
+  tests/unit/config/test_loader_env.py -q
+414 passed in 165.97s
+```
+
+This verifies the implementation, installer mapping, documentation ref
+contract, and project `.env` trust boundary. Additional checks still required
+before calling the backlog item complete:
+
+- Run the full relevant product test suite after the documentation patch.
+- Expose the changed installer/docs on the release branch.
+- Re-run `./ops/posthog.sh activation` after seven complete production days and
+  compare the ordered MCP-start cohort against the 482 → 127 baseline.

--- a/docs/first-command-activation/requirements.md
+++ b/docs/first-command-activation/requirements.md
@@ -1,0 +1,50 @@
+# First-command activation requirements
+
+> Generated: 2026-08-13
+> Status: Implemented, awaiting post-release measurement
+
+## Original requirement
+
+Reduce the PostHog drop-off between MCP server startup and the user's first
+Ouroboros command. Compare the real onboarding surfaces, find error and
+abandonment points, create a concrete product artifact, and leave the remaining
+measurement work in the marketer backlog.
+
+## Evidence baseline
+
+The ordered recent-seven-day cohort is:
+
+| Stage | Users | Conversion from prior stage |
+|---|---:|---:|
+| MCP server started | 482 | — |
+| First command | 127 | 26.3% |
+| Interview | 82 | 64.6% |
+| Seed | 51 | 62.2% |
+| Workflow completed | 17 | 33.3% |
+
+The earlier 31.2% figure is discarded because its denominator included users
+without an MCP start. The first-command surface was also missing for 296 of
+482 users, so the product needs a privacy-safe, fixed-enum attribution field.
+
+## Clarified specification
+
+1. Persist only a fixed onboarding enum from documented installer surfaces:
+   `readme_quickstart`, `getting_started`, `setup_complete`, or `unknown`.
+2. Include the enum on MCP startup and MCP command events so the activation
+   cohort can be grouped without recording URLs, prompts, paths, or identity.
+3. Preserve an install hint after setup; otherwise a README user would be
+   relabeled as `setup_complete` before the first command.
+4. Make the first post-install action explicit in the English, Korean, and
+   Simplified Chinese README, Getting Started, Codex, and OpenCode surfaces.
+5. Keep current telemetry allowlists and project `.env` trust boundaries
+   intact.
+
+## Success criteria
+
+- `TELEMETRY.md` and executable allowlists describe the same exact properties.
+- Tests cover enum validation, invalid/missing hints, setup fallback, and hint
+  preservation after setup.
+- A new user can copy a setup command followed immediately by a first workflow
+  command for Claude Code, Codex, and OpenCode.
+- The marketer backlog retains a dated DoD for a before/after seven-day
+  PostHog comparison; implementation alone does not claim conversion lift.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,8 +22,8 @@ compatible `python`, and otherwise run with
 `uv run --no-project --quiet --python '>=3.12' python`. Older global
 interpreters are rejected instead of entering the first-run flow.
 
-Then run the install commands in your terminal, and run setup and auto inside
-Claude Code to go from idea to execution:
+Then run the install commands in your terminal. Start Claude Code and follow
+the two commands below in order:
 
 **1. Install the plugin** (in your terminal):
 ```bash
@@ -31,13 +31,26 @@ claude plugin marketplace add Q00/ouroboros
 claude plugin install ouroboros@ouroboros
 ```
 
-**2. Set up and build** (inside a Claude Code session -- start one with `claude`):
+**2. First command** (inside a Claude Code session -- start one with `claude`):
 ```
 ooo setup
+ooo interview "Build a task management CLI"
+```
+
+`ooo setup` is a one-time runtime configuration. `ooo interview` is the first
+useful command: it starts the Socratic interview and returns a session that can
+be continued into Seed generation and execution.
+
+For a one-command pipeline after setup, use:
+
+```
 ooo auto "Build a task management CLI"
 ```
 
-That's it. `ooo auto` runs bounded Socratic interview rounds, generates an A-grade Seed, repairs B/C Seeds when possible, and starts execution only after the A-grade gate passes. It returns an `auto_session_id` so interrupted or blocked runs can be resumed.
+`ooo auto` runs bounded Socratic interview rounds, generates an A-grade Seed,
+repairs B/C Seeds when possible, and starts execution only after the A-grade
+gate passes. It returns an `auto_session_id` so interrupted or blocked runs can
+be resumed.
 
 Prefer the manual path when you want to answer every question yourself:
 
@@ -64,10 +77,16 @@ Use this path if you prefer a standalone terminal workflow, or are using a non-C
 # Install
 pip install ouroboros-ai
 
-# Set up
+# Set up the runtime once
 ouroboros setup
 
-# Run a seed spec
+# Start your first interview
+ouroboros init start "Build a task management CLI"
+```
+
+After the interview produces a Seed, run it with:
+
+```bash
 ouroboros run ~/.ouroboros/seeds/seed_abc123.yaml
 ```
 
@@ -84,18 +103,24 @@ codex plugin marketplace add Q00/ouroboros
 codex plugin add ouroboros@ouroboros
 ```
 
-Start a new Codex session and enter `ooo`. If setup has not run yet, Ouroboros
-offers to prepare the runtime before it changes anything. Once prepared, it
-uses Codex's current default model automatically. Choose **Directly configure
-models** only when you want to choose or pin a model for a pipeline stage; in
-Codex this opens the local settings UI in your browser at a temporary
-`localhost` address.
+Start a new Codex session and run these commands in order:
+
+```
+ooo setup
+ooo interview "Build a task management CLI"
+```
+
+`ooo setup` is the one-time runtime preparation. Once prepared, Codex uses its
+current default model automatically. Choose **Directly configure models** only
+when you want to choose or pin a model for a pipeline stage; in Codex this
+opens the local settings UI in your browser at a temporary `localhost` address.
 
 For a standalone Codex CLI installation without the plugin, prepare the
 integration once:
 
 ```bash
 ouroboros setup --runtime codex
+ouroboros init start "Build a task management CLI"
 ```
 
 > **Note:** The standalone CLI interview is invoked via `ouroboros init start "your context"` (not `ooo interview`, which is Claude Code-specific). The interview flow is identical across both tools. Power users can also author seed YAML files directly — see the [Seed Authoring Guide](guides/seed-authoring.md).

--- a/docs/runtime-guides/codex.md
+++ b/docs/runtime-guides/codex.md
@@ -216,6 +216,24 @@ codex --version
 > in the output, so do not grep for it. On the plugin path, and for anyone who
 > put `codex` on `PATH`, `codex --version` is the right check.
 
+### First command
+
+For the marketplace-plugin path, start a new Codex session and run the setup
+and first workflow command explicitly:
+
+```
+ooo setup
+ooo interview "Build a task management CLI"
+```
+
+For the standalone CLI path, run setup once from a terminal, then start the
+interview:
+
+```bash
+ouroboros setup --runtime codex
+ouroboros init start "Build a task management CLI"
+```
+
 ## How It Works
 
 ```

--- a/docs/runtime-guides/opencode.md
+++ b/docs/runtime-guides/opencode.md
@@ -246,6 +246,22 @@ opencode --version
 ouroboros --help
 ```
 
+### First command
+
+Configure the OpenCode integration once before opening the first workflow:
+
+```bash
+ouroboros setup --runtime opencode
+```
+
+Then start a new OpenCode session and run:
+
+```
+ooo interview "Build a task management CLI"
+```
+
+The `ooo` command is available after setup registers the Ouroboros MCP server.
+
 ## OpenCode-Specific Strengths
 
 - **Multi-provider support** -- use Anthropic, OpenAI, Google, or other providers through a single runtime

--- a/docs/workflow-failure-reason/architecture.md
+++ b/docs/workflow-failure-reason/architecture.md
@@ -1,0 +1,71 @@
+# Workflow Failure Reasons Architecture
+
+> Generated: 2026-08-13
+> Approach: one pure closed-vocabulary classifier at the durable terminal boundary
+
+## Overview
+
+```text
+runner / recovery path
+        │ terminal status + structured result_meta
+        ▼
+JobManager._append_event ──► classify_failure()
+        │                         │
+        │                         ├─ result_meta: reason + action + next_step
+        │                         └─ JobTelemetryBoundary
+        │                                      │
+        │                                      ▼
+        │                           workflow_outcome allowlist
+        │                           reason + action only
+        ▼
+job_status / job_result render the fixed next step
+```
+
+Direct, non-job evaluation calls use the same classifier at
+`record_direct_evaluation_outcome()`. They emit the two telemetry enums but do
+not have a durable job result in which to render `next_step`.
+
+## Components
+
+| Component | Responsibility | Location |
+|---|---|---|
+| `classify_failure` | Map terminal status and safe metadata to a fixed reason/action/text tuple | `src/ouroboros/mcp/failure_taxonomy.py` |
+| Job terminal boundary | Enrich persisted terminal metadata before telemetry observation | `src/ouroboros/mcp/job_manager.py` |
+| Durable telemetry | Emit only enum values on `workflow_outcome` | `src/ouroboros/telemetry.py` |
+| Direct evaluation telemetry | Keep the non-job producer on the same contract | `src/ouroboros/mcp/telemetry_boundary.py` |
+| User recovery surface | Render reason, action, and next step in terminal job summaries | `src/ouroboros/mcp/tools/job_handlers.py` |
+| Public contract | Document the exact event fields and privacy boundary | `TELEMETRY.md` |
+
+## Classification Rules
+
+1. `cancelled` or `interrupted` status maps to `cancelled` and `retry`.
+2. Shutdown, dead-owner, stranded-task, and user-cancellation flags map to the
+   same cancellation route.
+3. Progress-accounting stalls and explicit timeout metadata map to `timeout`
+   and `retry`.
+4. An exact machine-readable reason code may select `config`, `auth`, `model`,
+   `tool`, or `validation` and its fixed action.
+5. Anything else maps to `unknown` and `inspect_logs`.
+
+No rule scans exception or result strings. This prevents privacy leakage and
+avoids making telemetry semantics depend on provider wording.
+
+## Data Flow and Invariants
+
+- `JobManager._append_event()` enriches a copy of terminal event data; caller
+  dictionaries are not mutated.
+- `JobTelemetryBoundary.observe()` forwards only the structured `result_meta`
+  dictionary to `capture_job_outcome()`.
+- `capture_job_outcome()` derives `verified` exactly as before and preserves
+  the same one-way `$insert_id` digest.
+- `capture()` drops every property outside `_WORKFLOW_OUTCOME_KEYS`, which
+  contains only the two new enum fields in addition to the existing contract.
+- User-facing `next_step` is never included in telemetry.
+
+## Recovery Measurement
+
+After release, group failed `workflow_outcome` events by
+`failure_reason_code`/`recovery_action`, then identify a later `command_run` or
+terminal outcome for the same anonymous user within the chosen recovery window.
+The first seven-day report must state the cohort size and unknown share before
+being used as a product KPI.

--- a/docs/workflow-failure-reason/implementation.md
+++ b/docs/workflow-failure-reason/implementation.md
@@ -1,0 +1,90 @@
+# Workflow Failure Reasons Implementation
+
+> Completed locally: 2026-08-13
+> Branch: existing worktree branch
+
+## Summary
+
+Implemented privacy-safe failure classification across durable MCP job terminal
+events and direct evaluation telemetry. Failed job results now carry a fixed
+reason code, recovery action, and user-facing next step. Raw error text remains
+internal to the job record and is not sent to PostHog.
+
+## Files Created
+
+| File | Purpose |
+|---|---|
+| `src/ouroboros/mcp/failure_taxonomy.py` | Closed enums and pure metadata/status classifier |
+| `tests/unit/mcp/test_failure_taxonomy.py` | Classifier mapping and fail-closed tests |
+| `docs/workflow-failure-reason/requirements.md` | Requirements and acceptance criteria |
+| `docs/workflow-failure-reason/architecture.md` | Boundary/data-flow design |
+| `docs/workflow-failure-reason/implementation.md` | This implementation record |
+
+## Files Modified
+
+| File | Changes |
+|---|---|
+| `src/ouroboros/mcp/job_manager.py` | Enrich every failed/cancelled/interrupted terminal event with fixed recovery metadata |
+| `src/ouroboros/ralph_loop.py` | Carry Ralph's fixed stop-reason mappings into terminal tool metadata |
+| `src/ouroboros/mcp/tools/evaluation_handlers.py` | Pass trusted typed failure reasons through direct evaluation telemetry |
+| `src/ouroboros/telemetry.py` | Allowlist and emit `failure_reason_code`/`recovery_action` without raw text |
+| `src/ouroboros/mcp/telemetry_boundary.py` | Apply the same enum contract to direct evaluation outcomes |
+| `src/ouroboros/mcp/tools/job_handlers.py` | Render the reason, action, and next step for terminal jobs |
+| `TELEMETRY.md` | Publish the exact property and privacy contract |
+| `tests/unit/test_telemetry.py` | Cover each mapping, unknown fallback, and raw-data exclusion |
+| `tests/unit/mcp/test_job_manager.py` | Update general-exception terminal contract |
+
+## Key Implementation Details
+
+`classify_failure()` accepts only terminal status and a mapping of structured
+metadata. It returns `None` for successful/non-terminal states and always
+returns a `FailureResolution` for a failure. All output strings are fixed
+constants.
+
+Ralph contributes only its fixed `action`/`stop_reason` vocabulary: actual
+iteration or wall-clock exhaustion maps to `timeout`, while QA and convergence
+guards (including `max_generations reached`) map to `validation`. Generic
+`failed` remains `unknown`. Direct evaluation maps only typed errors such as
+`ConfigError`, `ProviderError`, `MCPAuthError`, `MCPTimeoutError`, and
+validation errors; generic `ValueError`/`RuntimeError` remains `unknown`.
+
+`JobManager._append_event()` applies the resolution before persisting and before
+`JobTelemetryBoundary.observe()` runs. This covers normal exceptions, shutdown,
+cancellation, dead-owner recovery, stranded tasks, progress stalls, and future
+terminal producers that use the same boundary.
+
+`capture_job_outcome()` adds only the two enum fields to `workflow_outcome`.
+`next_step`, raw `error`, `result_text`, and job IDs never enter telemetry.
+
+## Testing
+
+Focused verification:
+
+```text
+49 passed
+```
+
+Broader MCP/Ralph/telemetry verification:
+
+```text
+2190 passed, 1 skipped, 2 pre-existing failures
+```
+
+The two failures are in `tests/unit/mcp/test_routing_snapshot.py`; they use
+the pre-existing unsupported `MCPServerAdapter(enable_routing_receipts=True)`
+constructor argument and are unrelated to this feature. Ruff and mypy pass on
+the changed source and tests.
+
+Covered cases include successful evaluation regression, normal exception
+fallback, cancellation/shutdown, timeout/stall, explicit config/auth/
+validation codes, direct evaluation, exact allowlisting, deduplication, and
+raw error/path exclusion.
+
+## Known Limitations
+
+- The implementation is local and not released yet.
+- The seven-day reason-level recovery KPI cannot be reported until a complete
+  post-release cohort exists.
+- Unstructured provider failures and generic `ValueError`/`RuntimeError`
+  remain `unknown`; adding a new category requires a structured metadata
+  contract and corresponding tests.

--- a/docs/workflow-failure-reason/requirements.md
+++ b/docs/workflow-failure-reason/requirements.md
@@ -1,0 +1,58 @@
+# Workflow Failure Reasons Requirements
+
+> Generated: 2026-08-13
+> Status: Implemented locally; release and recovery-rate measurement pending
+
+## Original Requirement
+
+Add privacy-safe failure reasons and a user recovery path to failed `run` and
+`ralph` workflows, then measure recovery by reason in PostHog.
+
+## Clarified Specification
+
+The durable MCP job terminal boundary must classify failed, cancelled, and
+interrupted outcomes into a closed `failure_reason_code` enum and a closed
+`recovery_action` enum. The same fields must be present on direct evaluation
+terminal telemetry so the event contract does not diverge between producers.
+
+The classifier may use only terminal status and existing structured metadata.
+Raw exception messages, result text, prompts, paths, job IDs, and identifiers
+must never be used as telemetry values or classification inputs.
+
+Every failed terminal job result must include a fixed user-visible `next_step`
+alongside the reason and action. Existing completion semantics, `verified`, and
+job deduplication must remain unchanged.
+
+## Enum Contract
+
+`failure_reason_code`:
+
+`config | auth | timeout | model | tool | validation | cancelled | unknown`
+
+`recovery_action`:
+
+`retry | setup | login | update | inspect_logs | none`
+
+The current implementation emits `unknown` plus `inspect_logs` when no safe
+machine-readable signal exists. It emits `cancelled` for cancellation,
+shutdown interruption, dead-owner interruption, and stranded-task interruption;
+progress-accounting stalls and explicit timeout metadata emit `timeout`.
+
+## Success Criteria
+
+- All non-success durable job terminal outcomes have a reason/action pair.
+- A normal exception with no structured code falls back to `unknown` without
+  forwarding its raw text.
+- Job status/result surfaces show the recommended next step.
+- `workflow_outcome` allowlisting and `TELEMETRY.md` describe the exact same
+  fields.
+- Existing `$insert_id`, `verified`, and final approval behavior are unchanged.
+- After release, a complete seven-day window can calculate recovery by reason
+  from the terminal event followed by a later command or terminal outcome.
+
+## Out of Scope
+
+- Sending exception text, prompt content, paths, or provider identifiers.
+- Inferring a reason from arbitrary human-readable error messages.
+- Claiming the seven-day recovery KPI before this change is released and
+  observed in a complete cohort.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -844,6 +844,28 @@ fi
 INSTALL_REF="${OUROBOROS_INSTALL_REF:-direct}"
 [[ "$INSTALL_REF" =~ ^[A-Za-z0-9._-]{1,32}$ ]] || INSTALL_REF="direct"
 
+# Preserve a coarse onboarding hint for the first MCP session. This is not a
+# user identifier and is never sent as an install property; telemetry reads
+# only the fixed enum after install, until setup creates config.yaml. Existing
+# setup or an existing hint wins, so re-running the installer cannot
+# relabel a user's first documented install surface.
+_persist_first_command_surface_hint() {
+  local surface=""
+  case "$INSTALL_REF" in
+    readme|readme-*) surface="readme_quickstart" ;;
+    getting-started|getting_started|getting-started-*|docs-getting-started) surface="getting_started" ;;
+    *) return 0 ;;
+  esac
+  local dir="$HOME/.ouroboros" tmp="$HOME/.ouroboros/first_command_surface.$$"
+  [ -f "$dir/config.yaml" ] && return 0
+  [ -s "$dir/first_command_surface" ] && return 0
+  if mkdir -p "$dir" 2>/dev/null; then
+    (umask 077; printf '%s\n' "$surface" > "$tmp" && mv -f "$tmp" "$dir/first_command_surface") \
+      2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+  fi
+}
+_persist_first_command_surface_hint
+
 _banner
 
 _telemetry_notice

--- a/src/ouroboros/config/untrusted_env.py
+++ b/src/ouroboros/config/untrusted_env.py
@@ -167,6 +167,9 @@ UNTRUSTED_ENV_DENYLIST = frozenset(
         "OUROBOROS_TELEMETRY",
         "OUROBOROS_POSTHOG_API_KEY",
         "OUROBOROS_POSTHOG_HOST",
+        # Onboarding attribution is an analytics boundary. A cloned repo must
+        # not rewrite the surface label used to compare activation cohorts.
+        "OUROBOROS_FIRST_COMMAND_SURFACE",
         "DO_NOT_TRACK",
         "CI",
         "GITHUB_ACTIONS",

--- a/src/ouroboros/mcp/failure_taxonomy.py
+++ b/src/ouroboros/mcp/failure_taxonomy.py
@@ -1,0 +1,186 @@
+"""Privacy-safe failure reasons and fixed recovery guidance for MCP jobs.
+
+This module deliberately classifies only terminal status and machine-readable
+metadata.  It never inspects exception text, result text, prompts, paths, or
+identifiers.  The returned values are closed vocabularies suitable for both
+user-facing job results and anonymous telemetry.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class FailureReasonCode(StrEnum):
+    """Stable, privacy-safe reason categories for failed workflows."""
+
+    CONFIG = "config"
+    AUTH = "auth"
+    TIMEOUT = "timeout"
+    MODEL = "model"
+    TOOL = "tool"
+    VALIDATION = "validation"
+    CANCELLED = "cancelled"
+    UNKNOWN = "unknown"
+
+
+class RecoveryAction(StrEnum):
+    """The single recommended user action after a failed workflow."""
+
+    RETRY = "retry"
+    SETUP = "setup"
+    LOGIN = "login"
+    UPDATE = "update"
+    INSPECT_LOGS = "inspect_logs"
+    NONE = "none"
+
+
+@dataclass(frozen=True, slots=True)
+class FailureResolution:
+    """A closed reason/action pair plus fixed user-visible next-step text."""
+
+    reason_code: FailureReasonCode
+    recovery_action: RecoveryAction
+    next_step: str
+
+
+_FAILURE_STATUSES = frozenset({"failed", "cancelled", "interrupted", "timed_out", "timeout"})
+_SAFE_REASON_VALUES = frozenset(item.value for item in FailureReasonCode)
+_SAFE_MACHINE_REASON_KEYS = (
+    "failure_reason_code",
+    "reason_code",
+    "error_code",
+    "status",
+    "evaluation_status",
+)
+_SAFE_MACHINE_REASON_KEYS += ("action", "stop_reason")
+
+# These values are producer-owned vocabularies, not arbitrary error text.
+# Keep the mapping deliberately conservative: a generic ``failed`` action does
+# not identify whether the provider, a tool, or the workflow itself failed.
+_STRUCTURED_REASON_VALUES: dict[str, FailureReasonCode] = {
+    "iteration_timeout": FailureReasonCode.TIMEOUT,
+    "wall_clock_exhausted": FailureReasonCode.TIMEOUT,
+    # A generation budget is a quality/convergence guard, not a wall-clock
+    # deadline. Keep timeout reserved for the two actual time-budget signals.
+    "max_generations reached": FailureReasonCode.VALIDATION,
+    "qa_failed": FailureReasonCode.VALIDATION,
+    "oscillation_detected": FailureReasonCode.VALIDATION,
+    "grade_regressing": FailureReasonCode.VALIDATION,
+    "stagnated": FailureReasonCode.VALIDATION,
+    "interrupted": FailureReasonCode.CANCELLED,
+}
+
+_ACTION_BY_REASON: dict[FailureReasonCode, tuple[RecoveryAction, str]] = {
+    FailureReasonCode.CONFIG: (
+        RecoveryAction.SETUP,
+        "Run setup, then retry the workflow.",
+    ),
+    FailureReasonCode.AUTH: (
+        RecoveryAction.LOGIN,
+        "Sign in to the required provider, then retry the workflow.",
+    ),
+    FailureReasonCode.TIMEOUT: (
+        RecoveryAction.RETRY,
+        "Retry the workflow.",
+    ),
+    FailureReasonCode.MODEL: (
+        RecoveryAction.RETRY,
+        "Retry the workflow with the current model configuration.",
+    ),
+    FailureReasonCode.TOOL: (
+        RecoveryAction.INSPECT_LOGS,
+        "Inspect the server logs before retrying the workflow.",
+    ),
+    FailureReasonCode.VALIDATION: (
+        RecoveryAction.INSPECT_LOGS,
+        "Inspect the validation output before retrying the workflow.",
+    ),
+    FailureReasonCode.CANCELLED: (
+        RecoveryAction.RETRY,
+        "Retry the workflow when you are ready.",
+    ),
+    FailureReasonCode.UNKNOWN: (
+        RecoveryAction.INSPECT_LOGS,
+        "Inspect the server logs before retrying the workflow.",
+    ),
+}
+
+
+def _explicit_reason(metadata: Mapping[str, object]) -> FailureReasonCode | None:
+    """Accept only exact values from known machine-readable metadata keys."""
+    for key in _SAFE_MACHINE_REASON_KEYS:
+        value = metadata.get(key)
+        if isinstance(value, str) and value in _SAFE_REASON_VALUES:
+            return FailureReasonCode(value)
+        if not isinstance(value, str):
+            continue
+        structured_reason = _STRUCTURED_REASON_VALUES.get(value)
+        if structured_reason is not None:
+            return structured_reason
+        if value in {"timed_out", "timeout"}:
+            return FailureReasonCode.TIMEOUT
+        if value in {"config_error", "configuration_error"}:
+            return FailureReasonCode.CONFIG
+        if value in {"auth_error", "authentication_error", "unauthorized"}:
+            return FailureReasonCode.AUTH
+        if value in {"model_error", "provider_error"}:
+            return FailureReasonCode.MODEL
+        if value in {"tool_error"}:
+            return FailureReasonCode.TOOL
+        if value in {"validation_error", "invalid"}:
+            return FailureReasonCode.VALIDATION
+    return None
+
+
+def classify_failure(
+    terminal_status: str,
+    metadata: Mapping[str, object] | None = None,
+) -> FailureResolution | None:
+    """Classify one failed terminal outcome without reading raw error text.
+
+    ``None`` is returned for successful/non-terminal statuses.  For a failed
+    status, the classifier always returns a resolution, including the safe
+    ``unknown`` fallback, so every terminal failure can be measured.
+    """
+    status = terminal_status.strip().lower() if isinstance(terminal_status, str) else ""
+    if status not in _FAILURE_STATUSES:
+        return None
+
+    meta = metadata if isinstance(metadata, Mapping) else {}
+    reason: FailureReasonCode | None = None
+
+    if (
+        status in {"cancelled", "interrupted"}
+        or meta.get("interrupted_from_shutdown") is True
+        or any(
+            meta.get(key) is True
+            for key in (
+                "interrupted_from_dead_owner",
+                "interrupted_from_stranded_job_task",
+                "cancelled_by_user",
+            )
+        )
+    ):
+        reason = FailureReasonCode.CANCELLED
+    elif meta.get("failed_from_progress_accounting_stall") is True or any(
+        meta.get(key) is True for key in ("timed_out", "wait_timed_out")
+    ):
+        reason = FailureReasonCode.TIMEOUT
+    else:
+        reason = _explicit_reason(meta)
+
+    if reason is None:
+        reason = FailureReasonCode.UNKNOWN
+    action, next_step = _ACTION_BY_REASON[reason]
+    return FailureResolution(reason, action, next_step)
+
+
+__all__ = [
+    "FailureReasonCode",
+    "FailureResolution",
+    "RecoveryAction",
+    "classify_failure",
+]

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -18,6 +18,7 @@ import structlog
 
 from ouroboros.core.errors import PersistenceError
 from ouroboros.events.base import BaseEvent
+from ouroboros.mcp.failure_taxonomy import classify_failure
 from ouroboros.mcp.telemetry_boundary import JobTelemetryBoundary
 from ouroboros.orchestrator.agent_process import AgentProcessHandle
 from ouroboros.orchestrator.events import create_execution_terminal_event
@@ -137,6 +138,33 @@ def _safe_result_payload(result: Any) -> dict[str, Any]:
     }
 
 
+def _enrich_terminal_data(data: Mapping[str, Any]) -> dict[str, Any]:
+    """Add fixed recovery metadata to a terminal payload.
+
+    This helper is shared by durable writes and read-only synthetic
+    projections. Existing producer-owned metadata, especially an actionable
+    ``next_step`` such as ``ooo evaluate <session_id>``, takes precedence over
+    the generic fallback supplied by the taxonomy.
+    """
+    enriched = dict(data)
+    status = enriched.get("status")
+    if not isinstance(status, str):
+        return enriched
+    resolution = classify_failure(
+        status,
+        enriched.get("result_meta") if isinstance(enriched.get("result_meta"), dict) else None,
+    )
+    if resolution is None:
+        return enriched
+    existing_meta = enriched.get("result_meta")
+    result_meta = dict(existing_meta) if isinstance(existing_meta, dict) else {}
+    result_meta.setdefault("failure_reason_code", resolution.reason_code.value)
+    result_meta.setdefault("recovery_action", resolution.recovery_action.value)
+    result_meta.setdefault("next_step", resolution.next_step)
+    enriched["result_meta"] = result_meta
+    return enriched
+
+
 def _canonical_acceptance_payload(payload: Mapping[str, Any]) -> str:
     """Return a stable representation for idempotent plan-entry comparison."""
     return json.dumps(dict(payload), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
@@ -171,18 +199,23 @@ _STRANDED_INTERRUPTED_EVENT_ID_PREFIX = "mcp-job-stranded-interrupted-"
 _DRAIN_INTERRUPTED_EVENT_ID_PREFIX = "mcp-job-drain-interrupted-"
 _DRAIN_GRACE_SECONDS = 5.0
 _TERMINAL_APPEND_RETRY_DELAY_SECONDS = 0.05
+_TERMINAL_JOB_EVENTS = frozenset(
+    {"mcp.job.completed", "mcp.job.failed", "mcp.job.cancelled", "mcp.job.interrupted"}
+)
 
 
 def _drain_interrupted_data() -> dict[str, Any]:
     """Terminal payload for jobs interrupted by server shutdown (drain)."""
-    return {
-        "status": JobStatus.INTERRUPTED.value,
-        "message": "Job interrupted: MCP server shut down before the job finished",
-        "error": "MCP server shut down before the job reached a terminal state",
-        "result_text": "MCP server shut down before the job reached a terminal state",
-        "result_meta": {"interrupted_from_shutdown": True},
-        "is_error": True,
-    }
+    return _enrich_terminal_data(
+        {
+            "status": JobStatus.INTERRUPTED.value,
+            "message": "Job interrupted: MCP server shut down before the job finished",
+            "error": "MCP server shut down before the job reached a terminal state",
+            "result_text": "MCP server shut down before the job reached a terminal state",
+            "result_meta": {"interrupted_from_shutdown": True},
+            "is_error": True,
+        }
+    )
 
 
 logger = logging.getLogger(__name__)
@@ -275,15 +308,17 @@ def _progress_accounting_failed_job_event(job_id: str, blocker: str) -> BaseEven
         type="mcp.job.failed",
         aggregate_type="job",
         aggregate_id=job_id,
-        data={
-            "status": JobStatus.FAILED.value,
-            "message": "Job failed: workflow progress accounting stalled",
-            "error": blocker,
-            "result_text": blocker,
-            "result_meta": {"failed_from_progress_accounting_stall": True},
-            "is_error": True,
-            "timestamp": datetime.now(UTC).isoformat(),
-        },
+        data=_enrich_terminal_data(
+            {
+                "status": JobStatus.FAILED.value,
+                "message": "Job failed: workflow progress accounting stalled",
+                "error": blocker,
+                "result_text": blocker,
+                "result_meta": {"failed_from_progress_accounting_stall": True},
+                "is_error": True,
+                "timestamp": datetime.now(UTC).isoformat(),
+            }
+        ),
     )
 
 
@@ -294,15 +329,17 @@ def _linked_execution_failed_job_event(job_id: str, failure: str) -> BaseEvent:
         type="mcp.job.failed",
         aggregate_type="job",
         aggregate_id=job_id,
-        data={
-            "status": JobStatus.FAILED.value,
-            "message": "Job failed: linked execution recorded failure",
-            "error": failure,
-            "result_text": failure,
-            "result_meta": {"failed_from_linked_execution_failure": True},
-            "is_error": True,
-            "timestamp": datetime.now(UTC).isoformat(),
-        },
+        data=_enrich_terminal_data(
+            {
+                "status": JobStatus.FAILED.value,
+                "message": "Job failed: linked execution recorded failure",
+                "error": failure,
+                "result_text": failure,
+                "result_meta": {"failed_from_linked_execution_failure": True},
+                "is_error": True,
+                "timestamp": datetime.now(UTC).isoformat(),
+            }
+        ),
     )
 
 
@@ -313,29 +350,33 @@ def _orphaned_job_interrupted_event(job_id: str) -> BaseEvent:
         type="mcp.job.interrupted",
         aggregate_type="job",
         aggregate_id=job_id,
-        data={
-            "status": JobStatus.INTERRUPTED.value,
-            "message": "Job interrupted: owning process is no longer alive",
-            "error": "Owning process exited before the job reached a terminal state",
-            "result_text": "Owning process exited before the job reached a terminal state",
-            "result_meta": {"interrupted_from_dead_owner": True},
-            "is_error": True,
-            "timestamp": datetime.now(UTC).isoformat(),
-        },
+        data=_enrich_terminal_data(
+            {
+                "status": JobStatus.INTERRUPTED.value,
+                "message": "Job interrupted: owning process is no longer alive",
+                "error": "Owning process exited before the job reached a terminal state",
+                "result_text": "Owning process exited before the job reached a terminal state",
+                "result_meta": {"interrupted_from_dead_owner": True},
+                "is_error": True,
+                "timestamp": datetime.now(UTC).isoformat(),
+            }
+        ),
     )
 
 
 def _stranded_job_interrupted_data() -> dict[str, Any]:
     """Terminal payload for a job whose task was released without a terminal event."""
-    return {
-        "status": JobStatus.INTERRUPTED.value,
-        "message": "Job interrupted: job task released without persisting a terminal state",
-        "error": "Job task exited without persisting a terminal event",
-        "result_text": "Job task exited without persisting a terminal event",
-        "result_meta": {"interrupted_from_stranded_job_task": True},
-        "is_error": True,
-        "timestamp": datetime.now(UTC).isoformat(),
-    }
+    return _enrich_terminal_data(
+        {
+            "status": JobStatus.INTERRUPTED.value,
+            "message": "Job interrupted: job task released without persisting a terminal state",
+            "error": "Job task exited without persisting a terminal event",
+            "result_text": "Job task exited without persisting a terminal event",
+            "result_meta": {"interrupted_from_stranded_job_task": True},
+            "is_error": True,
+            "timestamp": datetime.now(UTC).isoformat(),
+        }
+    )
 
 
 def _stranded_job_interrupted_event(job_id: str) -> BaseEvent:
@@ -355,7 +396,7 @@ def _snapshot_with_terminal_event(
     cursor: int,
 ) -> JobSnapshot:
     """Project a terminal job event onto an existing reconstructed snapshot."""
-    data = event.data
+    data = _enrich_terminal_data(event.data)
     status = JobStatus(data.get("status", snapshot.status.value))
     return replace(
         snapshot,
@@ -2884,6 +2925,11 @@ class JobManager:
         event_id: str | None = None,
     ) -> None:
         """Persist one job event and observe its durable terminal boundary."""
+        if event_type in _TERMINAL_JOB_EVENTS:
+            status = data.get("status")
+            if not isinstance(status, str):
+                status = event_type.removeprefix("mcp.job.")
+            data = _enrich_terminal_data({**data, "status": status})
         await self._ensure_initialized()
         cursor = await self._event_store.append_with_rowid(
             BaseEvent(

--- a/src/ouroboros/mcp/telemetry_boundary.py
+++ b/src/ouroboros/mcp/telemetry_boundary.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from ouroboros import telemetry as usage_telemetry
 from ouroboros.core.types import Result
+from ouroboros.mcp.failure_taxonomy import classify_failure
 
 if TYPE_CHECKING:
     from ouroboros.mcp.server.adapter import MCPServerAdapter
@@ -262,7 +263,12 @@ async def call_sdk_tool(
     return response
 
 
-def record_direct_evaluation_outcome(*, final_approved: bool | None, failed: bool = False) -> None:
+def record_direct_evaluation_outcome(
+    *,
+    final_approved: bool | None,
+    failed: bool = False,
+    failure_reason_code: str | None = None,
+) -> None:
     """Durable-terminal telemetry for the direct (non-job) ouroboros_evaluate path.
 
     Job-backed evaluations reach ``workflow_outcome`` via JobTelemetryBoundary's
@@ -275,16 +281,28 @@ def record_direct_evaluation_outcome(*, final_approved: bool | None, failed: boo
     """
     try:
         status = "failed" if failed else "completed"
+        resolution = classify_failure(
+            status,
+            {"failure_reason_code": failure_reason_code} if failure_reason_code else None,
+        )
+        properties: dict[str, Any] = {
+            "command": "evaluate",
+            "phase": "terminal",
+            "terminal_status": status,
+            "ok": not failed,
+            "verified": (not failed) and final_approved is True,
+            "final_approved": final_approved if isinstance(final_approved, bool) else None,
+        }
+        if resolution is not None:
+            properties.update(
+                {
+                    "failure_reason_code": resolution.reason_code.value,
+                    "recovery_action": resolution.recovery_action.value,
+                }
+            )
         usage_telemetry.capture(
             "workflow_outcome",
-            {
-                "command": "evaluate",
-                "phase": "terminal",
-                "terminal_status": status,
-                "ok": not failed,
-                "verified": (not failed) and final_approved is True,
-                "final_approved": final_approved if isinstance(final_approved, bool) else None,
-            },
+            properties,
         )
     except Exception:
         pass

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -23,11 +23,11 @@ from ouroboros.config import (
     get_llm_backend_for_role,
     get_llm_model_for_role,
 )
-from ouroboros.core.errors import ValidationError
+from ouroboros.core.errors import ConfigError, ProviderError, ValidationError
 from ouroboros.core.project_paths import resolve_path_against_base, resolve_seed_project_path
 from ouroboros.core.seed import AcceptanceCriterionSpec, Seed, ac_text
 from ouroboros.core.types import Result
-from ouroboros.mcp.errors import MCPServerError, MCPToolError
+from ouroboros.mcp.errors import MCPAuthError, MCPServerError, MCPTimeoutError, MCPToolError
 from ouroboros.mcp.job_manager import JobLinks, JobManager
 from ouroboros.mcp.telemetry_boundary import record_direct_evaluation_outcome
 from ouroboros.mcp.tools import background as background_jobs
@@ -67,6 +67,22 @@ from ouroboros.persistence.event_store import EventStore
 from ouroboros.providers import create_llm_adapter
 
 log = structlog.get_logger(__name__)
+
+
+def _direct_evaluation_failure_reason(error: object) -> str | None:
+    """Map only trusted exception types to the telemetry reason vocabulary."""
+    if isinstance(error, (ConfigError,)):
+        return "config"
+    if isinstance(error, (ValidationError, PydanticValidationError)):
+        return "validation"
+    if isinstance(error, (MCPAuthError,)):
+        return "auth"
+    if isinstance(error, (MCPTimeoutError, TimeoutError)):
+        return "timeout"
+    if isinstance(error, ProviderError):
+        return "model"
+    return None
+
 
 if TYPE_CHECKING:
     from ouroboros.mcp.tools.ralph_handlers import StartRalphHandler
@@ -814,7 +830,11 @@ class EvaluateHandler:
                     error=rendered_error,
                 )
                 if emit_terminal_telemetry:
-                    record_direct_evaluation_outcome(final_approved=None, failed=True)
+                    record_direct_evaluation_outcome(
+                        final_approved=None,
+                        failed=True,
+                        failure_reason_code=_direct_evaluation_failure_reason(result.error),
+                    )
                 return Result.err(
                     MCPToolError(
                         f"Evaluation failed: {rendered_error}",
@@ -864,22 +884,47 @@ class EvaluateHandler:
                     meta=meta,
                 )
             )
-        except (ValueError, RuntimeError) as e:
+        except ConfigError as e:
             # Configuration/bootstrap errors (unsupported backend, missing
             # provider install) — actionable by the user, safe to surface.
             log.warning("mcp.tool.evaluate.config_error", error=str(e))
             if emit_terminal_telemetry:
-                record_direct_evaluation_outcome(final_approved=None, failed=True)
+                record_direct_evaluation_outcome(
+                    final_approved=None,
+                    failed=True,
+                    failure_reason_code="config",
+                )
             return Result.err(
                 MCPToolError(
                     f"Evaluation setup failed: {e}",
                     tool_name="ouroboros_evaluate",
                 )
             )
-        except Exception:
+        except (ValueError, RuntimeError) as e:
+            # Preserve the historical setup-facing response for these factory
+            # failures, but do not infer ``config`` from a generic built-in
+            # exception. Only a typed ConfigError earns that telemetry reason.
+            log.warning("mcp.tool.evaluate.setup_error", error=str(e))
+            if emit_terminal_telemetry:
+                record_direct_evaluation_outcome(
+                    final_approved=None,
+                    failed=True,
+                    failure_reason_code=_direct_evaluation_failure_reason(e),
+                )
+            return Result.err(
+                MCPToolError(
+                    f"Evaluation setup failed: {e}",
+                    tool_name="ouroboros_evaluate",
+                )
+            )
+        except Exception as exc:
             log.exception("mcp.tool.evaluate.error")
             if emit_terminal_telemetry:
-                record_direct_evaluation_outcome(final_approved=None, failed=True)
+                record_direct_evaluation_outcome(
+                    final_approved=None,
+                    failed=True,
+                    failure_reason_code=_direct_evaluation_failure_reason(exc),
+                )
             return Result.err(
                 MCPToolError(
                     "Evaluation failed due to an internal error. Check server logs for details.",
@@ -957,7 +1002,11 @@ class EvaluateHandler:
             err = first_result.error
             rendered = err.format_details() if hasattr(err, "format_details") else str(err)
             if emit_terminal_telemetry:
-                record_direct_evaluation_outcome(final_approved=None, failed=True)
+                record_direct_evaluation_outcome(
+                    final_approved=None,
+                    failed=True,
+                    failure_reason_code=_direct_evaluation_failure_reason(err),
+                )
             return Result.err(
                 MCPToolError(
                     f"Evaluation failed: {rendered}",
@@ -1003,7 +1052,11 @@ class EvaluateHandler:
                     session_id=session_id,
                 )
                 if emit_terminal_telemetry:
-                    record_direct_evaluation_outcome(final_approved=None, failed=True)
+                    record_direct_evaluation_outcome(
+                        final_approved=None,
+                        failed=True,
+                        failure_reason_code=_direct_evaluation_failure_reason(entry),
+                    )
                 return Result.err(
                     MCPToolError(
                         f"Evaluation failed during multi-AC run: {entry}",
@@ -1019,7 +1072,11 @@ class EvaluateHandler:
                     error=rendered,
                 )
                 if emit_terminal_telemetry:
-                    record_direct_evaluation_outcome(final_approved=None, failed=True)
+                    record_direct_evaluation_outcome(
+                        final_approved=None,
+                        failed=True,
+                        failure_reason_code=_direct_evaluation_failure_reason(err),
+                    )
                 return Result.err(
                     MCPToolError(
                         f"Evaluation failed: {rendered}",

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -1109,6 +1109,25 @@ async def _render_job_snapshot_inner(
             ]
         )
 
+    if snapshot.is_terminal:
+        next_step = snapshot.result_meta.get("next_step")
+        reason_code = snapshot.result_meta.get("failure_reason_code")
+        recovery_action = snapshot.result_meta.get("recovery_action")
+        if (
+            isinstance(next_step, str)
+            and isinstance(reason_code, str)
+            and isinstance(recovery_action, str)
+        ):
+            lines.extend(
+                [
+                    "",
+                    "### Recovery",
+                    f"**Failure reason**: {reason_code}",
+                    f"**Recommended action**: {recovery_action}",
+                    f"**Next step**: {next_step}",
+                ]
+            )
+
     if snapshot.error:
         lines.extend(["", f"**Error**: {snapshot.error}"])
 

--- a/src/ouroboros/ralph_loop.py
+++ b/src/ouroboros/ralph_loop.py
@@ -17,6 +17,7 @@ from typing import Any, Protocol
 from ouroboros.core.conductor import ConductorDirective
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError
+from ouroboros.mcp.failure_taxonomy import classify_failure
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 
 _TERMINAL_SUCCESS_ACTIONS = frozenset({"converged"})
@@ -123,6 +124,11 @@ class RalphLoopResult:
                 "generations": [iteration.generation for iteration in self.iterations],
             }
         )
+        resolution = classify_failure(self.status, meta)
+        if resolution is not None:
+            meta.setdefault("failure_reason_code", resolution.reason_code.value)
+            meta.setdefault("recovery_action", resolution.recovery_action.value)
+            meta.setdefault("next_step", resolution.next_step)
         return MCPToolResult(
             content=(MCPContentItem(type=ContentType.TEXT, text="\n".join(lines)),),
             is_error=self.status == "failed" or self.final_result.is_error,

--- a/src/ouroboros/telemetry.py
+++ b/src/ouroboros/telemetry.py
@@ -34,6 +34,7 @@ import urllib.request
 import uuid
 
 from ouroboros import __version__
+from ouroboros.mcp.failure_taxonomy import classify_failure
 
 # PostHog project API key. This is a *public, write-only* key (it can only
 # ingest events, never read them) — embedding it in an open-source repo is
@@ -322,6 +323,7 @@ _COMMAND_RUN_MCP_KEYS = frozenset(
         "interview_llm_backend",
         "evaluate_llm_backend",
         "frontdoor",
+        "first_command_surface",
         "app_version",
         "os",
         "python_version",
@@ -348,6 +350,8 @@ _WORKFLOW_OUTCOME_KEYS = frozenset(
         "ok",
         "verified",
         "final_approved",
+        "failure_reason_code",
+        "recovery_action",
         "$insert_id",
         "runtime_backend",
         "execute_runtime_backend",
@@ -361,7 +365,18 @@ _WORKFLOW_OUTCOME_KEYS = frozenset(
     }
 )
 _MCP_SERVE_STARTED_KEYS = frozenset(
-    {"transport", "tool_count", "frontdoor", "app_version", "os", "ci"}
+    {
+        "transport",
+        "tool_count",
+        "frontdoor",
+        "first_command_surface",
+        "app_version",
+        "os",
+        "ci",
+    }
+)
+_FIRST_COMMAND_SURFACES = frozenset(
+    {"setup_complete", "readme_quickstart", "getting_started", "unknown"}
 )
 # Bound on any single string property. Dropped, not truncated -- a truncated
 # value could still leak the start of a prompt or path.
@@ -820,6 +835,35 @@ def _detect_frontdoor() -> str | None:
     return None
 
 
+def _detect_first_command_surface() -> str:
+    """Return the privacy-safe onboarding surface attribution.
+
+    The value is deliberately a fixed enum. A trusted setup/config file wins
+    only when no install-time hint exists. The hint identifies the surface
+    that brought the user to installation, so it must survive the subsequent
+    setup step; otherwise every README cohort would be relabeled
+    ``setup_complete`` before its first command. ``setup_complete`` is the
+    fallback for users who configured Ouroboros without a known install
+    surface.
+    """
+    candidate = os.environ.get("OUROBOROS_FIRST_COMMAND_SURFACE", "").strip().lower()
+    if candidate in _FIRST_COMMAND_SURFACES:
+        return candidate
+
+    hint_path = Path.home() / ".ouroboros" / "first_command_surface"
+    try:
+        candidate = hint_path.read_text(encoding="utf-8").strip().lower()
+    except Exception:
+        candidate = ""
+    if candidate in _FIRST_COMMAND_SURFACES:
+        return candidate
+
+    config_path = Path.home() / ".ouroboros" / "config.yaml"
+    if config_path.is_file():
+        return "setup_complete"
+    return "unknown"
+
+
 def _base_properties() -> dict[str, Any]:
     props: dict[str, Any] = {
         "app_version": __version__,
@@ -829,6 +873,7 @@ def _base_properties() -> dict[str, Any]:
     frontdoor = _detect_frontdoor()
     if frontdoor:
         props["frontdoor"] = frontdoor
+    props["first_command_surface"] = _detect_first_command_surface()
     # CI runs are excluded from the published counting rule (TELEMETRY.md);
     # stamping them lets every insight filter ci != true.
     if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"):
@@ -1065,24 +1110,31 @@ def capture_job_outcome(
         verified = (
             normalized_status == "completed" and job_type == "evaluate" and final_approved is True
         )
+        resolution = classify_failure(normalized_status, meta)
         command = (
             _JOB_FUNNEL.get(job_type, job_type)
             if job_type in _CANONICAL_JOB_TYPES
             else _EXTENSION_JOB_COMMAND
         )
+        properties: dict[str, Any] = {
+            "command": command,
+            "phase": "terminal",
+            "terminal_status": normalized_status,
+            "ok": normalized_status == "completed",
+            "verified": verified,
+            "final_approved": (final_approved if isinstance(final_approved, bool) else None),
+            "$insert_id": hashlib.sha256(f"ouroboros-job-outcome\0{job_id}".encode()).hexdigest(),
+        }
+        if resolution is not None:
+            properties.update(
+                {
+                    "failure_reason_code": resolution.reason_code.value,
+                    "recovery_action": resolution.recovery_action.value,
+                }
+            )
         capture(
             "workflow_outcome",
-            {
-                "command": command,
-                "phase": "terminal",
-                "terminal_status": normalized_status,
-                "ok": normalized_status == "completed",
-                "verified": verified,
-                "final_approved": (final_approved if isinstance(final_approved, bool) else None),
-                "$insert_id": hashlib.sha256(
-                    f"ouroboros-job-outcome\0{job_id}".encode()
-                ).hexdigest(),
-            },
+            properties,
         )
     except Exception:
         pass

--- a/tests/unit/config/test_loader_env.py
+++ b/tests/unit/config/test_loader_env.py
@@ -142,6 +142,7 @@ def test_denylist_covers_known_execution_routing_keys() -> None:
         "OUROBOROS_TELEMETRY",
         "OUROBOROS_POSTHOG_API_KEY",
         "OUROBOROS_POSTHOG_HOST",
+        "OUROBOROS_FIRST_COMMAND_SURFACE",
         "DO_NOT_TRACK",
         "CI",
         "GITHUB_ACTIONS",

--- a/tests/unit/mcp/test_failure_taxonomy.py
+++ b/tests/unit/mcp/test_failure_taxonomy.py
@@ -1,0 +1,64 @@
+"""Tests for privacy-safe workflow failure classification."""
+
+from ouroboros.mcp.failure_taxonomy import (
+    FailureReasonCode,
+    RecoveryAction,
+    classify_failure,
+)
+
+
+def test_success_is_not_a_failure() -> None:
+    assert classify_failure("completed", {}) is None
+
+
+def test_machine_metadata_maps_without_reading_raw_error() -> None:
+    resolution = classify_failure(
+        "failed",
+        {
+            "failure_reason_code": "auth",
+            "error": "private prompt and path must not matter",
+        },
+    )
+
+    assert resolution is not None
+    assert resolution.reason_code is FailureReasonCode.AUTH
+    assert resolution.recovery_action is RecoveryAction.LOGIN
+
+
+def test_timeout_status_metadata_maps_to_retry() -> None:
+    resolution = classify_failure("failed", {"evaluation_status": "timed_out"})
+
+    assert resolution is not None
+    assert resolution.reason_code is FailureReasonCode.TIMEOUT
+    assert resolution.recovery_action is RecoveryAction.RETRY
+
+
+def test_unhashable_metadata_value_fails_closed_to_unknown() -> None:
+    resolution = classify_failure("failed", {"status": {"private": "value"}})
+
+    assert resolution is not None
+    assert resolution.reason_code is FailureReasonCode.UNKNOWN
+    assert resolution.recovery_action is RecoveryAction.INSPECT_LOGS
+
+
+def test_ralph_timeout_stop_reason_maps_to_retry() -> None:
+    resolution = classify_failure("failed", {"stop_reason": "iteration_timeout"})
+
+    assert resolution is not None
+    assert resolution.reason_code is FailureReasonCode.TIMEOUT
+    assert resolution.recovery_action is RecoveryAction.RETRY
+
+
+def test_ralph_quality_guard_maps_to_validation() -> None:
+    resolution = classify_failure("failed", {"action": "oscillation_detected"})
+
+    assert resolution is not None
+    assert resolution.reason_code is FailureReasonCode.VALIDATION
+
+
+def test_ralph_generation_budget_is_not_a_timeout() -> None:
+    resolution = classify_failure("failed", {"stop_reason": "max_generations reached"})
+
+    assert resolution is not None
+    assert resolution.reason_code is FailureReasonCode.VALIDATION
+    assert resolution.recovery_action is RecoveryAction.INSPECT_LOGS

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -140,14 +140,26 @@ class TestJobManager:
                     initial_message="queued",
                     runner=failed_execution(),
                 )
-                await _wait_for_job_status(manager, started.job_id, JobStatus.FAILED)
+                terminal = await _wait_for_job_status(manager, started.job_id, JobStatus.FAILED)
 
             capture.assert_called_once_with(
                 started.job_id,
                 "execute_seed",
                 terminal_status="failed",
-                result_meta=None,
+                result_meta={
+                    "failure_reason_code": "unknown",
+                    "recovery_action": "inspect_logs",
+                    "next_step": "Inspect the server logs before retrying the workflow.",
+                },
             )
+            assert terminal.result_meta["failure_reason_code"] == "unknown"
+            assert terminal.result_meta["recovery_action"] == "inspect_logs"
+            assert terminal.result_meta["next_step"] == (
+                "Inspect the server logs before retrying the workflow."
+            )
+            rendered, _ = await _render_job_snapshot_inner(terminal, store)
+            assert "### Recovery" in rendered
+            assert "**Recommended action**: inspect_logs" in rendered
         finally:
             await _cancel_manager_tasks(manager)
             await store.close()
@@ -1330,6 +1342,9 @@ class TestJobManager:
 
             assert snapshot.status is JobStatus.FAILED
             assert snapshot.result_meta["failed_from_progress_accounting_stall"] is True
+            assert snapshot.result_meta["failure_reason_code"] == "timeout"
+            assert snapshot.result_meta["recovery_action"] == "retry"
+            assert snapshot.result_meta["next_step"] == "Retry the workflow."
             assert "workflow progress accounting stalled" in (snapshot.error or "")
             events, _ = await store.get_events_after("job", "job_recover_failed", last_row_id=0)
             assert [event.type for event in events] == ["mcp.job.created", "mcp.job.failed"]
@@ -2290,6 +2305,9 @@ class TestJobManager:
 
             assert snapshot.status is JobStatus.FAILED
             assert snapshot.result_meta["failed_from_progress_accounting_stall"] is True
+            assert snapshot.result_meta["failure_reason_code"] == "timeout"
+            assert snapshot.result_meta["recovery_action"] == "retry"
+            assert snapshot.result_meta["next_step"] == "Retry the workflow."
             assert "workflow progress accounting stalled" in (snapshot.error or "")
             events, _ = await read_only_store.get_events_after(
                 "job",
@@ -7030,6 +7048,9 @@ class TestZombieJobReconciliation:
 
             assert snapshot.status is JobStatus.INTERRUPTED
             assert snapshot.result_meta["interrupted_from_dead_owner"] is True
+            assert snapshot.result_meta["failure_reason_code"] == "cancelled"
+            assert snapshot.result_meta["recovery_action"] == "retry"
+            assert snapshot.result_meta["next_step"] == "Retry the workflow when you are ready."
             store._read_only = False
             events, _ = await store.get_events_after("job", "job_ro", last_row_id=0)
             # Projection only — nothing persisted on a read-only store.

--- a/tests/unit/mcp/tools/test_evaluate_telemetry.py
+++ b/tests/unit/mcp/tools/test_evaluate_telemetry.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from ouroboros.core.errors import ConfigError
 from ouroboros.core.types import Result
 from ouroboros.evaluation.models import (
     CheckResult,
@@ -182,7 +183,7 @@ class TestDirectEvaluateSingleACTelemetry:
         with (
             patch(
                 "ouroboros.mcp.tools.evaluation_handlers.create_llm_adapter",
-                side_effect=RuntimeError("unsupported backend"),
+                side_effect=ConfigError("unsupported backend"),
             ),
             patch(
                 "ouroboros.persistence.event_store.EventStore",
@@ -205,6 +206,60 @@ class TestDirectEvaluateSingleACTelemetry:
         assert props["terminal_status"] == "failed"
         assert props["ok"] is False
         assert props["final_approved"] is None
+        assert props["failure_reason_code"] == "config"
+
+    async def test_generic_factory_runtime_error_is_not_config(self) -> None:
+        with (
+            patch(
+                "ouroboros.mcp.tools.evaluation_handlers.create_llm_adapter",
+                side_effect=RuntimeError("provider construction failed"),
+            ),
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+            patch(_CAPTURE_TARGET) as capture,
+        ):
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s4c",
+                    "artifact": "def f(): pass",
+                    "acceptance_criterion": "Only AC",
+                }
+            )
+
+        assert result.is_err
+        _, props = capture.call_args.args
+        assert props["failure_reason_code"] == "unknown"
+
+    async def test_pipeline_runtime_error_falls_back_to_unknown(self) -> None:
+        mock_pipeline = _install_pipeline_mock(  # type: ignore[arg-type]
+            Result.ok(_eval_result("s4b", final_approved=True))
+        )
+        mock_pipeline.evaluate = AsyncMock(side_effect=RuntimeError("pipeline bug"))
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+            patch(_CAPTURE_TARGET) as capture,
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s4b",
+                    "artifact": "def f(): pass",
+                    "acceptance_criterion": "Only AC",
+                }
+            )
+
+        assert result.is_err
+        _, props = capture.call_args.args
+        assert props["failure_reason_code"] == "unknown"
 
 
 class TestDirectEvaluateMultiACTelemetry:

--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -200,6 +200,43 @@ def test_installer_absent_config_retains_disclosed_default_on(tmp_path: Path) ->
     assert result.stdout.count("Anonymous usage stats help improve Ouroboros") == 1
 
 
+@pytest.mark.parametrize(
+    ("install_ref", "expected_surface"),
+    (("readme", "readme_quickstart"), ("docs-getting-started", "getting_started")),
+)
+def test_installer_persists_first_command_surface_hint(
+    tmp_path: Path, install_ref: str, expected_surface: str
+) -> None:
+    result = _run_installer(
+        tmp_path,
+        local_repo=False,
+        env={"OUROBOROS_TELEMETRY": "", "OUROBOROS_INSTALL_REF": install_ref},
+        fake_commands=_telemetry_fake_commands(tmp_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    hint = tmp_path / "home" / ".ouroboros" / "first_command_surface"
+    assert hint.read_text(encoding="utf-8") == f"{expected_surface}\n"
+
+
+def test_installer_does_not_relabel_existing_first_command_surface_hint(
+    tmp_path: Path,
+) -> None:
+    hint = tmp_path / "home" / ".ouroboros" / "first_command_surface"
+    hint.parent.mkdir(parents=True)
+    hint.write_text("readme_quickstart\n", encoding="utf-8")
+
+    result = _run_installer(
+        tmp_path,
+        local_repo=False,
+        env={"OUROBOROS_TELEMETRY": "", "OUROBOROS_INSTALL_REF": "docs-getting-started"},
+        fake_commands=_telemetry_fake_commands(tmp_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert hint.read_text(encoding="utf-8") == "readme_quickstart\n"
+
+
 def test_copied_installer_dangling_config_symlink_fails_closed(tmp_path: Path) -> None:
     config = tmp_path / "home" / ".ouroboros" / "config.yaml"
     config.parent.mkdir(parents=True)

--- a/tests/unit/test_ralph_loop_budget.py
+++ b/tests/unit/test_ralph_loop_budget.py
@@ -118,6 +118,8 @@ async def test_ralph_loop_wall_clock_exhausted_surfaces_in_tool_result_meta() ->
     assert tool_result.is_error is True
     assert tool_result.meta["status"] == "failed"
     assert tool_result.meta["stop_reason"] == "wall_clock_exhausted"
+    assert tool_result.meta["failure_reason_code"] == "timeout"
+    assert tool_result.meta["recovery_action"] == "retry"
 
 
 @dataclass

--- a/tests/unit/test_ralph_loop_timeout.py
+++ b/tests/unit/test_ralph_loop_timeout.py
@@ -108,6 +108,8 @@ async def test_ralph_loop_timeout_surfaces_in_tool_result_meta() -> None:
     assert tool_result.meta["status"] == "failed"
     assert tool_result.meta["stop_reason"] == "iteration_timeout"
     assert tool_result.meta["actions"] == ["iteration_timeout"]
+    assert tool_result.meta["failure_reason_code"] == "timeout"
+    assert tool_result.meta["recovery_action"] == "retry"
 
 
 @dataclass

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -179,6 +179,7 @@ class TestOptOut:
             "OUROBOROS_TELEMETRY",
             "OUROBOROS_POSTHOG_HOST",
             "OUROBOROS_POSTHOG_API_KEY",
+            "OUROBOROS_FIRST_COMMAND_SURFACE",
         ):
             env.pop(key, None)
         env["HOME"] = str(tmp_path / "home")
@@ -803,6 +804,59 @@ class TestCapture:
         assert sent[0]["properties"]["command"] == "extension_job"
 
     @pytest.mark.parametrize(
+        ("terminal_status", "meta", "reason", "action"),
+        (
+            ("cancelled", {}, "cancelled", "retry"),
+            ("interrupted", {"interrupted_from_shutdown": True}, "cancelled", "retry"),
+            ("failed", {"failed_from_progress_accounting_stall": True}, "timeout", "retry"),
+            ("failed", {"failure_reason_code": "config"}, "config", "setup"),
+            ("failed", {"failure_reason_code": "auth"}, "auth", "login"),
+            ("failed", {"failure_reason_code": "validation"}, "validation", "inspect_logs"),
+            ("failed", {}, "unknown", "inspect_logs"),
+        ),
+    )
+    def test_failed_outcome_emits_closed_reason_and_action(
+        self,
+        sent: list[dict[str, Any]],
+        terminal_status: str,
+        meta: dict[str, Any],
+        reason: str,
+        action: str,
+    ) -> None:
+        telemetry.capture_job_outcome(
+            "job-private-id",
+            "execute_seed",
+            terminal_status=terminal_status,
+            result_meta=meta,
+        )
+        telemetry.flush(timeout=2.0)
+
+        props = sent[0]["properties"]
+        assert props["failure_reason_code"] == reason
+        assert props["recovery_action"] == action
+        assert "job-private-id" not in json.dumps(sent[0])
+
+    def test_failed_outcome_does_not_forward_raw_error_or_unknown_metadata(
+        self, sent: list[dict[str, Any]]
+    ) -> None:
+        telemetry.capture_job_outcome(
+            "job-private-id",
+            "execute_seed",
+            terminal_status="failed",
+            result_meta={
+                "error": "secret prompt /Users/private/project",
+                "failure_reason_code": "not-a-real-code",
+            },
+        )
+        telemetry.flush(timeout=2.0)
+
+        props = sent[0]["properties"]
+        assert props["failure_reason_code"] == "unknown"
+        assert props["recovery_action"] == "inspect_logs"
+        assert "secret prompt" not in json.dumps(sent[0])
+        assert "/Users/private/project" not in json.dumps(sent[0])
+
+    @pytest.mark.parametrize(
         ("job_type", "expected_command"),
         (
             ("execute_seed", "run"),
@@ -988,6 +1042,7 @@ class TestExactPropertySets:
             "execute_runtime_backend",
             "interview_llm_backend",
             "evaluate_llm_backend",
+            "first_command_surface",
             "app_version",
             "os",
             "python_version",
@@ -1013,6 +1068,7 @@ class TestExactPropertySets:
             "is_funnel",
             "phase",
             "accepted",
+            "first_command_surface",
             "app_version",
             "os",
             "python_version",
@@ -1112,7 +1168,13 @@ class TestExactPropertySets:
         keys = set(props)
 
         assert keys <= telemetry._MCP_SERVE_STARTED_KEYS
-        assert keys == {"transport", "tool_count", "app_version", "os"}
+        assert keys == {
+            "transport",
+            "tool_count",
+            "first_command_surface",
+            "app_version",
+            "os",
+        }
         assert "python_version" not in props
         for backend_key in telemetry._CONTEXT_ALLOWLIST:
             assert backend_key not in props
@@ -1181,6 +1243,43 @@ class TestFrontdoor:
         monkeypatch.delenv("CODEX_THREAD_ID", raising=False)
         monkeypatch.delenv("CODEX_SANDBOX_NETWORK_DISABLED", raising=False)
         assert telemetry._detect_frontdoor() is None
+
+
+class TestFirstCommandSurface:
+    @pytest.mark.parametrize(
+        "surface", ("setup_complete", "readme_quickstart", "getting_started", "unknown")
+    )
+    def test_explicit_fixed_enum_wins(self, monkeypatch: pytest.MonkeyPatch, surface: str) -> None:
+        monkeypatch.setenv("OUROBOROS_FIRST_COMMAND_SURFACE", surface)
+        (Path.home() / ".ouroboros").mkdir()
+        (Path.home() / ".ouroboros" / "first_command_surface").write_text(
+            "readme_quickstart\n", encoding="utf-8"
+        )
+        (Path.home() / ".ouroboros" / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+        assert telemetry._detect_first_command_surface() == surface
+
+    def test_install_hint_survives_setup(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / ".ouroboros"
+        state_dir.mkdir()
+        (state_dir / "first_command_surface").write_text("readme_quickstart\n", encoding="utf-8")
+        (state_dir / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+        assert telemetry._detect_first_command_surface() == "readme_quickstart"
+
+    def test_config_is_fallback_when_hint_is_absent(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / ".ouroboros"
+        state_dir.mkdir()
+        (state_dir / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+        assert telemetry._detect_first_command_surface() == "setup_complete"
+
+    def test_invalid_hint_without_config_is_unknown(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / ".ouroboros"
+        state_dir.mkdir()
+        (state_dir / "first_command_surface").write_text("private-url\n", encoding="utf-8")
+
+        assert telemetry._detect_first_command_surface() == "unknown"
 
 
 class TestNotice:


### PR DESCRIPTION
## Summary

- Add first-command surface attribution so installation sources can be compared after release.
- Add privacy-safe workflow failure reasons and recovery actions for run and ralph.
- Keep activation and workflow telemetry behind one 31-path release bundle so partial releases fail closed.

## Changes

- Persist installer ref and first-command surface hints across supported runtime entry points.
- Emit failure reason codes and user next-step recovery data for workflow outcomes.
- Add focused tests and documentation for activation and workflow recovery measurement.

## Notes

- Candidate commit: 3103014e8363b2cbe484bdbddf87b63fe33d4041
- Clean candidate validation: 607 tests passed.
- The implementation is intended to be measured after release; this PR does not claim conversion lift before the post-release cohort exists.


Closes #1909
