### PR TITLE
fix(hooks): fail open when plugin cache root disappears

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "ROOT=\"${CLAUDE_PLUGIN_ROOT:-$PWD}\"; python3 \"$ROOT/scripts/keyword-detector.py\" || python \"$ROOT/scripts/keyword-detector.py\"",
+            "command": "ROOT=\"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-$PWD}}\"; SCRIPT=\"$ROOT/scripts/keyword-detector.py\"; if [ ! -r \"$SCRIPT\" ]; then printf '%s\\n' \"Ouroboros hook skipped: $SCRIPT is unavailable.\" >&2; exit 0; fi; if command -v python3 >/dev/null 2>&1; then PYTHON=python3; elif command -v python >/dev/null 2>&1; then PYTHON=python; else printf '%s\\n' 'Ouroboros hook skipped: Python is unavailable.' >&2; exit 0; fi; \"$PYTHON\" \"$SCRIPT\" || { STATUS=$?; printf '%s\\n' \"Ouroboros hook failed open: $SCRIPT exited with code $STATUS.\" >&2; exit 0; }",
             "timeout": 5
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "ROOT=\"${CLAUDE_PLUGIN_ROOT:-$PWD}\"; python3 \"$ROOT/scripts/drift-monitor.py\" || python \"$ROOT/scripts/drift-monitor.py\"",
+            "command": "ROOT=\"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-$PWD}}\"; SCRIPT=\"$ROOT/scripts/drift-monitor.py\"; if [ ! -r \"$SCRIPT\" ]; then printf '%s\\n' \"Ouroboros hook skipped: $SCRIPT is unavailable.\" >&2; exit 0; fi; if command -v python3 >/dev/null 2>&1; then PYTHON=python3; elif command -v python >/dev/null 2>&1; then PYTHON=python; else printf '%s\\n' 'Ouroboros hook skipped: Python is unavailable.' >&2; exit 0; fi; \"$PYTHON\" \"$SCRIPT\" || { STATUS=$?; printf '%s\\n' \"Ouroboros hook failed open: $SCRIPT exited with code $STATUS.\" >&2; exit 0; }",
             "timeout": 3
           }
         ]

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "ROOT=\"${CLAUDE_PLUGIN_ROOT:-$PWD}\"; python3 \"$ROOT/scripts/drift-monitor.py\" || python \"$ROOT/scripts/drift-monitor.py\"",
+            "command": "ROOT=\"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-$PWD}}\"; SCRIPT=\"$ROOT/scripts/drift-monitor.py\"; if [ ! -r \"$SCRIPT\" ]; then printf '%s\\n' \"Ouroboros hook skipped: $SCRIPT is unavailable.\" >&2; exit 0; fi; if command -v python3 >/dev/null 2>&1; then PYTHON=python3; elif command -v python >/dev/null 2>&1; then PYTHON=python; else printf '%s\\n' 'Ouroboros hook skipped: Python is unavailable.' >&2; exit 0; fi; \"$PYTHON\" \"$SCRIPT\" || { STATUS=$?; printf '%s\\n' \"Ouroboros hook failed open: $SCRIPT exited with code $STATUS.\" >&2; exit 0; }",
             "timeout": 3
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "ROOT=\"${CLAUDE_PLUGIN_ROOT:-$PWD}\"; python3 \"$ROOT/scripts/keyword-detector.py\" || python \"$ROOT/scripts/keyword-detector.py\"",
+            "command": "ROOT=\"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-$PWD}}\"; SCRIPT=\"$ROOT/scripts/keyword-detector.py\"; if [ ! -r \"$SCRIPT\" ]; then printf '%s\\n' \"Ouroboros hook skipped: $SCRIPT is unavailable.\" >&2; exit 0; fi; if command -v python3 >/dev/null 2>&1; then PYTHON=python3; elif command -v python >/dev/null 2>&1; then PYTHON=python; else printf '%s\\n' 'Ouroboros hook skipped: Python is unavailable.' >&2; exit 0; fi; \"$PYTHON\" \"$SCRIPT\" || { STATUS=$?; printf '%s\\n' \"Ouroboros hook failed open: $SCRIPT exited with code $STATUS.\" >&2; exit 0; }",
             "timeout": 5
           }
         ]

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "ROOT=\"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-$PWD}}\"; SCRIPT=\"$ROOT/scripts/session-start.py\"; if [ ! -r \"$SCRIPT\" ]; then printf '%s\\n' \"Ouroboros hook skipped: $SCRIPT is unavailable.\" >&2; exit 0; fi; if command -v python3 >/dev/null 2>&1; then PYTHON=python3; elif command -v python >/dev/null 2>&1; then PYTHON=python; else printf '%s\\n' 'Ouroboros hook skipped: Python is unavailable.' >&2; exit 0; fi; \"$PYTHON\" \"$SCRIPT\" || { STATUS=$?; printf '%s\\n' \"Ouroboros hook failed open: $SCRIPT exited with code $STATUS.\" >&2; exit 0; }",
+            "command": "ROOT=\"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if [ -z \"$ROOT\" ]; then printf '%s\\n' 'Ouroboros hook skipped: plugin root is unavailable.' >&2; exit 0; fi; SCRIPT=\"$ROOT/scripts/session-start.py\"; if [ ! -r \"$SCRIPT\" ]; then printf '%s\\n' \"Ouroboros hook skipped: $SCRIPT is unavailable.\" >&2; exit 0; fi; if command -v python3 >/dev/null 2>&1; then PYTHON=python3; elif command -v python >/dev/null 2>&1; then PYTHON=python; else printf '%s\\n' 'Ouroboros hook skipped: Python is unavailable.' >&2; exit 0; fi; \"$PYTHON\" \"$SCRIPT\" || { STATUS=$?; printf '%s\\n' \"Ouroboros hook failed open: $SCRIPT exited with code $STATUS.\" >&2; exit 0; }",
             "timeout": 5
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "ROOT=\"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-$PWD}}\"; SCRIPT=\"$ROOT/scripts/keyword-detector.py\"; if [ ! -r \"$SCRIPT\" ]; then printf '%s\\n' \"Ouroboros hook skipped: $SCRIPT is unavailable.\" >&2; exit 0; fi; if command -v python3 >/dev/null 2>&1; then PYTHON=python3; elif command -v python >/dev/null 2>&1; then PYTHON=python; else printf '%s\\n' 'Ouroboros hook skipped: Python is unavailable.' >&2; exit 0; fi; \"$PYTHON\" \"$SCRIPT\" || { STATUS=$?; printf '%s\\n' \"Ouroboros hook failed open: $SCRIPT exited with code $STATUS.\" >&2; exit 0; }",
+            "command": "ROOT=\"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if [ -z \"$ROOT\" ]; then printf '%s\\n' 'Ouroboros hook skipped: plugin root is unavailable.' >&2; exit 0; fi; SCRIPT=\"$ROOT/scripts/keyword-detector.py\"; if [ ! -r \"$SCRIPT\" ]; then printf '%s\\n' \"Ouroboros hook skipped: $SCRIPT is unavailable.\" >&2; exit 0; fi; if command -v python3 >/dev/null 2>&1; then PYTHON=python3; elif command -v python >/dev/null 2>&1; then PYTHON=python; else printf '%s\\n' 'Ouroboros hook skipped: Python is unavailable.' >&2; exit 0; fi; \"$PYTHON\" \"$SCRIPT\" || { STATUS=$?; printf '%s\\n' \"Ouroboros hook failed open: $SCRIPT exited with code $STATUS.\" >&2; exit 0; }",
             "timeout": 5
           }
         ]
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "ROOT=\"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-$PWD}}\"; SCRIPT=\"$ROOT/scripts/drift-monitor.py\"; if [ ! -r \"$SCRIPT\" ]; then printf '%s\\n' \"Ouroboros hook skipped: $SCRIPT is unavailable.\" >&2; exit 0; fi; if command -v python3 >/dev/null 2>&1; then PYTHON=python3; elif command -v python >/dev/null 2>&1; then PYTHON=python; else printf '%s\\n' 'Ouroboros hook skipped: Python is unavailable.' >&2; exit 0; fi; \"$PYTHON\" \"$SCRIPT\" || { STATUS=$?; printf '%s\\n' \"Ouroboros hook failed open: $SCRIPT exited with code $STATUS.\" >&2; exit 0; }",
+            "command": "ROOT=\"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if [ -z \"$ROOT\" ]; then printf '%s\\n' 'Ouroboros hook skipped: plugin root is unavailable.' >&2; exit 0; fi; SCRIPT=\"$ROOT/scripts/drift-monitor.py\"; if [ ! -r \"$SCRIPT\" ]; then printf '%s\\n' \"Ouroboros hook skipped: $SCRIPT is unavailable.\" >&2; exit 0; fi; if command -v python3 >/dev/null 2>&1; then PYTHON=python3; elif command -v python >/dev/null 2>&1; then PYTHON=python; else printf '%s\\n' 'Ouroboros hook skipped: Python is unavailable.' >&2; exit 0; fi; \"$PYTHON\" \"$SCRIPT\" || { STATUS=$?; printf '%s\\n' \"Ouroboros hook failed open: $SCRIPT exited with code $STATUS.\" >&2; exit 0; }",
             "timeout": 3
           }
         ]

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.py\"",
+            "command": "ROOT=\"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-$PWD}}\"; SCRIPT=\"$ROOT/scripts/session-start.py\"; if [ ! -r \"$SCRIPT\" ]; then printf '%s\\n' \"Ouroboros hook skipped: $SCRIPT is unavailable.\" >&2; exit 0; fi; if command -v python3 >/dev/null 2>&1; then PYTHON=python3; elif command -v python >/dev/null 2>&1; then PYTHON=python; else printf '%s\\n' 'Ouroboros hook skipped: Python is unavailable.' >&2; exit 0; fi; \"$PYTHON\" \"$SCRIPT\" || { STATUS=$?; printf '%s\\n' \"Ouroboros hook failed open: $SCRIPT exited with code $STATUS.\" >&2; exit 0; }",
             "timeout": 5
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/keyword-detector.py\"",
+            "command": "ROOT=\"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-$PWD}}\"; SCRIPT=\"$ROOT/scripts/keyword-detector.py\"; if [ ! -r \"$SCRIPT\" ]; then printf '%s\\n' \"Ouroboros hook skipped: $SCRIPT is unavailable.\" >&2; exit 0; fi; if command -v python3 >/dev/null 2>&1; then PYTHON=python3; elif command -v python >/dev/null 2>&1; then PYTHON=python; else printf '%s\\n' 'Ouroboros hook skipped: Python is unavailable.' >&2; exit 0; fi; \"$PYTHON\" \"$SCRIPT\" || { STATUS=$?; printf '%s\\n' \"Ouroboros hook failed open: $SCRIPT exited with code $STATUS.\" >&2; exit 0; }",
             "timeout": 5
           }
         ]
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/drift-monitor.py\"",
+            "command": "ROOT=\"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-$PWD}}\"; SCRIPT=\"$ROOT/scripts/drift-monitor.py\"; if [ ! -r \"$SCRIPT\" ]; then printf '%s\\n' \"Ouroboros hook skipped: $SCRIPT is unavailable.\" >&2; exit 0; fi; if command -v python3 >/dev/null 2>&1; then PYTHON=python3; elif command -v python >/dev/null 2>&1; then PYTHON=python; else printf '%s\\n' 'Ouroboros hook skipped: Python is unavailable.' >&2; exit 0; fi; \"$PYTHON\" \"$SCRIPT\" || { STATUS=$?; printf '%s\\n' \"Ouroboros hook failed open: $SCRIPT exited with code $STATUS.\" >&2; exit 0; }",
             "timeout": 3
           }
         ]

--- a/tests/unit/scripts/test_claude_hook_settings.py
+++ b/tests/unit/scripts/test_claude_hook_settings.py
@@ -20,7 +20,7 @@ def test_plugin_hooks_prefer_plugin_root_and_fallback_to_repo_root() -> None:
     """Hooks must work both inside plugin runtime and normal repo checkouts."""
     commands = _hook_commands()
 
-    assert any('ROOT="${CLAUDE_PLUGIN_ROOT:-$PWD}"' in cmd for cmd in commands)
+    assert all('ROOT="${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-$PWD}}"' in cmd for cmd in commands)
     assert any('"$ROOT/scripts/keyword-detector.py"' in cmd for cmd in commands)
     assert any('"$ROOT/scripts/drift-monitor.py"' in cmd for cmd in commands)
     assert all("CLAUDE_PROJECT_DIR" not in cmd for cmd in commands)
@@ -31,5 +31,12 @@ def test_plugin_hooks_fall_back_to_unversioned_python() -> None:
     """Prefer python3 where available, but fall back for Windows installs."""
     commands = _hook_commands()
 
-    assert all("python3 " in cmd for cmd in commands)
-    assert all(" || python " in cmd for cmd in commands)
+    assert all("command -v python3" in cmd for cmd in commands)
+    assert all("command -v python" in cmd for cmd in commands)
+
+
+def test_plugin_hooks_are_advisory_and_fail_open() -> None:
+    commands = _hook_commands()
+
+    assert all('[ ! -r "$SCRIPT" ]' in cmd for cmd in commands)
+    assert all("exit 0" in cmd for cmd in commands)

--- a/tests/unit/scripts/test_plugin_hook_manifest.py
+++ b/tests/unit/scripts/test_plugin_hook_manifest.py
@@ -9,11 +9,14 @@ import subprocess
 
 import pytest
 
-_HOOKS_PATH = Path(__file__).resolve().parents[3] / "hooks" / "hooks.json"
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_HOOKS_PATH = _REPO_ROOT / "hooks" / "hooks.json"
+_CLAUDE_SETTINGS_PATH = _REPO_ROOT / ".claude" / "settings.json"
+_CODEX_HOOKS_PATH = _REPO_ROOT / ".codex" / "hooks.json"
 
 
-def _hook_command(event_name: str) -> str:
-    manifest = json.loads(_HOOKS_PATH.read_text(encoding="utf-8"))
+def _hook_command(manifest_path: Path, event_name: str) -> str:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     entries = manifest["hooks"][event_name]
     assert len(entries) == 1
     hooks = entries[0]["hooks"]
@@ -21,8 +24,20 @@ def _hook_command(event_name: str) -> str:
     return hooks[0]["command"]
 
 
-@pytest.mark.parametrize("event_name", ["SessionStart", "UserPromptSubmit", "PostToolUse"])
+@pytest.mark.parametrize(
+    ("manifest_path", "event_name"),
+    [
+        (_HOOKS_PATH, "SessionStart"),
+        (_HOOKS_PATH, "UserPromptSubmit"),
+        (_HOOKS_PATH, "PostToolUse"),
+        (_CLAUDE_SETTINGS_PATH, "UserPromptSubmit"),
+        (_CLAUDE_SETTINGS_PATH, "PostToolUse"),
+        (_CODEX_HOOKS_PATH, "UserPromptSubmit"),
+        (_CODEX_HOOKS_PATH, "PostToolUse"),
+    ],
+)
 def test_advisory_hook_fails_open_when_loaded_plugin_version_was_removed(
+    manifest_path: Path,
     event_name: str,
     tmp_path: Path,
 ) -> None:
@@ -33,7 +48,7 @@ def test_advisory_hook_fails_open_when_loaded_plugin_version_was_removed(
     env["CLAUDE_PLUGIN_ROOT"] = str(removed_plugin_root)
 
     result = subprocess.run(
-        _hook_command(event_name),
+        _hook_command(manifest_path, event_name),
         shell=True,
         input=json.dumps({"hook_event_name": event_name}),
         capture_output=True,
@@ -45,7 +60,12 @@ def test_advisory_hook_fails_open_when_loaded_plugin_version_was_removed(
     assert result.returncode == 0, result.stderr
 
 
-def test_codex_plugin_root_takes_precedence_over_claude_compatibility_root(
+@pytest.mark.parametrize(
+    "manifest_path",
+    [_HOOKS_PATH, _CLAUDE_SETTINGS_PATH, _CODEX_HOOKS_PATH],
+)
+def test_plugin_root_takes_precedence_over_claude_compatibility_root(
+    manifest_path: Path,
     tmp_path: Path,
 ) -> None:
     plugin_root = tmp_path / "current-version"
@@ -57,7 +77,7 @@ def test_codex_plugin_root_takes_precedence_over_claude_compatibility_root(
     env["CLAUDE_PLUGIN_ROOT"] = str(tmp_path / "removed-version")
 
     result = subprocess.run(
-        _hook_command("UserPromptSubmit"),
+        _hook_command(manifest_path, "UserPromptSubmit"),
         shell=True,
         input="{}",
         capture_output=True,

--- a/tests/unit/scripts/test_plugin_hook_manifest.py
+++ b/tests/unit/scripts/test_plugin_hook_manifest.py
@@ -1,0 +1,70 @@
+"""Behavioral regression tests for host-facing plugin hook commands."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+_HOOKS_PATH = Path(__file__).resolve().parents[3] / "hooks" / "hooks.json"
+
+
+def _hook_command(event_name: str) -> str:
+    manifest = json.loads(_HOOKS_PATH.read_text(encoding="utf-8"))
+    entries = manifest["hooks"][event_name]
+    assert len(entries) == 1
+    hooks = entries[0]["hooks"]
+    assert len(hooks) == 1
+    return hooks[0]["command"]
+
+
+@pytest.mark.parametrize("event_name", ["SessionStart", "UserPromptSubmit", "PostToolUse"])
+def test_advisory_hook_fails_open_when_loaded_plugin_version_was_removed(
+    event_name: str,
+    tmp_path: Path,
+) -> None:
+    """A host cache rotation must not turn a missing advisory hook into a block."""
+    removed_plugin_root = tmp_path / "cache" / "ouroboros" / "removed-version"
+    env = os.environ.copy()
+    env["PLUGIN_ROOT"] = str(removed_plugin_root)
+    env["CLAUDE_PLUGIN_ROOT"] = str(removed_plugin_root)
+
+    result = subprocess.run(
+        _hook_command(event_name),
+        shell=True,
+        input=json.dumps({"hook_event_name": event_name}),
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=5,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_codex_plugin_root_takes_precedence_over_claude_compatibility_root(
+    tmp_path: Path,
+) -> None:
+    plugin_root = tmp_path / "current-version"
+    script = plugin_root / "scripts" / "keyword-detector.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("print('PLUGIN_ROOT_OK')\n", encoding="utf-8")
+    env = os.environ.copy()
+    env["PLUGIN_ROOT"] = str(plugin_root)
+    env["CLAUDE_PLUGIN_ROOT"] = str(tmp_path / "removed-version")
+
+    result = subprocess.run(
+        _hook_command("UserPromptSubmit"),
+        shell=True,
+        input="{}",
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=5,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "PLUGIN_ROOT_OK"

--- a/tests/unit/scripts/test_plugin_hook_manifest.py
+++ b/tests/unit/scripts/test_plugin_hook_manifest.py
@@ -61,6 +61,47 @@ def test_advisory_hook_fails_open_when_loaded_plugin_version_was_removed(
 
 
 @pytest.mark.parametrize(
+    ("event_name", "script_name"),
+    [
+        ("SessionStart", "session-start.py"),
+        ("UserPromptSubmit", "keyword-detector.py"),
+        ("PostToolUse", "drift-monitor.py"),
+    ],
+)
+def test_packaged_hook_does_not_execute_project_script_without_plugin_root(
+    event_name: str,
+    script_name: str,
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "untrusted-project"
+    script = project_root / "scripts" / script_name
+    script.parent.mkdir(parents=True)
+    marker = tmp_path / "executed"
+    script.write_text(
+        "import os\nfrom pathlib import Path\nPath(os.environ['MARKER']).write_text('executed')\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env.pop("PLUGIN_ROOT", None)
+    env.pop("CLAUDE_PLUGIN_ROOT", None)
+    env["MARKER"] = str(marker)
+
+    result = subprocess.run(
+        _hook_command(_HOOKS_PATH, event_name),
+        shell=True,
+        input=json.dumps({"hook_event_name": event_name}),
+        capture_output=True,
+        text=True,
+        cwd=project_root,
+        env=env,
+        timeout=5,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize(
     "manifest_path",
     [_HOOKS_PATH, _CLAUDE_SETTINGS_PATH, _CODEX_HOOKS_PATH],
 )


### PR DESCRIPTION
## Summary

- Make packaged and development advisory hooks validate the resolved script and Python executable before invocation.
- Prefer Codex `PLUGIN_ROOT` while retaining the Claude `CLAUDE_PLUGIN_ROOT` compatibility fallback.
- Treat missing cache roots and hook execution errors as warnings so a plugin update cannot block the next user prompt.
- Add behavioral regression coverage that executes every packaged hook after its versioned cache directory has been removed.

## Test plan

- [x] `uv run --python 3.14 --no-sync pytest -q tests/unit/scripts/test_plugin_hook_manifest.py tests/unit/scripts/test_claude_hook_settings.py` — 7 passed
- [x] `uv run --python 3.14 --no-sync ruff check src/ tests/`
- [x] `uv run --python 3.14 --no-sync ruff format --check src/ tests/`
- [x] `uv run --python 3.14 --no-sync mypy src/`
- [ ] Full suite: 20,555 passed, 94 skipped, 1 xfailed; two pre-existing macOS-only poison-control assertions fail because current `uv run` sanitizes `PYTHONEXECUTABLE` and `__PYVENV_LAUNCHER__`

## Related issues

Closes #2109
Refs openai/codex#31383