### PR TITLE
docs(readme): add mcp-name marker for MCP registry ownership check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- mcp-name: io.github.Q00/ouroboros -->
 <p align="right">
   <strong>English</strong> | <a href="./README.ko.md">한국어</a> | <a href="./README.zh-CN.md">简体中文</a>
 </p>


### PR DESCRIPTION
Closes #2114.

The official MCP registry (registry.modelcontextprotocol.io) rejects publishing `io.github.Q00/ouroboros` until the PyPI-rendered README contains the literal marker `mcp-name: io.github.Q00/ouroboros`. It's a one-line HTML comment, invisible on GitHub's render, and only needs to survive into PyPI's `long_description` (sourced from `README.md` per `pyproject.toml`'s `readme` field) for the ownership check to pass on the next release.

Verified: `mcp-publisher login github` and `mcp-publisher validate` both pass today against a corrected `server.json`; `mcp-publisher publish` fails on exactly this marker check, confirmed by fetching the current live PyPI README and the last three README.md commits, none of which contain it.

No content change, no rendering change, just the marker line at the top of the file.
