### PR TITLE
fix(auto): make the Seed QA gate advisory instead of a dead end

### DIFF
--- a/docs/rfc/active-conductor.md
+++ b/docs/rfc/active-conductor.md
@@ -149,8 +149,15 @@ not depend on the truncated human-readable event detail.
 
 ### Seed-QA gate
 
-Emit `auto.seed_qa.blocked` whenever the Seed-QA repair budget closes without a
-passing verdict.
+Emit `auto.seed_qa.advisory_override` whenever the Seed-QA gate gives up without
+a passing verdict — repair budget closed, feedback that the repair mapper cannot
+map, or an evaluator timeout/error. The gate is advisory: it never blocks the
+session, because a session with no Seed-QA evaluator wired runs unconditionally
+and a wired evaluator must not leave the session worse off. The unresolved
+verdict is carried into run → evaluate, which judges execution evidence.
+
+`auto.seed_qa.blocked` is retained for history persisted before the gate became
+advisory; nothing emits it now.
 
 Required data:
 
@@ -163,8 +170,10 @@ Required data:
 - `suggestions`
 - `reason`
 
-Transient evaluator errors and timeouts remain ordinary Auto blockers and use a
-different trigger code from a genuine non-passing Seed-QA verdict.
+Transient evaluator errors and timeouts carry their own `reason`
+(`evaluator_timeout` / `evaluator_error` / `evaluator_transient_error`) so they
+stay distinguishable from a genuine non-passing Seed-QA verdict
+(`repair_budget_exhausted` / `seed_qa_feedback_unmapped`).
 
 ### Frugality and stagnation
 
@@ -266,7 +275,8 @@ menus.
 | `deliver_verdict_rejected_streak` | at least two rejected verdicts for one `(judgment_scope_id, semantic_ac_key)` | verify immediately; mutate only after ownership closes |
 | `frugality_grounding_regression` | proof status `fail_grounding_regression` | successor only |
 | `frugality_no_savings` | proof status `fail_no_frugality` | successor only |
-| `seed_qa_blocked` | `auto.seed_qa.blocked` | successor/resume only |
+| `seed_qa_blocked` | `auto.seed_qa.blocked` (historical; the gate no longer blocks) | successor/resume only |
+| `seed_qa_advisory` | `auto.seed_qa.advisory_override` | none — engine ownership still active |
 | `lineage_stagnated` | `lineage.stagnated` | successor generation only |
 
 If a rejected streak is observed while engine ownership is still active, the

--- a/docs/rfc/active-conductor.md
+++ b/docs/rfc/active-conductor.md
@@ -156,11 +156,14 @@ session, because a session with no Seed-QA evaluator wired runs unconditionally
 and a wired evaluator must not leave the session worse off. The unresolved
 verdict is carried into run → evaluate, which judges execution evidence.
 
+The event is written only on the continuation path: the grade gate and the
+pipeline deadline both run before it. It is not retracted afterwards — a
+retraction cannot be made reliable, since the correcting append can fail
+exactly when the original succeeded — so the deadline is enforced at the
+boundaries that follow instead (RUN phase entry, and skip-run completion).
+
 `auto.seed_qa.blocked` is retained for history persisted before the gate became
-advisory, and has exactly one live producer: when the pipeline deadline trips
-*after* the advisory event was already persisted, it is re-emitted with
-`reason="pipeline_deadline_after_advisory"` so the ownership-closed
-classification corrects the standing "engine still driving" claim.
+advisory; nothing emits it now.
 
 Required data:
 
@@ -278,7 +281,7 @@ menus.
 | `deliver_verdict_rejected_streak` | at least two rejected verdicts for one `(judgment_scope_id, semantic_ac_key)` | verify immediately; mutate only after ownership closes |
 | `frugality_grounding_regression` | proof status `fail_grounding_regression` | successor only |
 | `frugality_no_savings` | proof status `fail_no_frugality` | successor only |
-| `seed_qa_blocked` | `auto.seed_qa.blocked` (history, plus the post-advisory deadline correction) | successor/resume only |
+| `seed_qa_blocked` | `auto.seed_qa.blocked` (historical; the gate no longer blocks) | successor/resume only |
 | `seed_qa_advisory` | `auto.seed_qa.advisory_override` | none — engine ownership still active |
 | `lineage_stagnated` | `lineage.stagnated` | successor generation only |
 

--- a/docs/rfc/active-conductor.md
+++ b/docs/rfc/active-conductor.md
@@ -162,6 +162,13 @@ retraction cannot be made reliable, since the correcting append can fail
 exactly when the original succeeded — so the deadline is enforced at the
 boundaries that follow instead (RUN phase entry, and skip-run completion).
 
+The event therefore carries **no ownership claim**. The append itself takes
+time, so a session can stop at the very next gate; an event that asserted
+"engine still driving" would be falsified by what happens next, in any path
+rather than one special case. Attention classification treats it as progress
+(`progress_advanced` / `seed_qa_advisory`), and ownership is read from the
+events that actually close a session.
+
 `auto.seed_qa.blocked` is retained for history persisted before the gate became
 advisory; nothing emits it now.
 

--- a/docs/rfc/active-conductor.md
+++ b/docs/rfc/active-conductor.md
@@ -157,7 +157,10 @@ and a wired evaluator must not leave the session worse off. The unresolved
 verdict is carried into run → evaluate, which judges execution evidence.
 
 `auto.seed_qa.blocked` is retained for history persisted before the gate became
-advisory; nothing emits it now.
+advisory, and has exactly one live producer: when the pipeline deadline trips
+*after* the advisory event was already persisted, it is re-emitted with
+`reason="pipeline_deadline_after_advisory"` so the ownership-closed
+classification corrects the standing "engine still driving" claim.
 
 Required data:
 
@@ -275,7 +278,7 @@ menus.
 | `deliver_verdict_rejected_streak` | at least two rejected verdicts for one `(judgment_scope_id, semantic_ac_key)` | verify immediately; mutate only after ownership closes |
 | `frugality_grounding_regression` | proof status `fail_grounding_regression` | successor only |
 | `frugality_no_savings` | proof status `fail_no_frugality` | successor only |
-| `seed_qa_blocked` | `auto.seed_qa.blocked` (historical; the gate no longer blocks) | successor/resume only |
+| `seed_qa_blocked` | `auto.seed_qa.blocked` (history, plus the post-advisory deadline correction) | successor/resume only |
 | `seed_qa_advisory` | `auto.seed_qa.advisory_override` | none — engine ownership still active |
 | `lineage_stagnated` | `lineage.stagnated` | successor generation only |
 

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -57,9 +57,8 @@ from ouroboros.auto.reference_candidate_bridge import (
     apply_requirement_distillation_to_ledger,
 )
 from ouroboros.auto.seed_qa_advisory import (
-    SEED_QA_ADVISORY_EVENT,
     clear_seed_qa_verdict,
-    seed_qa_advisory_payload,
+    publish_advisory_or_block,
     seed_qa_advisory_progress,
 )
 from ouroboros.auto.seed_repairer import SeedRepairer
@@ -2945,11 +2944,7 @@ class AutoPipeline:
         attempts: int,
         score: float | None,
     ) -> tuple[AutoPipelineResult | None, Seed, SeedReview | None]:
-        """Downgrade an unresolved Seed QA verdict to advisory and keep going.
-
-        See :mod:`ouroboros.auto.seed_qa_advisory` for why this gate must never
-        dead-end the pipeline.
-        """
+        """Advisory continuation — see :mod:`ouroboros.auto.seed_qa_advisory`."""
 
         def stop(blocker: str | None) -> tuple[AutoPipelineResult | None, Seed, SeedReview | None]:
             return self._result(state, ledger, review=review, blocker=blocker), seed, review
@@ -2960,15 +2955,18 @@ class AutoPipeline:
             state.mark_blocked(review_blocker, tool_name="grade_gate")
             self._save(state)
             return stop(review_blocker)
-        if self._enforce_deadline(state):
-            return stop(state.last_error)
-        await self._emit_runtime_event(
-            SEED_QA_ADVISORY_EVENT,
-            state.auto_session_id,
-            seed_qa_advisory_payload(state, seed, reason=reason, attempts=attempts, score=score),
-        )
-        # The append is awaited and its wait is not charged against the deadline.
-        if self._enforce_deadline(state):
+        if await publish_advisory_or_block(
+            state=state,
+            seed=seed,
+            reason=reason,
+            attempts=attempts,
+            score=score,
+            emit=self._emit_runtime_event,
+            enforce_deadline=self._enforce_deadline,
+            save=self._save,
+            append_budget_seconds=_INTERVIEW_OBSERVER_DRAIN_TIMEOUT_SECONDS,
+            deadline_tool_name=PIPELINE_DEADLINE_TOOL_NAME,
+        ):
             return stop(state.last_error)
         state.mark_progress(seed_qa_advisory_progress(reason, detail), tool_name="seed_qa")
         self._save(state)

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -56,6 +56,11 @@ from ouroboros.auto.recovery_plan import (
 from ouroboros.auto.reference_candidate_bridge import (
     apply_requirement_distillation_to_ledger,
 )
+from ouroboros.auto.seed_qa_advisory import (
+    SEED_QA_ADVISORY_EVENT,
+    seed_qa_advisory_payload,
+    seed_qa_advisory_progress,
+)
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
 from ouroboros.auto.state import (
@@ -2804,6 +2809,22 @@ class AutoPipeline:
         current_seed = seed
         current_review = review
         max_attempts = max(1, int(state.max_repair_rounds or 1))
+
+        async def advisory(
+            reason: str, detail: str, *, score: float | None = None
+        ) -> tuple[AutoPipelineResult | None, Seed, SeedReview | None]:
+            # Reads the loop-carried Seed / review / attempt at call time.
+            return await self._seed_qa_advisory_continue(
+                state,
+                ledger,
+                current_seed,
+                current_review,
+                reason=reason,
+                detail=detail,
+                attempts=attempt,
+                score=score,
+            )
+
         for attempt in range(1, max_attempts + 1):
             timeout = self._deadline_capped_timeout(
                 state, state.phase_timeout_seconds(AutoPhase.EVALUATE)
@@ -2821,38 +2842,15 @@ class AutoPipeline:
                         current_seed,
                         current_review,
                     )
-                state.mark_blocked(
-                    f"Seed QA timed out after {timeout:.0f}s",
-                    tool_name="seed_qa",
-                )
-                self._save(state)
-                return (
-                    self._result(state, ledger, review=current_review, blocker=state.last_error),
-                    current_seed,
-                    current_review,
+                return await advisory(
+                    "evaluator_timeout", f"Seed QA timed out after {timeout:.0f}s"
                 )
             except Exception as exc:
-                state.mark_blocked(
-                    f"Seed QA raised {type(exc).__name__}",
-                    tool_name="seed_qa",
-                )
-                self._save(state)
-                return (
-                    self._result(state, ledger, review=current_review, blocker=state.last_error),
-                    current_seed,
-                    current_review,
-                )
+                return await advisory("evaluator_error", f"Seed QA raised {type(exc).__name__}")
 
             if qa_result.error:
-                state.mark_blocked(
-                    "Seed QA reported a transient evaluator error",
-                    tool_name="seed_qa",
-                )
-                self._save(state)
-                return (
-                    self._result(state, ledger, review=current_review, blocker=state.last_error),
-                    current_seed,
-                    current_review,
+                return await advisory(
+                    "evaluator_transient_error", "Seed QA reported a transient evaluator error"
                 )
 
             state.last_qa_score = float(qa_result.score)
@@ -2885,33 +2883,14 @@ class AutoPipeline:
                         )
                     )
                 except SeedQaRepairMappingError as exc:
-                    await self._emit_runtime_event(
-                        "auto.seed_qa.blocked",
-                        state.auto_session_id,
-                        {
-                            "schema_version": 1,
-                            "auto_session_id": state.auto_session_id,
-                            "seed_id": current_seed.metadata.seed_id,
-                            "attempts": attempt,
-                            "verdict": state.last_qa_verdict,
-                            "score": float(qa_result.score),
-                            "differences": state.last_qa_differences[:5],
-                            "suggestions": state.last_qa_suggestions[:5],
-                            "reason": "seed_qa_feedback_unmapped",
-                        },
-                    )
-                    state.mark_blocked(
-                        str(exc),
-                        tool_name="seed_qa",
-                        error_code="seed_qa_feedback_unmapped",
-                    )
-                    self._save(state)
-                    return (
-                        self._result(
-                            state, ledger, review=current_review, blocker=state.last_error
-                        ),
-                        current_seed,
-                        current_review,
+                    # The repair mapper only understands a bounded vocabulary of
+                    # QA findings. Unmapped feedback means "this pipeline cannot
+                    # mechanically repair the Seed", not "this Seed must never
+                    # run" — re-judging the *unchanged* Seed would only produce
+                    # the same unmapped feedback, so stop repairing and hand the
+                    # verdict to run → evaluate.
+                    return await advisory(
+                        "seed_qa_feedback_unmapped", str(exc), score=float(qa_result.score)
                     )
                 current_review = SeedReviewer(self.grade_gate).review(
                     current_seed,
@@ -2943,36 +2922,49 @@ class AutoPipeline:
                 self._save(state)
                 continue
 
-            details = [
+            return await advisory(
+                "repair_budget_exhausted",
                 f"Seed QA did not pass after {attempt} attempt(s): "
-                f"{state.last_qa_verdict} (score {qa_result.score:.2f})"
-            ]
-            details.extend(state.last_qa_differences)
-            details.extend(state.last_qa_suggestions)
-            await self._emit_runtime_event(
-                "auto.seed_qa.blocked",
-                state.auto_session_id,
-                {
-                    "schema_version": 1,
-                    "auto_session_id": state.auto_session_id,
-                    "seed_id": current_seed.metadata.seed_id,
-                    "attempts": attempt,
-                    "verdict": state.last_qa_verdict,
-                    "score": float(qa_result.score),
-                    "differences": state.last_qa_differences[:5],
-                    "suggestions": state.last_qa_suggestions[:5],
-                    "reason": "repair_budget_exhausted",
-                },
-            )
-            state.mark_blocked("; ".join(details), tool_name="seed_qa")
-            self._save(state)
-            return (
-                self._result(state, ledger, review=current_review, blocker=state.last_error),
-                current_seed,
-                current_review,
+                f"{state.last_qa_verdict} (score {qa_result.score:.2f})",
+                score=float(qa_result.score),
             )
 
         return None, current_seed, current_review
+
+    async def _seed_qa_advisory_continue(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        seed: Seed,
+        review: SeedReview | None,
+        *,
+        reason: str,
+        detail: str,
+        attempts: int,
+        score: float | None,
+    ) -> tuple[AutoPipelineResult | None, Seed, SeedReview | None]:
+        """Downgrade an unresolved Seed QA verdict to advisory and keep going.
+
+        See :mod:`ouroboros.auto.seed_qa_advisory` for why this gate must never
+        dead-end the pipeline.
+        """
+        await self._emit_runtime_event(
+            SEED_QA_ADVISORY_EVENT,
+            state.auto_session_id,
+            seed_qa_advisory_payload(state, seed, reason=reason, attempts=attempts, score=score),
+        )
+        review_blocker = self._seed_review_gate_blocker(state, review)
+        if review_blocker is not None:
+            state.mark_blocked(review_blocker, tool_name="grade_gate")
+            self._save(state)
+            return (
+                self._result(state, ledger, review=review, blocker=review_blocker),
+                seed,
+                review,
+            )
+        state.mark_progress(seed_qa_advisory_progress(reason, detail), tool_name="seed_qa")
+        self._save(state)
+        return None, seed, review
 
     async def _repair_seed_after_qa(
         self,

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -58,6 +58,7 @@ from ouroboros.auto.reference_candidate_bridge import (
 )
 from ouroboros.auto.seed_qa_advisory import (
     SEED_QA_ADVISORY_EVENT,
+    clear_seed_qa_verdict,
     seed_qa_advisory_payload,
     seed_qa_advisory_progress,
 )
@@ -2826,6 +2827,7 @@ class AutoPipeline:
             )
 
         for attempt in range(1, max_attempts + 1):
+            clear_seed_qa_verdict(state)  # a stale verdict must not outlive its attempt
             timeout = self._deadline_capped_timeout(
                 state, state.phase_timeout_seconds(AutoPhase.EVALUATE)
             )

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -2948,20 +2948,26 @@ class AutoPipeline:
         See :mod:`ouroboros.auto.seed_qa_advisory` for why this gate must never
         dead-end the pipeline.
         """
+
+        def stop(blocker: str | None) -> tuple[AutoPipelineResult | None, Seed, SeedReview | None]:
+            return self._result(state, ledger, review=review, blocker=blocker), seed, review
+
+        # Gates first, event second — see the module docstring for why.
+        review_blocker = self._seed_review_gate_blocker(state, review)
+        if review_blocker is not None:
+            state.mark_blocked(review_blocker, tool_name="grade_gate")
+            self._save(state)
+            return stop(review_blocker)
+        if self._enforce_deadline(state):
+            return stop(state.last_error)
         await self._emit_runtime_event(
             SEED_QA_ADVISORY_EVENT,
             state.auto_session_id,
             seed_qa_advisory_payload(state, seed, reason=reason, attempts=attempts, score=score),
         )
-        review_blocker = self._seed_review_gate_blocker(state, review)
-        if review_blocker is not None:
-            state.mark_blocked(review_blocker, tool_name="grade_gate")
-            self._save(state)
-            return (
-                self._result(state, ledger, review=review, blocker=review_blocker),
-                seed,
-                review,
-            )
+        # The append is awaited and its wait is not charged against the deadline.
+        if self._enforce_deadline(state):
+            return stop(state.last_error)
         state.mark_progress(seed_qa_advisory_progress(reason, detail), tool_name="seed_qa")
         self._save(state)
         return None, seed, review

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -58,7 +58,7 @@ from ouroboros.auto.reference_candidate_bridge import (
 )
 from ouroboros.auto.seed_qa_advisory import (
     clear_seed_qa_verdict,
-    publish_advisory_or_block,
+    publish_advisory,
     seed_qa_advisory_progress,
 )
 from ouroboros.auto.seed_repairer import SeedRepairer
@@ -1323,6 +1323,10 @@ class AutoPipeline:
                 return seed_qa
 
             if self.skip_run or state.skip_run:
+                # The only COMPLETE transition with no deadline check of its
+                # own; RUN enforces it at ``_run_execution_phase`` entry.
+                if self._enforce_deadline(state):
+                    return self._result(state, ledger, review=review, blocker=state.last_error)
                 state.transition(
                     AutoPhase.COMPLETE,
                     f"Seed grade {review.grade_result.grade.value} ready; skip-run requested",
@@ -2827,6 +2831,7 @@ class AutoPipeline:
 
         for attempt in range(1, max_attempts + 1):
             clear_seed_qa_verdict(state)  # a stale verdict must not outlive its attempt
+            self._save(state)  # ...including across an interruption mid-attempt
             timeout = self._deadline_capped_timeout(
                 state, state.phase_timeout_seconds(AutoPhase.EVALUATE)
             )
@@ -2955,19 +2960,16 @@ class AutoPipeline:
             state.mark_blocked(review_blocker, tool_name="grade_gate")
             self._save(state)
             return stop(review_blocker)
-        if await publish_advisory_or_block(
+        if self._enforce_deadline(state):
+            return stop(state.last_error)
+        await publish_advisory(
             state=state,
             seed=seed,
             reason=reason,
             attempts=attempts,
             score=score,
             emit=self._emit_runtime_event,
-            enforce_deadline=self._enforce_deadline,
-            save=self._save,
-            append_budget_seconds=_INTERVIEW_OBSERVER_DRAIN_TIMEOUT_SECONDS,
-            deadline_tool_name=PIPELINE_DEADLINE_TOOL_NAME,
-        ):
-            return stop(state.last_error)
+        )
         state.mark_progress(seed_qa_advisory_progress(reason, detail), tool_name="seed_qa")
         self._save(state)
         return None, seed, review

--- a/src/ouroboros/auto/seed_qa_advisory.py
+++ b/src/ouroboros/auto/seed_qa_advisory.py
@@ -33,7 +33,6 @@ performs no deadline check of its own.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-import time
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -41,33 +40,12 @@ if TYPE_CHECKING:
     from ouroboros.core.seed import Seed
 
 SEED_QA_ADVISORY_EVENT = "auto.seed_qa.advisory_override"
-# Correction event for the one case the pre-charge cannot prevent: the append
-# completed but the budget is gone anyway (a clock jump, an append that
-# overran its own bound). ``attention_relay`` already classifies this type as
-# ownership *closed* with a successor action, which is exactly the record the
-# session needs once it has stopped — so the durable stream self-corrects
-# rather than leaving an "active" claim standing.
-SEED_QA_CLOSURE_EVENT = "auto.seed_qa.blocked"
 
 # Bound on the evidence lists carried by the event payload.
 _MAX_EVIDENCE = 5
 
 
-def append_fits_in_deadline(state: AutoPipelineState, *, append_budget_seconds: float) -> bool:
-    """Return whether the advisory append can complete inside the remaining budget.
-
-    The event is durable evidence that the engine kept going, and the append is
-    itself awaited, so a deadline can only be re-checked *after* it. Charging
-    the append's own bound up front closes that window: when the remaining
-    budget cannot cover a worst-case append, the session blocks without
-    publishing a continuation it will not perform.
-    """
-    if state.deadline_at is None:
-        return True
-    return (state.deadline_at - time.monotonic()) > append_budget_seconds
-
-
-async def publish_advisory_or_block(
+async def publish_advisory(
     *,
     state: AutoPipelineState,
     seed: Seed,
@@ -75,44 +53,23 @@ async def publish_advisory_or_block(
     attempts: int,
     score: float | None,
     emit: Callable[[str, str, dict[str, Any]], Awaitable[None]],
-    enforce_deadline: Callable[[AutoPipelineState], bool],
-    save: Callable[[AutoPipelineState], None],
-    append_budget_seconds: float,
-    deadline_tool_name: str,
-) -> bool:
-    """Publish the advisory event. Return True when the session must stop instead.
+) -> None:
+    """Publish the advisory event on a path that has already decided to continue.
 
-    Ordering is the whole point. The event is durable evidence that the engine
-    kept driving, so it may only exist on a path that actually continues:
-
-    1. an expired budget — or one too small to cover a worst-case append —
-       blocks *without* publishing anything, since publishing "still going" and
-       then stopping inside that append would leave the conductor an
-       active-ownership claim for a Seed that never ran;
-    2. if the post-append check trips anyway (a clock jump, an append that
-       overran its bound), the stream self-corrects with
-       :data:`SEED_QA_CLOSURE_EVENT`, which is classified as ownership closed.
+    Every gate that can still stop the session runs *before* this — the grade
+    gate and the pipeline deadline — so the event is only ever written on the
+    continuation path. It is not re-checked afterwards: the append is awaited
+    and its latency is real, but a budget that expires during it is the next
+    phase's business (RUN enforces the deadline at entry, and skip-run
+    completion now does too), not a reason to publish a continuation claim and
+    then retract it. Retraction cannot be made reliable anyway — the correction
+    append can fail exactly when the original succeeded.
     """
-    payload = seed_qa_advisory_payload(state, seed, reason=reason, attempts=attempts, score=score)
-    if enforce_deadline(state) or not append_fits_in_deadline(
-        state, append_budget_seconds=append_budget_seconds
-    ):
-        if not state.is_terminal():
-            state.mark_blocked(
-                "pipeline_timeout: remaining budget cannot cover the advisory append",
-                tool_name=deadline_tool_name,
-            )
-            save(state)
-        return True
-    await emit(SEED_QA_ADVISORY_EVENT, state.auto_session_id, payload)
-    if enforce_deadline(state):
-        await emit(
-            SEED_QA_CLOSURE_EVENT,
-            state.auto_session_id,
-            {**payload, "reason": "pipeline_deadline_after_advisory"},
-        )
-        return True
-    return False
+    await emit(
+        SEED_QA_ADVISORY_EVENT,
+        state.auto_session_id,
+        seed_qa_advisory_payload(state, seed, reason=reason, attempts=attempts, score=score),
+    )
 
 
 def clear_seed_qa_verdict(state: AutoPipelineState) -> None:

--- a/src/ouroboros/auto/seed_qa_advisory.py
+++ b/src/ouroboros/auto/seed_qa_advisory.py
@@ -1,0 +1,67 @@
+"""Advisory (non-blocking) surface for the auto Seed-QA gate.
+
+The Seed-QA gate is *optional*: when no ``seed_qa_evaluator`` is wired the auto
+pipeline runs the Seed unconditionally. A wired evaluator must therefore never
+leave the session in a worse place than having no evaluator at all — it may
+repair, annotate and warn, but it may not dead-end a run that would otherwise
+have started. Blocking handed the session to a human holding exactly the same
+unmapped prose the repair mapper could not act on, which made ``blocked`` a dead
+end rather than a decision point.
+
+When the gate gives up (repair budget exhausted, feedback the repair mapper
+cannot map, evaluator timeout / error) it therefore emits
+:data:`SEED_QA_ADVISORY_EVENT` and lets the pipeline continue. The unresolved
+findings stay on ``state.last_qa_*`` — surfaced by the result envelope and by
+the event — so the real verdict is deferred to run → evaluate, which judges
+execution evidence instead of a static read of the Seed.
+
+The deterministic grade gate keeps its authority: a repaired Seed that no longer
+meets ``required_grade`` (or is no longer cleared to run) is still blocked by
+``grade_gate``, not by this advisory path.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ouroboros.auto.state import AutoPipelineState
+    from ouroboros.core.seed import Seed
+
+SEED_QA_ADVISORY_EVENT = "auto.seed_qa.advisory_override"
+
+# Bound on the evidence lists carried by the event payload.
+_MAX_EVIDENCE = 5
+
+
+def seed_qa_advisory_payload(
+    state: AutoPipelineState,
+    seed: Seed,
+    *,
+    reason: str,
+    attempts: int,
+    score: float | None,
+) -> dict[str, Any]:
+    """Build the :data:`SEED_QA_ADVISORY_EVENT` payload.
+
+    ``reason`` distinguishes a genuine non-passing verdict
+    (``repair_budget_exhausted`` / ``seed_qa_feedback_unmapped``) from an
+    evaluator-side failure (``evaluator_timeout`` / ``evaluator_error`` /
+    ``evaluator_transient_error``), which carries no verdict of its own.
+    """
+    return {
+        "schema_version": 1,
+        "auto_session_id": state.auto_session_id,
+        "seed_id": seed.metadata.seed_id,
+        "attempts": attempts,
+        "verdict": state.last_qa_verdict,
+        "score": score,
+        "differences": list(state.last_qa_differences[:_MAX_EVIDENCE]),
+        "suggestions": list(state.last_qa_suggestions[:_MAX_EVIDENCE]),
+        "reason": reason,
+    }
+
+
+def seed_qa_advisory_progress(reason: str, detail: str) -> str:
+    """Return the non-terminal progress message recorded for the override."""
+    return f"Seed QA advisory ({reason}): {detail}; continuing with the current Seed"

--- a/src/ouroboros/auto/seed_qa_advisory.py
+++ b/src/ouroboros/auto/seed_qa_advisory.py
@@ -17,7 +17,17 @@ execution evidence instead of a static read of the Seed.
 
 The deterministic grade gate keeps its authority: a repaired Seed that no longer
 meets ``required_grade`` (or is no longer cleared to run) is still blocked by
-``grade_gate``, not by this advisory path.
+``grade_gate``, not by this advisory path. So does the pipeline deadline.
+
+**Emission order.** The event is durable orchestration evidence that the engine
+kept driving — ``attention_relay`` classifies it as engine ownership ``active``
+with no successor action offered. Emitting it before the retained gates have
+spoken would make that evidence lie whenever a gate then stops the session, so
+every gate that can still block runs *first* and the event is emitted only on
+the true continuation path. The deadline is re-checked after the append as well:
+the append is awaited under the observer-drain timeout, which is not charged
+against ``deadline_at``, and the skip-run COMPLETE transition downstream
+performs no deadline check of its own.
 """
 
 from __future__ import annotations

--- a/src/ouroboros/auto/seed_qa_advisory.py
+++ b/src/ouroboros/auto/seed_qa_advisory.py
@@ -44,6 +44,23 @@ SEED_QA_ADVISORY_EVENT = "auto.seed_qa.advisory_override"
 _MAX_EVIDENCE = 5
 
 
+def clear_seed_qa_verdict(state: AutoPipelineState) -> None:
+    """Drop the previous attempt's verdict before a new Seed-QA attempt runs.
+
+    ``state.last_qa_*`` is durable and is read by surfaces that decide whether a
+    product was verified (a persisted ``last_qa_passed=True`` alone makes a
+    terminal report ``artifact_state="complete_verified"``). An evaluator that
+    times out or raises produces no verdict at all, so without this reset a
+    resumed session would keep publishing the *previous* attempt's pass — inside
+    an ``evaluator_error`` advisory event, and into its own completion state.
+    """
+    state.last_qa_score = None
+    state.last_qa_verdict = None
+    state.last_qa_passed = None
+    state.last_qa_differences = []
+    state.last_qa_suggestions = []
+
+
 def seed_qa_advisory_payload(
     state: AutoPipelineState,
     seed: Seed,

--- a/src/ouroboros/auto/seed_qa_advisory.py
+++ b/src/ouroboros/auto/seed_qa_advisory.py
@@ -32,6 +32,8 @@ performs no deadline check of its own.
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
+import time
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -39,9 +41,78 @@ if TYPE_CHECKING:
     from ouroboros.core.seed import Seed
 
 SEED_QA_ADVISORY_EVENT = "auto.seed_qa.advisory_override"
+# Correction event for the one case the pre-charge cannot prevent: the append
+# completed but the budget is gone anyway (a clock jump, an append that
+# overran its own bound). ``attention_relay`` already classifies this type as
+# ownership *closed* with a successor action, which is exactly the record the
+# session needs once it has stopped — so the durable stream self-corrects
+# rather than leaving an "active" claim standing.
+SEED_QA_CLOSURE_EVENT = "auto.seed_qa.blocked"
 
 # Bound on the evidence lists carried by the event payload.
 _MAX_EVIDENCE = 5
+
+
+def append_fits_in_deadline(state: AutoPipelineState, *, append_budget_seconds: float) -> bool:
+    """Return whether the advisory append can complete inside the remaining budget.
+
+    The event is durable evidence that the engine kept going, and the append is
+    itself awaited, so a deadline can only be re-checked *after* it. Charging
+    the append's own bound up front closes that window: when the remaining
+    budget cannot cover a worst-case append, the session blocks without
+    publishing a continuation it will not perform.
+    """
+    if state.deadline_at is None:
+        return True
+    return (state.deadline_at - time.monotonic()) > append_budget_seconds
+
+
+async def publish_advisory_or_block(
+    *,
+    state: AutoPipelineState,
+    seed: Seed,
+    reason: str,
+    attempts: int,
+    score: float | None,
+    emit: Callable[[str, str, dict[str, Any]], Awaitable[None]],
+    enforce_deadline: Callable[[AutoPipelineState], bool],
+    save: Callable[[AutoPipelineState], None],
+    append_budget_seconds: float,
+    deadline_tool_name: str,
+) -> bool:
+    """Publish the advisory event. Return True when the session must stop instead.
+
+    Ordering is the whole point. The event is durable evidence that the engine
+    kept driving, so it may only exist on a path that actually continues:
+
+    1. an expired budget — or one too small to cover a worst-case append —
+       blocks *without* publishing anything, since publishing "still going" and
+       then stopping inside that append would leave the conductor an
+       active-ownership claim for a Seed that never ran;
+    2. if the post-append check trips anyway (a clock jump, an append that
+       overran its bound), the stream self-corrects with
+       :data:`SEED_QA_CLOSURE_EVENT`, which is classified as ownership closed.
+    """
+    payload = seed_qa_advisory_payload(state, seed, reason=reason, attempts=attempts, score=score)
+    if enforce_deadline(state) or not append_fits_in_deadline(
+        state, append_budget_seconds=append_budget_seconds
+    ):
+        if not state.is_terminal():
+            state.mark_blocked(
+                "pipeline_timeout: remaining budget cannot cover the advisory append",
+                tool_name=deadline_tool_name,
+            )
+            save(state)
+        return True
+    await emit(SEED_QA_ADVISORY_EVENT, state.auto_session_id, payload)
+    if enforce_deadline(state):
+        await emit(
+            SEED_QA_CLOSURE_EVENT,
+            state.auto_session_id,
+            {**payload, "reason": "pipeline_deadline_after_advisory"},
+        )
+        return True
+    return False
 
 
 def clear_seed_qa_verdict(state: AutoPipelineState) -> None:

--- a/src/ouroboros/mcp/tools/attention_relay.py
+++ b/src/ouroboros/mcp/tools/attention_relay.py
@@ -14,7 +14,6 @@ ATTENTION_SOURCE_EVENT_TYPES = frozenset(
         "execution.ac.deliver_verdict",
         "execution.frugality_proof.evaluated",
         "auto.seed_qa.blocked",
-        "auto.seed_qa.advisory_override",
         "lineage.stagnated",
         "control.session.signal.rejected",
         "control.session.signal.delivery_uncertain",
@@ -38,6 +37,11 @@ PROACTIVE_SOURCE_EVENT_TYPES = frozenset(
         "control.session.signal.queued",
         "control.session.signal.applied",
         "control.session.signal.completed",
+        # Informational, deliberately NOT an attention/ownership signal: the
+        # engine may continue past an advisory Seed-QA verdict and still stop at
+        # the next gate. An event that claims ownership can be falsified by what
+        # happens next; a progress event cannot.
+        "auto.seed_qa.advisory_override",
     }
 )
 
@@ -444,6 +448,25 @@ def _proactive_relays(
                     },
                 )
             )
+        elif event.type == "auto.seed_qa.advisory_override":
+            # Reported, not adjudicated. The engine ran the Seed despite an
+            # unresolved verdict; whether it then keeps going is decided by the
+            # gates that follow, and their own events say so.
+            relays.append(
+                _progress(
+                    event,
+                    kind="progress_advanced",
+                    subtype="seed_qa_advisory",
+                    job_id=job_id,
+                    evidence={
+                        "reason": data.get("reason"),
+                        "verdict": _text(data.get("verdict"), limit=80),
+                        "score": data.get("score"),
+                        "differences": _strings(data.get("differences"), limit=5),
+                        "suggestions": _strings(data.get("suggestions"), limit=5),
+                    },
+                )
+            )
         elif event.type == "execution.ac.phase_changed":
             relays.append(
                 _progress(
@@ -824,20 +847,13 @@ def classify_relay_events(
                     available_tools=registered,
                 )
             )
-        elif event.type in {"auto.seed_qa.blocked", "auto.seed_qa.advisory_override"}:
-            # ``blocked`` is retained for history persisted before the Seed QA
-            # gate became advisory: the engine had stopped, so a successor
-            # action was on the menu. ``advisory_override`` means the engine is
-            # still driving the same session (it ran the Seed anyway), so it
-            # stays ``active`` — the conductor is being told, not handed the
-            # wheel.
-            advisory = event.type == "auto.seed_qa.advisory_override"
+        elif event.type == "auto.seed_qa.blocked":
             relays.append(
                 _attention(
                     event,
-                    trigger="seed_qa_advisory" if advisory else "seed_qa_blocked",
+                    trigger="seed_qa_blocked",
                     job_id=job_id,
-                    ownership_state="active" if advisory else "closed",
+                    ownership_state="closed",
                     evidence={
                         "attempts": data.get("attempts"),
                         "verdict": _text(data.get("verdict"), limit=80),

--- a/src/ouroboros/mcp/tools/attention_relay.py
+++ b/src/ouroboros/mcp/tools/attention_relay.py
@@ -14,6 +14,7 @@ ATTENTION_SOURCE_EVENT_TYPES = frozenset(
         "execution.ac.deliver_verdict",
         "execution.frugality_proof.evaluated",
         "auto.seed_qa.blocked",
+        "auto.seed_qa.advisory_override",
         "lineage.stagnated",
         "control.session.signal.rejected",
         "control.session.signal.delivery_uncertain",
@@ -823,13 +824,20 @@ def classify_relay_events(
                     available_tools=registered,
                 )
             )
-        elif event.type == "auto.seed_qa.blocked":
+        elif event.type in {"auto.seed_qa.blocked", "auto.seed_qa.advisory_override"}:
+            # ``blocked`` is retained for history persisted before the Seed QA
+            # gate became advisory: the engine had stopped, so a successor
+            # action was on the menu. ``advisory_override`` means the engine is
+            # still driving the same session (it ran the Seed anyway), so it
+            # stays ``active`` — the conductor is being told, not handed the
+            # wheel.
+            advisory = event.type == "auto.seed_qa.advisory_override"
             relays.append(
                 _attention(
                     event,
-                    trigger="seed_qa_blocked",
+                    trigger="seed_qa_advisory" if advisory else "seed_qa_blocked",
                     job_id=job_id,
-                    ownership_state="closed",
+                    ownership_state="active" if advisory else "closed",
                     evidence={
                         "attempts": data.get("attempts"),
                         "verdict": _text(data.get("verdict"), limit=80),

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1827,20 +1827,23 @@ async def test_advisory_event_is_not_emitted_when_the_grade_gate_then_blocks(tmp
 
 
 @pytest.mark.asyncio
-async def test_deadline_spent_during_the_advisory_append_self_corrects(tmp_path) -> None:
-    """A stop after the event was published must not leave an "active" claim.
+async def test_skip_run_completion_enforces_the_pipeline_deadline(tmp_path) -> None:
+    """Skip-run completion was the one COMPLETE transition with no deadline check.
 
-    The append is awaited, so the deadline can only be re-checked afterwards.
-    If it trips there, the already-persisted advisory event would otherwise keep
-    telling the conductor the engine is still driving a Seed that never ran, so
-    the stream self-corrects with the ownership-closed event type.
+    Making the Seed-QA gate advisory means sessions now *reach* that transition
+    where they previously stopped at the gate, so an expired budget could
+    complete successfully. The check belongs at that boundary — it protects
+    every path through it, not just the advisory one.
     """
 
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         return _seed()
 
     async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
-        return EvaluateResult(passed=False, score=0.58, verdict="revise")
+        # Expire the budget while the gate is running, as a slow evaluator would.
+        state.deadline_at = time.monotonic() - 1.0
+        state.deadline_at_epoch = time.time() - 1.0
+        return EvaluateResult(passed=True, score=0.91, verdict="pass")
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
     state.max_repair_rounds = 1
@@ -1857,44 +1860,33 @@ async def test_deadline_spent_during_the_advisory_append_self_corrects(tmp_path)
         seed_qa_evaluator=seed_qa,
     )
 
-    def _burn_the_budget() -> None:
-        state.deadline_at = time.monotonic() - 1.0
-        state.deadline_at_epoch = time.time() - 1.0
-
-    pipeline.on_emit = _burn_the_budget
-
     result = await pipeline.run(state)
 
     assert result.status == "blocked"
     assert state.last_tool_name == "pipeline_deadline"
-    assert "auto.seed_qa.advisory_override" in pipeline.emitted
-    # ...and the record is corrected to ownership-closed rather than left active.
-    assert "auto.seed_qa.blocked" in pipeline.emitted
-    closure = next(
-        p for p in pipeline.payloads if p["reason"] == "pipeline_deadline_after_advisory"
-    )
-    assert closure["auto_session_id"] == state.auto_session_id
 
 
 @pytest.mark.asyncio
-async def test_a_budget_too_small_for_the_append_blocks_without_publishing(tmp_path) -> None:
-    """Publishing "still going" and then stopping inside that append is the defect.
+async def test_an_unexpired_deadline_is_never_redefined_as_expired(tmp_path) -> None:
+    """A short-but-live budget must not be treated as spent.
 
-    The append has a bound of its own, so charging it up front removes the
-    window entirely: a budget that cannot cover a worst-case append blocks
-    before any durable continuation claim exists.
+    Reserving the append's worst-case latency up front turned an unexpired
+    deadline into a blocker — and did so even where no EventStore is wired and
+    the append is a no-op. Disabling Seed QA imposes no such block, so a wired
+    evaluator must not either.
     """
 
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         return _seed()
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
+        return {"job_id": "job_short_budget"}
 
     async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
         return EvaluateResult(passed=False, score=0.58, verdict="revise")
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
     state.max_repair_rounds = 1
-    state.skip_run = True
-    # Not expired, but too little left to cover the observer-drain bound (1.5s).
     state.deadline_at = time.monotonic() + 0.5
     state.deadline_at_epoch = time.time() + 0.5
     ledger = SeedDraftLedger.from_goal(state.goal)
@@ -1904,79 +1896,14 @@ async def test_a_budget_too_small_for_the_append_blocks_without_publishing(tmp_p
         AutoInterviewDriver(_seed_qa_interview_backend(), store=AutoStore(tmp_path), max_rounds=1),
         generate_seed,
         tmp_path,
+        run_starter=run_seed,
         seed_qa_evaluator=seed_qa,
     )
 
     result = await pipeline.run(state)
 
-    assert result.status == "blocked"
-    assert state.last_tool_name == "pipeline_deadline"
-    assert "auto.seed_qa.advisory_override" not in pipeline.emitted
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "failure",
-    ["timeout", "exception", "transient"],
-    ids=["evaluator_timeout", "evaluator_error", "evaluator_transient_error"],
-)
-async def test_a_failed_evaluator_never_republishes_the_previous_verdict(
-    tmp_path, failure: str
-) -> None:
-    """An evaluator that produces no verdict must not inherit the last one.
-
-    ``state.last_qa_*`` is durable, so a resumed session carrying a prior pass
-    would otherwise publish ``verdict="pass"`` inside an evaluator-failure
-    advisory event — and a persisted ``last_qa_passed=True`` alone makes a
-    skip-run terminal report ``artifact_state="complete_verified"``.
-    """
-
-    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
-        return _seed()
-
-    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
-        if failure == "timeout":
-            await asyncio.sleep(30)
-            raise AssertionError("unreachable")
-        if failure == "exception":
-            raise RuntimeError("evaluator crashed")
-        return EvaluateResult(passed=False, score=0.0, verdict="", error="transient")
-
-    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
-    state.max_repair_rounds = 1
-    state.skip_run = True
-    state.timeout_seconds_by_phase[AutoPhase.EVALUATE.value] = 1
-    # A previous attempt's passing verdict, persisted across the resume.
-    state.last_qa_passed = True
-    state.last_qa_verdict = "pass"
-    state.last_qa_score = 0.93
-    state.last_qa_differences = ["stale difference"]
-    state.last_qa_suggestions = ["stale suggestion"]
-    ledger = SeedDraftLedger.from_goal(state.goal)
-    _fill_ready(ledger)
-    state.ledger = ledger.to_dict()
-    pipeline = _advisory_pipeline(
-        AutoInterviewDriver(_seed_qa_interview_backend(), store=AutoStore(tmp_path), max_rounds=1),
-        generate_seed,
-        tmp_path,
-        seed_qa_evaluator=seed_qa,
-    )
-
-    result = await pipeline.run(state)
-
+    assert result.status != "blocked"
     assert "auto.seed_qa.advisory_override" in pipeline.emitted
-    assert state.last_qa_passed is None
-    assert state.last_qa_verdict is None
-    assert state.last_qa_score is None
-    assert state.last_qa_differences == []
-    assert state.last_qa_suggestions == []
-    # The published event describes this attempt, which produced no verdict.
-    advisory = next(p for p in pipeline.payloads if p["reason"].startswith("evaluator_"))
-    assert advisory["verdict"] is None
-    assert advisory["score"] is None
-    assert advisory["differences"] == []
-    assert advisory["suggestions"] == []
-    assert result.status == "complete"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1696,7 +1696,15 @@ async def test_auto_interview_requires_backend_ambiguity_below_threshold(tmp_pat
 
 
 @pytest.mark.asyncio
-async def test_pipeline_blocks_run_when_seed_qa_does_not_pass(tmp_path) -> None:
+async def test_pipeline_runs_advisory_when_seed_qa_does_not_pass(tmp_path) -> None:
+    """A non-passing Seed QA verdict is advisory, not a dead end.
+
+    The gate is optional (no evaluator wired ⇒ the Seed runs unconditionally),
+    so a wired evaluator must never leave the session worse off than having no
+    evaluator: it repairs what it can, records the unresolved verdict, and lets
+    run → evaluate judge the Seed against execution evidence.
+    """
+
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         return InterviewTurn(
             "done",
@@ -1719,7 +1727,7 @@ async def test_pipeline_blocks_run_when_seed_qa_does_not_pass(tmp_path) -> None:
         return _seed()
 
     async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
-        raise AssertionError("run must not start before Seed QA passes")
+        return {"job_id": "job_seed_qa_advisory"}
 
     async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
         return EvaluateResult(
@@ -1749,12 +1757,15 @@ async def test_pipeline_blocks_run_when_seed_qa_does_not_pass(tmp_path) -> None:
 
     result = await pipeline.run(state)
 
-    assert result.status == "blocked"
-    assert result.blocker is not None
-    assert "manual Seed revision is required" in result.blocker
-    assert state.last_tool_name == "seed_qa"
-    assert state.last_error_code == "seed_qa_feedback_unmapped"
+    assert result.status != "blocked"
+    assert result.blocker is None
+    assert result.job_id == "job_seed_qa_advisory"
+    assert state.last_error_code != "seed_qa_feedback_unmapped"
+    # The unresolved verdict survives on the state surface so the advisory run
+    # is auditable rather than silent.
+    assert state.last_qa_passed is False
     assert state.last_qa_score == 0.58
+    assert state.last_qa_verdict == "revise"
 
 
 @pytest.mark.asyncio
@@ -1883,9 +1894,97 @@ async def test_pipeline_repairs_seed_qa_feedback_before_run(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_pipeline_blocks_unrepairable_structural_seed_qa_feedback_without_retrying(
+async def test_pipeline_runs_repaired_seed_after_seed_qa_repair_budget_exhausted(
     tmp_path,
 ) -> None:
+    """An exhausted repair budget runs the best Seed the loop produced.
+
+    The repairs still happen (the whole budget is spent), but a still-failing
+    verdict at the end hands the decision to run → evaluate instead of parking
+    the session in ``blocked``.
+    """
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done",
+            "interview_seed_qa_exhausted",
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.12,
+        )
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done",
+            session_id,
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.12,
+        )
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    qa_calls = 0
+    captured_run_seed: Seed | None = None
+
+    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
+        nonlocal qa_calls
+        qa_calls += 1
+        return EvaluateResult(
+            passed=False,
+            score=0.55,
+            verdict="revise",
+            differences=("missing explicit no-op scope",),
+            suggestions=("add no-op scope constraint",),
+        )
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
+        nonlocal captured_run_seed
+        captured_run_seed = seed
+        return {"job_id": "job_seed_qa_exhausted"}
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.max_repair_rounds = 2
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        seed_qa_evaluator=seed_qa,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status != "blocked"
+    assert result.job_id == "job_seed_qa_exhausted"
+    assert qa_calls == 2
+    assert state.last_qa_passed is False
+    assert captured_run_seed is not None
+    # The repair produced by the spent budget is what actually runs.
+    assert any("Define explicit no-op scope" in item for item in captured_run_seed.constraints)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_runs_advisory_on_unrepairable_seed_qa_feedback_without_retrying(
+    tmp_path,
+) -> None:
+    """Unmapped QA feedback stops the *repair loop*, not the pipeline.
+
+    Re-judging an unchanged Seed would only reproduce the same unmapped prose,
+    so the gate gives up on repairing (one QA call, no lateral) and runs the
+    Seed as authored. The injected prompt in the QA suggestions must still be
+    withheld from the persisted state and the Seed.
+    """
+
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         return InterviewTurn(
             "done",
@@ -1941,7 +2040,7 @@ async def test_pipeline_blocks_unrepairable_structural_seed_qa_feedback_without_
     async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
         nonlocal run_called
         run_called = True
-        return {"job_id": "job_must_not_run"}
+        return {"job_id": "job_seed_qa_unmapped_advisory"}
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
     state.max_repair_rounds = 3
@@ -1964,12 +2063,12 @@ async def test_pipeline_blocks_unrepairable_structural_seed_qa_feedback_without_
 
     result = await pipeline.run(state)
 
-    assert result.status == "blocked"
-    assert state.last_error_code == "seed_qa_feedback_unmapped"
-    assert "could not be mapped" in (result.blocker or "")
+    assert result.status != "blocked"
+    assert result.blocker is None
+    assert result.job_id == "job_seed_qa_unmapped_advisory"
     assert qa_calls == 1
     assert lateral_calls == 0
-    assert run_called is False
+    assert run_called is True
     assert "attacker@example.test" not in str(state.to_dict())
     persisted_seed = Seed.from_dict(state.seed_artifact)
     assert persisted_seed.exit_conditions == _seed().exit_conditions

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1907,6 +1907,74 @@ async def test_an_unexpired_deadline_is_never_redefined_as_expired(tmp_path) -> 
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure",
+    ["timeout", "exception", "transient"],
+    ids=["evaluator_timeout", "evaluator_error", "evaluator_transient_error"],
+)
+async def test_a_failed_evaluator_never_republishes_the_previous_verdict(
+    tmp_path, failure: str
+) -> None:
+    """An evaluator that produces no verdict must not inherit the last one.
+
+    ``state.last_qa_*`` is durable, so a resumed session carrying a prior pass
+    would otherwise publish ``verdict="pass"`` inside an evaluator-failure
+    advisory event — and a persisted ``last_qa_passed=True`` alone makes a
+    skip-run terminal report ``artifact_state="complete_verified"``.
+    """
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
+        if failure == "timeout":
+            await asyncio.sleep(30)
+            raise AssertionError("unreachable")
+        if failure == "exception":
+            raise RuntimeError("evaluator crashed")
+        return EvaluateResult(passed=False, score=0.0, verdict="", error="transient")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.max_repair_rounds = 1
+    state.skip_run = True
+    state.timeout_seconds_by_phase[AutoPhase.EVALUATE.value] = 1
+    # A previous attempt's passing verdict, persisted across the resume.
+    state.last_qa_passed = True
+    state.last_qa_verdict = "pass"
+    state.last_qa_score = 0.93
+    state.last_qa_differences = ["stale difference"]
+    state.last_qa_suggestions = ["stale suggestion"]
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    pipeline = _advisory_pipeline(
+        AutoInterviewDriver(_seed_qa_interview_backend(), store=AutoStore(tmp_path), max_rounds=1),
+        generate_seed,
+        tmp_path,
+        seed_qa_evaluator=seed_qa,
+    )
+
+    result = await pipeline.run(state)
+
+    assert "auto.seed_qa.advisory_override" in pipeline.emitted
+    # The clear is persisted before the evaluator runs, so an interruption
+    # mid-attempt cannot leave the previous verdict on disk.
+    assert AutoStore(tmp_path).load(state.auto_session_id).last_qa_passed is None
+    assert state.last_qa_passed is None
+    assert state.last_qa_verdict is None
+    assert state.last_qa_score is None
+    assert state.last_qa_differences == []
+    assert state.last_qa_suggestions == []
+    # The published event describes this attempt, which produced no verdict.
+    advisory = next(p for p in pipeline.payloads if p["reason"].startswith("evaluator_"))
+    assert advisory["verdict"] is None
+    assert advisory["score"] is None
+    assert advisory["differences"] == []
+    assert advisory["suggestions"] == []
+    assert result.status == "complete"
+
+
+@pytest.mark.asyncio
 async def test_pipeline_runs_advisory_when_seed_qa_does_not_pass(tmp_path) -> None:
     """A non-passing Seed QA verdict is advisory, not a dead end.
 

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 
 import pytest
 
@@ -1693,6 +1694,176 @@ async def test_auto_interview_requires_backend_ambiguity_below_threshold(tmp_pat
     assert result.status == "blocked"
     assert "ambiguity_score=0.42" in (result.blocker or "")
     assert state.interview_completed is False
+
+
+class _RecordingEventPipeline(AutoPipeline):
+    """Captures durable runtime events and lets a test stall the append."""
+
+    emitted: list[str]
+    on_emit = None
+
+    async def _emit_runtime_event(self, event_type, aggregate_id, payload):  # noqa: ANN001
+        self.emitted.append(event_type)
+        if self.on_emit is not None:
+            self.on_emit()
+        return await super()._emit_runtime_event(event_type, aggregate_id, payload)
+
+
+def _advisory_pipeline(driver, generate_seed, tmp_path, **kwargs) -> _RecordingEventPipeline:
+    pipeline = _RecordingEventPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        **kwargs,
+    )
+    pipeline.emitted = []
+    return pipeline
+
+
+def _seed_qa_interview_backend() -> FunctionInterviewBackend:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done", "interview_seed_qa_gate", seed_ready=True, completed=True, ambiguity_score=0.12
+        )
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done", session_id, seed_ready=True, completed=True, ambiguity_score=0.12
+        )
+
+    return FunctionInterviewBackend(start, answer)
+
+
+@pytest.mark.asyncio
+async def test_advisory_event_is_not_emitted_when_the_grade_gate_then_blocks(tmp_path) -> None:
+    """Durable evidence must not claim the engine continued when it stopped.
+
+    ``attention_relay`` reads ``auto.seed_qa.advisory_override`` as engine
+    ownership ``active`` with no successor action. If the repaired Seed then
+    fails the retained grade gate, emitting that event would make the durable
+    orchestration record contradict what actually happened.
+    """
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
+        raise AssertionError("a grade-blocked Seed must not run")
+
+    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
+        # Never passes: the repair lands, the budget closes, and the advisory
+        # path is reached with a repaired Seed the grade gate rejects.
+        return EvaluateResult(
+            passed=False,
+            score=0.58,
+            verdict="revise",
+            suggestions=("introduce review-blocking post-QA constraint",),
+        )
+
+    class ConstraintBlockingGate(GradeGate):
+        def grade_seed(
+            self,
+            seed: Seed,
+            *,
+            ledger: SeedDraftLedger | None = None,  # noqa: ARG002
+            closure_mode: str | None = None,  # noqa: ARG002
+            degraded: bool | None = None,  # noqa: ARG002
+        ) -> GradeResult:
+            if any("review-blocking" in constraint for constraint in seed.constraints):
+                return GradeResult(
+                    grade=SeedGrade.C,
+                    scores={
+                        "coverage": 0.5,
+                        "ambiguity": 0.5,
+                        "testability": 0.5,
+                        "execution_feasibility": 0.4,
+                        "risk": 0.4,
+                    },
+                    blockers=[
+                        GradeFinding(
+                            "post_qa_review_blocker",
+                            "high",
+                            "QA repair introduced a deterministic blocker",
+                            "constraints",
+                            "Remove the post-QA blocker before execution.",
+                        )
+                    ],
+                    may_run=False,
+                )
+            return GradeResult(
+                grade=SeedGrade.A,
+                scores={
+                    "coverage": 0.95,
+                    "ambiguity": 0.05,
+                    "testability": 0.95,
+                    "execution_feasibility": 0.95,
+                    "risk": 0.05,
+                },
+                may_run=True,
+            )
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.max_repair_rounds = 2
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    pipeline = _advisory_pipeline(
+        AutoInterviewDriver(_seed_qa_interview_backend(), store=AutoStore(tmp_path), max_rounds=1),
+        generate_seed,
+        tmp_path,
+        run_starter=run_seed,
+        grade_gate=ConstraintBlockingGate(),
+        seed_qa_evaluator=seed_qa,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.last_tool_name == "grade_gate"
+    assert "auto.seed_qa.advisory_override" not in pipeline.emitted
+
+
+@pytest.mark.asyncio
+async def test_deadline_spent_during_the_advisory_append_still_blocks_skip_run(tmp_path) -> None:
+    """The advisory path must not turn an expired deadline into a completion.
+
+    The event append is awaited under the observer-drain timeout, which is not
+    charged against ``deadline_at``, and the skip-run COMPLETE transition
+    performs no deadline check of its own.
+    """
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
+        return EvaluateResult(passed=False, score=0.58, verdict="revise")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.max_repair_rounds = 1
+    state.skip_run = True
+    state.deadline_at = time.monotonic() + 600.0
+    state.deadline_at_epoch = time.time() + 600.0
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    pipeline = _advisory_pipeline(
+        AutoInterviewDriver(_seed_qa_interview_backend(), store=AutoStore(tmp_path), max_rounds=1),
+        generate_seed,
+        tmp_path,
+        seed_qa_evaluator=seed_qa,
+    )
+
+    def _burn_the_budget() -> None:
+        state.deadline_at = time.monotonic() - 1.0
+        state.deadline_at_epoch = time.time() - 1.0
+
+    pipeline.on_emit = _burn_the_budget
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.last_tool_name == "pipeline_deadline"
+    assert "auto.seed_qa.advisory_override" in pipeline.emitted
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1700,10 +1700,12 @@ class _RecordingEventPipeline(AutoPipeline):
     """Captures durable runtime events and lets a test stall the append."""
 
     emitted: list[str]
+    payloads: list[dict]
     on_emit = None
 
     async def _emit_runtime_event(self, event_type, aggregate_id, payload):  # noqa: ANN001
         self.emitted.append(event_type)
+        self.payloads.append(dict(payload))
         if self.on_emit is not None:
             self.on_emit()
         return await super()._emit_runtime_event(event_type, aggregate_id, payload)
@@ -1717,6 +1719,7 @@ def _advisory_pipeline(driver, generate_seed, tmp_path, **kwargs) -> _RecordingE
         **kwargs,
     )
     pipeline.emitted = []
+    pipeline.payloads = []
     return pipeline
 
 
@@ -1864,6 +1867,71 @@ async def test_deadline_spent_during_the_advisory_append_still_blocks_skip_run(t
     assert result.status == "blocked"
     assert state.last_tool_name == "pipeline_deadline"
     assert "auto.seed_qa.advisory_override" in pipeline.emitted
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure",
+    ["timeout", "exception", "transient"],
+    ids=["evaluator_timeout", "evaluator_error", "evaluator_transient_error"],
+)
+async def test_a_failed_evaluator_never_republishes_the_previous_verdict(
+    tmp_path, failure: str
+) -> None:
+    """An evaluator that produces no verdict must not inherit the last one.
+
+    ``state.last_qa_*`` is durable, so a resumed session carrying a prior pass
+    would otherwise publish ``verdict="pass"`` inside an evaluator-failure
+    advisory event — and a persisted ``last_qa_passed=True`` alone makes a
+    skip-run terminal report ``artifact_state="complete_verified"``.
+    """
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
+        if failure == "timeout":
+            await asyncio.sleep(30)
+            raise AssertionError("unreachable")
+        if failure == "exception":
+            raise RuntimeError("evaluator crashed")
+        return EvaluateResult(passed=False, score=0.0, verdict="", error="transient")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.max_repair_rounds = 1
+    state.skip_run = True
+    state.timeout_seconds_by_phase[AutoPhase.EVALUATE.value] = 1
+    # A previous attempt's passing verdict, persisted across the resume.
+    state.last_qa_passed = True
+    state.last_qa_verdict = "pass"
+    state.last_qa_score = 0.93
+    state.last_qa_differences = ["stale difference"]
+    state.last_qa_suggestions = ["stale suggestion"]
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    pipeline = _advisory_pipeline(
+        AutoInterviewDriver(_seed_qa_interview_backend(), store=AutoStore(tmp_path), max_rounds=1),
+        generate_seed,
+        tmp_path,
+        seed_qa_evaluator=seed_qa,
+    )
+
+    result = await pipeline.run(state)
+
+    assert "auto.seed_qa.advisory_override" in pipeline.emitted
+    assert state.last_qa_passed is None
+    assert state.last_qa_verdict is None
+    assert state.last_qa_score is None
+    assert state.last_qa_differences == []
+    assert state.last_qa_suggestions == []
+    # The published event describes this attempt, which produced no verdict.
+    advisory = next(p for p in pipeline.payloads if p["reason"].startswith("evaluator_"))
+    assert advisory["verdict"] is None
+    assert advisory["score"] is None
+    assert advisory["differences"] == []
+    assert advisory["suggestions"] == []
+    assert result.status == "complete"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 import time
 
 import pytest
@@ -32,6 +33,7 @@ from ouroboros.core.seed import (
     ac_text,
     derive_semantic_ac_key,
 )
+from ouroboros.events.base import BaseEvent
 
 # The unsafe-context matcher / safe-default blocking machinery exercised here
 # is disabled by default under the freedom policy (empty production bank);
@@ -1864,6 +1866,72 @@ async def test_skip_run_completion_enforces_the_pipeline_deadline(tmp_path) -> N
 
     assert result.status == "blocked"
     assert state.last_tool_name == "pipeline_deadline"
+
+
+@pytest.mark.asyncio
+async def test_a_block_after_the_advisory_leaves_no_ownership_claim(tmp_path) -> None:
+    """The append can outlive the budget; the relay must not read that as "active".
+
+    The deadline is checked before the awaited append, but the append itself
+    takes time, so RUN entry can block immediately afterwards. Rather than
+    trying to retract a durable event — which cannot be made reliable, since the
+    correcting append fails exactly when the original succeeded — the advisory
+    event carries no ownership claim at all.
+    """
+    from ouroboros.mcp.tools.attention_relay import classify_relay_events
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
+        raise AssertionError("RUN must not start once the deadline has expired")
+
+    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
+        return EvaluateResult(passed=False, score=0.58, verdict="revise")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.max_repair_rounds = 1
+    state.deadline_at = time.monotonic() + 600.0
+    state.deadline_at_epoch = time.time() + 600.0
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    pipeline = _advisory_pipeline(
+        AutoInterviewDriver(_seed_qa_interview_backend(), store=AutoStore(tmp_path), max_rounds=1),
+        generate_seed,
+        tmp_path,
+        run_starter=run_seed,
+        seed_qa_evaluator=seed_qa,
+    )
+
+    def _burn_the_budget() -> None:
+        state.deadline_at = time.monotonic() - 1.0
+        state.deadline_at_epoch = time.time() - 1.0
+
+    pipeline.on_emit = _burn_the_budget
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.last_tool_name == "pipeline_deadline"
+    assert "auto.seed_qa.advisory_override" in pipeline.emitted
+    # The persisted advisory event is reported as progress, never as ownership.
+    relays = classify_relay_events(
+        [
+            BaseEvent(
+                id="event_advisory",
+                type="auto.seed_qa.advisory_override",
+                aggregate_type="auto",
+                aggregate_id=state.auto_session_id,
+                timestamp=datetime(2026, 8, 14, tzinfo=UTC),
+                data=pipeline.payloads[-1],
+            )
+        ],
+        job_id="job_1",
+    )
+    assert relays
+    assert all(relay["kind"] != "attention_required" for relay in relays)
+    assert all("engine_ownership" not in relay for relay in relays)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1827,12 +1827,13 @@ async def test_advisory_event_is_not_emitted_when_the_grade_gate_then_blocks(tmp
 
 
 @pytest.mark.asyncio
-async def test_deadline_spent_during_the_advisory_append_still_blocks_skip_run(tmp_path) -> None:
-    """The advisory path must not turn an expired deadline into a completion.
+async def test_deadline_spent_during_the_advisory_append_self_corrects(tmp_path) -> None:
+    """A stop after the event was published must not leave an "active" claim.
 
-    The event append is awaited under the observer-drain timeout, which is not
-    charged against ``deadline_at``, and the skip-run COMPLETE transition
-    performs no deadline check of its own.
+    The append is awaited, so the deadline can only be re-checked afterwards.
+    If it trips there, the already-persisted advisory event would otherwise keep
+    telling the conductor the engine is still driving a Seed that never ran, so
+    the stream self-corrects with the ownership-closed event type.
     """
 
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
@@ -1867,6 +1868,50 @@ async def test_deadline_spent_during_the_advisory_append_still_blocks_skip_run(t
     assert result.status == "blocked"
     assert state.last_tool_name == "pipeline_deadline"
     assert "auto.seed_qa.advisory_override" in pipeline.emitted
+    # ...and the record is corrected to ownership-closed rather than left active.
+    assert "auto.seed_qa.blocked" in pipeline.emitted
+    closure = next(
+        p for p in pipeline.payloads if p["reason"] == "pipeline_deadline_after_advisory"
+    )
+    assert closure["auto_session_id"] == state.auto_session_id
+
+
+@pytest.mark.asyncio
+async def test_a_budget_too_small_for_the_append_blocks_without_publishing(tmp_path) -> None:
+    """Publishing "still going" and then stopping inside that append is the defect.
+
+    The append has a bound of its own, so charging it up front removes the
+    window entirely: a budget that cannot cover a worst-case append blocks
+    before any durable continuation claim exists.
+    """
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
+        return EvaluateResult(passed=False, score=0.58, verdict="revise")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.max_repair_rounds = 1
+    state.skip_run = True
+    # Not expired, but too little left to cover the observer-drain bound (1.5s).
+    state.deadline_at = time.monotonic() + 0.5
+    state.deadline_at_epoch = time.time() + 0.5
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    pipeline = _advisory_pipeline(
+        AutoInterviewDriver(_seed_qa_interview_backend(), store=AutoStore(tmp_path), max_rounds=1),
+        generate_seed,
+        tmp_path,
+        seed_qa_evaluator=seed_qa,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.last_tool_name == "pipeline_deadline"
+    assert "auto.seed_qa.advisory_override" not in pipeline.emitted
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/tools/test_attention_relay.py
+++ b/tests/unit/mcp/tools/test_attention_relay.py
@@ -239,6 +239,7 @@ def test_frugality_attention_respects_persisted_assurance() -> None:
     ("event_type", "expected_trigger"),
     [
         ("auto.seed_qa.blocked", "seed_qa_blocked"),
+        ("auto.seed_qa.advisory_override", "seed_qa_advisory"),
         ("lineage.stagnated", "lineage_stagnated"),
         ("control.session.signal.delivery_uncertain", "session_signal_delivery_uncertain"),
     ],
@@ -249,6 +250,23 @@ def test_direct_attention_triggers(event_type: str, expected_trigger: str) -> No
     relays = classify_relay_events([event], job_id="job_1")
 
     assert any(relay.get("trigger") == expected_trigger for relay in relays)
+
+
+def test_seed_qa_advisory_keeps_engine_ownership_active() -> None:
+    """The advisory override means the engine kept driving the same session.
+
+    ``blocked`` handed the wheel to the conductor (ownership closed, successor
+    action offered); ``advisory_override`` only informs, so ownership stays
+    active and no successor action is proposed.
+    """
+    blocked = _event(1, "auto.seed_qa.blocked", {"reason": "repair_budget_exhausted"})
+    advisory = _event(2, "auto.seed_qa.advisory_override", {"reason": "repair_budget_exhausted"})
+
+    relays = classify_relay_events([blocked, advisory], job_id="job_1")
+    by_trigger = {cast(str, relay.get("trigger")): relay for relay in relays}
+
+    assert cast(dict, by_trigger["seed_qa_blocked"]["engine_ownership"])["state"] == "closed"
+    assert cast(dict, by_trigger["seed_qa_advisory"]["engine_ownership"])["state"] == "active"
 
 
 def test_proactive_relay_has_no_action_menu_and_deduplicates_unchanged_route() -> None:

--- a/tests/unit/mcp/tools/test_attention_relay.py
+++ b/tests/unit/mcp/tools/test_attention_relay.py
@@ -239,7 +239,6 @@ def test_frugality_attention_respects_persisted_assurance() -> None:
     ("event_type", "expected_trigger"),
     [
         ("auto.seed_qa.blocked", "seed_qa_blocked"),
-        ("auto.seed_qa.advisory_override", "seed_qa_advisory"),
         ("lineage.stagnated", "lineage_stagnated"),
         ("control.session.signal.delivery_uncertain", "session_signal_delivery_uncertain"),
     ],
@@ -252,21 +251,25 @@ def test_direct_attention_triggers(event_type: str, expected_trigger: str) -> No
     assert any(relay.get("trigger") == expected_trigger for relay in relays)
 
 
-def test_seed_qa_advisory_keeps_engine_ownership_active() -> None:
-    """The advisory override means the engine kept driving the same session.
+def test_seed_qa_advisory_reports_without_claiming_ownership() -> None:
+    """An advisory verdict is information, not an ownership claim.
 
-    ``blocked`` handed the wheel to the conductor (ownership closed, successor
-    action offered); ``advisory_override`` only informs, so ownership stays
-    active and no successor action is proposed.
+    The engine ran the Seed despite an unresolved verdict, but whether it keeps
+    going is decided by the gates that follow — so this must never be durable
+    evidence that ownership is `active`, which a later block would falsify.
     """
     blocked = _event(1, "auto.seed_qa.blocked", {"reason": "repair_budget_exhausted"})
     advisory = _event(2, "auto.seed_qa.advisory_override", {"reason": "repair_budget_exhausted"})
 
     relays = classify_relay_events([blocked, advisory], job_id="job_1")
-    by_trigger = {cast(str, relay.get("trigger")): relay for relay in relays}
+    by_key = {cast(str, r.get("trigger") or r.get("subtype")): r for r in relays}
 
-    assert cast(dict, by_trigger["seed_qa_blocked"]["engine_ownership"])["state"] == "closed"
-    assert cast(dict, by_trigger["seed_qa_advisory"]["engine_ownership"])["state"] == "active"
+    assert cast(dict, by_key["seed_qa_blocked"]["engine_ownership"])["state"] == "closed"
+    reported = by_key["seed_qa_advisory"]
+    assert reported["kind"] == "progress_advanced"
+    assert "engine_ownership" not in reported
+    assert "recommended_host_actions" not in reported
+    assert reported["evidence"]["reason"] == "repair_budget_exhausted"
 
 
 def test_proactive_relay_has_no_action_menu_and_deduplicates_unchanged_route() -> None:


### PR DESCRIPTION
## Summary

The pre-run Seed QA gate ended every non-passing path in `mark_blocked`. This makes it advisory: it repairs what it can, records the unresolved verdict, and lets `run → evaluate` decide against execution evidence.

The gate is optional — with no `seed_qa_evaluator` wired the pipeline runs the Seed unconditionally — so turning QA on could leave a session strictly worse off than leaving it off. Blocking was also not a decision point: the operator received exactly the same unmapped prose the repair mapper could not act on.

What changed per path:

| path | before | after |
|---|---|---|
| `repair_budget_exhausted` | blocked | runs the best repaired Seed |
| `seed_qa_feedback_unmapped` | blocked on attempt 1 | stops the repair loop, runs the Seed as authored (no pointless re-judge of an unchanged Seed) |
| evaluator timeout / error / transient | blocked | advisory continue |
| pipeline deadline | blocked | **unchanged** — still blocks |
| repaired Seed below `required_grade` | blocked by `grade_gate` | **unchanged** — still blocks |

The unresolved verdict stays on `state.last_qa_*` (already surfaced by the result envelope) and is emitted as `auto.seed_qa.advisory_override` with a typed `reason`, so an advisory run is auditable rather than silent. The attention relay carries it as `seed_qa_advisory` with engine ownership `active` — the engine is still driving, so no successor action is offered. `auto.seed_qa.blocked` is kept for history persisted before this change.

`seed_qa_advisory.py` is a new module rather than more lines in `pipeline.py`: the module-size ratchet (#1797) holds `pipeline.py` at its budget, and the rationale for why this gate must never dead-end belongs somewhere readable.

## Test plan

- [x] `uv run pytest tests/unit -q` — 20148 passed, 88 skipped
- [x] `uv run ruff check src/ tests/` and `ruff format --check` clean
- [x] `uv run mypy src/` clean
- [x] `uv run python scripts/check-module-size.py` — OK

Contract tests rewritten from the blocking contract to the advisory one (`test_pipeline_runs_advisory_when_seed_qa_does_not_pass`, `test_pipeline_runs_advisory_on_unrepairable_seed_qa_feedback_without_retrying`), plus new coverage for the exhausted-budget path running the repaired Seed and for relay ownership staying `active`. The prompt-injection withholding assertion is preserved.

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [ ] within 1.5× / [ ] regression flagged with mitigation /
[x] N/A (no per-round comparison applies)

The interview round loop is untouched. This changes a one-shot pre-run gate, so there is no per-round cost to compare; the only runtime delta is that a previously-terminal session now proceeds to RUN.

## Related issues

Refs #2117
