### PR TITLE
feat(auto): delegate run successors to the run job's own chain

### DIFF
--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -101,7 +101,8 @@ ask or send either argument; Auto restores the persisted contract.
 3. Generates a Seed.
 4. Reviews and repairs until A-grade or blocked.
 5. Starts execution only after A-grade.
-6. When `complete_product=true`, chains RUN → RALPH_HANDOFF after a successful run handoff and waits for a terminal Ralph status so a single invocation iterates Ralph until QA passes, convergence, or a budget bound trips. A QA-pass on the executed product completes the auto session; recognized failure modes (`iteration_timeout`, `wall_clock_exhausted`, `oscillation_detected`, `grade_regressing`, `max_generations reached`) block the auto session with the matching `stop_reason` in `last_error` so operators can resume after the cause is addressed.
+6. When `complete_product=false` (the default), auto reaches `COMPLETE` as soon as the run has a durable handle — the run itself keeps going as a background job, and that job carries its own `run → evaluate → ralph` chain governed by `execution.auto_evaluate` / `execution.auto_evolve` (both default `true`, Ralph bounded by `execution.auto_evolve_max_generations`). Auto does not evaluate the run itself in this mode; the chained evaluate job does.
+7. When `complete_product=true`, chains RUN → RALPH_HANDOFF after a successful run handoff and waits for a terminal Ralph status so a single invocation iterates Ralph until QA passes, convergence, or a budget bound trips. A QA-pass on the executed product completes the auto session; recognized failure modes (`iteration_timeout`, `wall_clock_exhausted`, `oscillation_detected`, `grade_regressing`, `max_generations reached`) block the auto session with the matching `stop_reason` in `last_error` so operators can resume after the cause is addressed.
 
 ## Background monitoring UX
 

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -247,6 +247,7 @@ class HandlerRunStarter:
         efficiency_mode: str = "adaptive",
         frugality_assurance: str = "observe",
         frugality_assurance_explicit: bool = False,
+        owns_successors: bool = False,
     ) -> None:
         self.handler = handler
         self.cwd = cwd
@@ -254,6 +255,9 @@ class HandlerRunStarter:
         self.efficiency_mode = efficiency_mode
         self.frugality_assurance = frugality_assurance
         self.frugality_assurance_explicit = frugality_assurance_explicit
+        # True only for complete-product Auto, which drives RALPH_HANDOFF →
+        # EVALUATE itself. See :meth:`__call__`.
+        self.owns_successors = owns_successors
 
     async def __call__(self, seed: Seed, *, idempotency_key: str = "") -> dict[str, object]:
         seed_yaml = yaml.dump(
@@ -264,12 +268,19 @@ class HandlerRunStarter:
             "cwd": self.cwd,
             "use_worktree": self.use_worktree,
             "efficiency_mode": self.efficiency_mode,
-            # Auto owns its own RALPH_HANDOFF and final-evaluation path. Keep
-            # the run handoff from adding a second evaluation owner or a
-            # competing run-session Ralph lineage.
-            "auto_evaluate": False,
-            "auto_evolve": False,
         }
+        if self.owns_successors:
+            # Complete-product Auto owns its own RALPH_HANDOFF and
+            # final-evaluation path. Keep the run handoff from adding a second
+            # evaluation owner or a competing run-session Ralph lineage.
+            arguments["auto_evaluate"] = False
+            arguments["auto_evolve"] = False
+        # Otherwise send no override at all: Auto stops at COMPLETE as soon as
+        # the run has a durable handle and has no EVALUATE edge out of RUN, so
+        # suppressing the run job's own successors would leave the finished run
+        # with no evaluation owner at all. Letting ``execution.auto_evaluate`` /
+        # ``execution.auto_evolve`` govern makes an Auto-started run chain
+        # run → evaluate → ralph exactly like a direct ``ooo run``.
         if self.frugality_assurance_explicit:
             arguments["frugality_assurance"] = self.frugality_assurance
         if idempotency_key:

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -78,6 +78,7 @@ from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler, StartExec
 from ouroboros.mcp.tools.job_handlers import JobResultHandler, JobWaitHandler
 from ouroboros.mcp.tools.qa import QAHandler
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler
+from ouroboros.mcp.tools.run_successors import build_run_successor_handler
 from ouroboros.mcp.tools.subagent import should_dispatch_via_plugin
 from ouroboros.orchestrator import resolve_agent_runtime_backend
 from ouroboros.package_profiles import (
@@ -578,6 +579,12 @@ async def _run_auto(
         execute_handler=execute_seed,
         agent_runtime_backend=runtime_plan.execute.runtime_backend,
         opencode_mode=execute_opencode_mode,
+        # Without the successor stack a finished run reports
+        # ``evaluation_status="enqueue_failed"`` and nothing grades it.
+        start_evaluate_handler=build_run_successor_handler(
+            agent_runtime_backend=runtime_plan.evaluate.runtime_backend,
+            opencode_mode=runtime_plan.evaluate.opencode_mode,
+        ),
     )
     seed_qa = QAHandler(
         agent_runtime_backend=runtime_plan.interview.runtime_backend,

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -584,7 +584,7 @@ async def _run_auto(
         start_evaluate_handler=build_run_successor_handler(
             agent_runtime_backend=runtime_plan.evaluate.runtime_backend,
             opencode_mode=runtime_plan.evaluate.opencode_mode,
-        ),
+        ),  # composition-root wiring; a hand-built stack dies on its first generation
     )
     seed_qa = QAHandler(
         agent_runtime_backend=runtime_plan.interview.runtime_backend,

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -641,6 +641,7 @@ class AutoHandler:
                 efficiency_mode=state.efficiency_mode,
                 frugality_assurance=state.frugality_assurance,
                 frugality_assurance_explicit=state.frugality_assurance_explicit,
+                owns_successors=complete_product,
             ),
             store=store,
             repairer=SeedRepairer(max_repair_rounds=max_repair_rounds),

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -97,6 +97,7 @@ from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler, StartExec
 from ouroboros.mcp.tools.job_observer import build_job_observer_contract
 from ouroboros.mcp.tools.qa import QAHandler
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler
+from ouroboros.mcp.tools.run_successors import resolve_run_successor_handler
 from ouroboros.mcp.tools.subagent import (
     DELEGATED_TO_PLUGIN,
     build_subagent_payload,
@@ -2361,12 +2362,16 @@ def _execution_start_handler(
         mcp_manager=mcp_manager,
         mcp_tool_prefix=mcp_tool_prefix,
     )
+    # Without the successor stack the run cannot enqueue the evaluation it
+    # delegates to and finishes with ``evaluation_status="enqueue_failed"``.
     return StartExecuteSeedHandler(
         execute_handler=execute_seed,
         event_store=event_store,
         job_manager=job_manager,
         agent_runtime_backend=agent_runtime_backend,
         opencode_mode=opencode_mode,
+        start_evaluate_handler=resolve_run_successor_handler(handler, execute_seed, job_manager),
+        seed_handoff_registry=getattr(handler, "seed_handoff_registry", None),
     )
 
 

--- a/src/ouroboros/mcp/tools/run_successors.py
+++ b/src/ouroboros/mcp/tools/run_successors.py
@@ -1,0 +1,93 @@
+"""One place that wires the run job's successor chain.
+
+A terminal ``execute_seed`` run enqueues a formal evaluation, and a rejected
+verdict enqueues a bounded Ralph loop. That behaviour is not a property of the
+run handler — it is a property of the *dependencies* the run handler was built
+with. ``StartExecuteSeedHandler`` without a ``start_evaluate_handler`` silently
+degrades to ``evaluation_status="enqueue_failed"``, and a ``StartEvaluateHandler``
+without a ``start_ralph_handler`` degrades the same way one link further down.
+
+Every composition root that builds a run handler therefore has to assemble the
+same stack, and any that forgets a link produces a run nobody grades. That is
+exactly how ``ooo auto`` ended up starting runs whose successors could never be
+enqueued while the shipped stdio server wired them correctly.
+
+This module owns that assembly so the composition roots can share one
+definition instead of each keeping a partial copy.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ouroboros.mcp.tools.evaluation_handlers import EvaluateHandler, StartEvaluateHandler
+from ouroboros.mcp.tools.ralph_handlers import StartRalphHandler
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from ouroboros.mcp.job_manager import JobManager
+    from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
+    from ouroboros.persistence.event_store import EventStore
+
+
+def resolve_run_successor_handler(
+    existing: Any,
+    execute_handler: Any,
+    job_manager: JobManager | None = None,
+) -> StartEvaluateHandler:
+    """Carry an already-wired successor owner across a run-handler rebuild.
+
+    A composition root that rebuilds a run handler for a different runtime must
+    not drop the stack the original was given; only build a fresh one when
+    there is nothing to carry. Backends are read from the rebuilt execute
+    handler so the successors judge on the same runtime the run used.
+    """
+    carried = getattr(existing, "start_evaluate_handler", None)
+    if carried is not None:
+        return carried
+    return build_run_successor_handler(
+        event_store=getattr(execute_handler, "event_store", None),
+        job_manager=job_manager,
+        llm_backend=getattr(execute_handler, "llm_backend", None),
+        agent_runtime_backend=getattr(execute_handler, "agent_runtime_backend", None),
+        opencode_mode=getattr(execute_handler, "opencode_mode", None),
+    )
+
+
+def build_run_successor_handler(
+    *,
+    event_store: EventStore | None = None,
+    job_manager: JobManager | None = None,
+    llm_backend: str | None = None,
+    agent_runtime_backend: str | None = None,
+    opencode_mode: str | None = None,
+    seed_handoff_registry: SeedHandoffRegistry | None = None,
+) -> StartEvaluateHandler:
+    """Build the evaluate → ralph successor owner for a run handler.
+
+    ``opencode_mode`` is deliberately **not** forwarded to the Ralph link.
+    Automatic convergence is owned by the parent even in passive plugin mode, so
+    its private Ralph surface must enqueue a real pollable job rather than emit
+    a second plugin delegation envelope — mirroring the shipped stdio server.
+    """
+    return StartEvaluateHandler(
+        evaluate_handler=EvaluateHandler(
+            event_store=event_store,
+            llm_backend=llm_backend,
+            agent_runtime_backend=agent_runtime_backend,
+            opencode_mode=opencode_mode,
+        ),
+        event_store=event_store,
+        job_manager=job_manager,
+        llm_backend=llm_backend,
+        agent_runtime_backend=agent_runtime_backend,
+        opencode_mode=opencode_mode,
+        start_ralph_handler=StartRalphHandler(
+            event_store=event_store,
+            job_manager=job_manager,
+            agent_runtime_backend=agent_runtime_backend,
+            opencode_mode=None,
+        ),
+        seed_handoff_registry=seed_handoff_registry,
+    )

--- a/src/ouroboros/mcp/tools/run_successors.py
+++ b/src/ouroboros/mcp/tools/run_successors.py
@@ -1,93 +1,77 @@
-"""One place that wires the run job's successor chain.
+"""One place that resolves the run job's successor chain.
 
 A terminal ``execute_seed`` run enqueues a formal evaluation, and a rejected
 verdict enqueues a bounded Ralph loop. That behaviour is not a property of the
 run handler — it is a property of the *dependencies* the run handler was built
-with. ``StartExecuteSeedHandler`` without a ``start_evaluate_handler`` silently
-degrades to ``evaluation_status="enqueue_failed"``, and a ``StartEvaluateHandler``
-without a ``start_ralph_handler`` degrades the same way one link further down.
+with, and every link degrades **silently** when its dependency is missing:
 
-Every composition root that builds a run handler therefore has to assemble the
-same stack, and any that forgets a link produces a run nobody grades. That is
-exactly how ``ooo auto`` ended up starting runs whose successors could never be
-enqueued while the shipped stdio server wired them correctly.
+* ``StartExecuteSeedHandler`` without ``start_evaluate_handler`` terminates the
+  run at ``evaluation_status="enqueue_failed"``;
+* ``StartEvaluateHandler`` without ``start_ralph_handler`` reports
+  ``chained_ralph_skipped`` one link further down;
+* a hand-built ``StartRalphHandler`` gets an ``EvolveStepHandler`` with no
+  ``EvolutionaryLoop``, so the Ralph job *is* enqueued and then dies on its
+  first generation with ``EvolutionaryLoop not configured``.
 
-This module owns that assembly so the composition roots can share one
-definition instead of each keeping a partial copy.
+The last one is why this module resolves the stack from the MCP composition
+root instead of assembling it here. ``create_ouroboros_server`` is the only
+place that wires the evolutionary loop's executor, evaluator, validator and
+rewind observer, so any hand-rolled copy is a chain that looks complete and
+is not — the same trap ``_build_configured_ralph_handler`` in the CLI already
+documents for the complete-product path.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from ouroboros.mcp.tools.evaluation_handlers import EvaluateHandler, StartEvaluateHandler
-from ouroboros.mcp.tools.ralph_handlers import StartRalphHandler
+from ouroboros.mcp.tools.evaluation_handlers import StartEvaluateHandler
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from ouroboros.mcp.job_manager import JobManager
-    from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
-    from ouroboros.persistence.event_store import EventStore
+
+_START_EVALUATE_TOOL = "ouroboros_start_evaluate"
+
+
+def build_run_successor_handler(
+    *,
+    agent_runtime_backend: str | None = None,
+    opencode_mode: str | None = None,
+) -> StartEvaluateHandler:
+    """Return the composition root's fully wired evaluate → ralph successor owner.
+
+    Imported lazily: this module is reached from composition roots, and the
+    server module pulls in the full pipeline graph.
+    """
+    from ouroboros.mcp.server.adapter import create_ouroboros_server
+
+    server = create_ouroboros_server(
+        runtime_backend=agent_runtime_backend,
+        opencode_mode=opencode_mode,
+    )
+    handler = server._tool_handlers[_START_EVALUATE_TOOL]  # noqa: SLF001
+    if not isinstance(handler, StartEvaluateHandler):
+        msg = f"MCP composition root returned non-evaluate handler for {_START_EVALUATE_TOOL}"
+        raise TypeError(msg)
+    return handler
 
 
 def resolve_run_successor_handler(
     existing: Any,
     execute_handler: Any,
-    job_manager: JobManager | None = None,
+    job_manager: JobManager | None = None,  # noqa: ARG001 - kept for call-site symmetry
 ) -> StartEvaluateHandler:
     """Carry an already-wired successor owner across a run-handler rebuild.
 
     A composition root that rebuilds a run handler for a different runtime must
-    not drop the stack the original was given; only build a fresh one when
+    not drop the stack the original was given; only resolve a fresh one when
     there is nothing to carry. Backends are read from the rebuilt execute
-    handler so the successors judge on the same runtime the run used.
+    handler so the successors judge on the runtime the run actually used.
     """
     carried = getattr(existing, "start_evaluate_handler", None)
     if carried is not None:
         return carried
     return build_run_successor_handler(
-        event_store=getattr(execute_handler, "event_store", None),
-        job_manager=job_manager,
-        llm_backend=getattr(execute_handler, "llm_backend", None),
         agent_runtime_backend=getattr(execute_handler, "agent_runtime_backend", None),
         opencode_mode=getattr(execute_handler, "opencode_mode", None),
-    )
-
-
-def build_run_successor_handler(
-    *,
-    event_store: EventStore | None = None,
-    job_manager: JobManager | None = None,
-    llm_backend: str | None = None,
-    agent_runtime_backend: str | None = None,
-    opencode_mode: str | None = None,
-    seed_handoff_registry: SeedHandoffRegistry | None = None,
-) -> StartEvaluateHandler:
-    """Build the evaluate → ralph successor owner for a run handler.
-
-    ``opencode_mode`` is deliberately **not** forwarded to the Ralph link.
-    Automatic convergence is owned by the parent even in passive plugin mode, so
-    its private Ralph surface must enqueue a real pollable job rather than emit
-    a second plugin delegation envelope — mirroring the shipped stdio server.
-    """
-    return StartEvaluateHandler(
-        evaluate_handler=EvaluateHandler(
-            event_store=event_store,
-            llm_backend=llm_backend,
-            agent_runtime_backend=agent_runtime_backend,
-            opencode_mode=opencode_mode,
-        ),
-        event_store=event_store,
-        job_manager=job_manager,
-        llm_backend=llm_backend,
-        agent_runtime_backend=agent_runtime_backend,
-        opencode_mode=opencode_mode,
-        start_ralph_handler=StartRalphHandler(
-            event_store=event_store,
-            job_manager=job_manager,
-            agent_runtime_backend=agent_runtime_backend,
-            opencode_mode=None,
-        ),
-        seed_handoff_registry=seed_handoff_registry,
     )

--- a/tests/unit/auto/test_adapters_client_gates.py
+++ b/tests/unit/auto/test_adapters_client_gates.py
@@ -26,6 +26,32 @@ class _FakeSeed:
 
 @pytest.mark.asyncio
 async def test_auto_run_starter_keeps_one_authoritative_evaluation_path(tmp_path) -> None:
+    """Complete-product Auto owns RALPH_HANDOFF → EVALUATE, so the run job must
+    not start a competing evaluation owner or Ralph lineage."""
+    handler = AsyncMock()
+    handler.handle = AsyncMock(
+        return_value=Result.ok(MCPToolResult(meta={"job_id": "job_run", "session_id": "orch_run"}))
+    )
+    starter = HandlerRunStarter(handler, cwd=str(tmp_path), owns_successors=True)
+
+    await starter(_FakeSeed())  # type: ignore[arg-type]
+
+    arguments = handler.handle.await_args.args[0]
+    assert arguments["auto_evaluate"] is False
+    assert arguments["auto_evolve"] is False
+
+
+@pytest.mark.asyncio
+async def test_auto_run_starter_delegates_successors_when_auto_does_not_own_them(tmp_path) -> None:
+    """Default Auto has no evaluation path of its own.
+
+    It stops at COMPLETE once the run has a durable handle and there is no
+    RUN → EVALUATE edge, so it must leave the run job's own
+    run → evaluate → ralph chain alone rather than suppressing it — otherwise a
+    finished run has no evaluation owner at all. Sending no override lets
+    ``execution.auto_evaluate`` / ``execution.auto_evolve`` govern, exactly as
+    for a direct ``ooo run``.
+    """
     handler = AsyncMock()
     handler.handle = AsyncMock(
         return_value=Result.ok(MCPToolResult(meta={"job_id": "job_run", "session_id": "orch_run"}))
@@ -35,8 +61,8 @@ async def test_auto_run_starter_keeps_one_authoritative_evaluation_path(tmp_path
     await starter(_FakeSeed())  # type: ignore[arg-type]
 
     arguments = handler.handle.await_args.args[0]
-    assert arguments["auto_evaluate"] is False
-    assert arguments["auto_evolve"] is False
+    assert "auto_evaluate" not in arguments
+    assert "auto_evolve" not in arguments
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -1227,4 +1227,9 @@ def test_run_auto_wires_the_run_successor_stack(tmp_path) -> None:
 
     start_evaluate = captured["run_starter"].handler.start_evaluate_handler
     assert start_evaluate is not None
-    assert start_evaluate.start_ralph_handler is not None
+    start_ralph = start_evaluate.start_ralph_handler
+    assert start_ralph is not None
+    # A hand-built Ralph handler enqueues a job that dies on its first
+    # generation with "EvolutionaryLoop not configured", so a non-null handler
+    # is not evidence that the chain completes.
+    assert start_ralph._evolve_handler.evolutionary_loop is not None

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -1174,3 +1174,57 @@ def test_print_result_attached_completion_remains_product_complete() -> None:
     assert "Status: complete" in output
     assert "Status: run_handoff_started" not in output
     assert "Product status: not verified complete" not in output
+
+
+def test_run_auto_wires_the_run_successor_stack(tmp_path) -> None:
+    """CLI Auto delegates run successors, so it must build a handler that can enqueue them.
+
+    Without ``start_evaluate_handler`` the delegation degrades to
+    ``evaluation_status="enqueue_failed"``: the run finishes and nothing grades
+    it. The Ralph link below it must be present for the same reason.
+    """
+    import asyncio
+
+    from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+    from ouroboros.cli.commands.auto import _run_auto
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.runtime_backend = "claude"
+    state.skip_run = True
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.mark_blocked("auto interview reached max rounds with unresolved gaps: actors")
+    store = AutoStore(tmp_path)
+    store.save(state)
+    session_id = state.auto_session_id
+
+    captured: dict[str, object] = {}
+
+    async def fake_pipeline_run(self, run_state):  # noqa: ARG001
+        captured["run_starter"] = self.run_starter
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id=session_id,
+            phase="complete",
+            grade="A",
+        )
+
+    with (
+        patch("ouroboros.cli.commands.auto.AutoStore") as store_cls,
+        patch("ouroboros.cli.commands.auto.AutoPipeline.run", new=fake_pipeline_run),
+    ):
+        store_cls.return_value = store
+
+        asyncio.run(
+            _run_auto(
+                goal=None,
+                resume=session_id,
+                runtime=None,
+                max_interview_rounds=None,
+                max_repair_rounds=None,
+                skip_run=False,
+            )
+        )
+
+    start_evaluate = captured["run_starter"].handler.start_evaluate_handler
+    assert start_evaluate is not None
+    assert start_evaluate.start_ralph_handler is not None

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -2913,7 +2913,12 @@ class TestAutoRunSuccessorWiring:
         start_evaluate = handler.start_evaluate_handler
         assert start_evaluate is not None
         # ...and the link below it, or a rejected verdict cannot start Ralph.
-        assert start_evaluate.start_ralph_handler is not None
+        start_ralph = start_evaluate.start_ralph_handler
+        assert start_ralph is not None
+        # A Ralph handler assembled by hand enqueues a job that then dies on its
+        # first generation with "EvolutionaryLoop not configured", so a non-null
+        # handler is not evidence the chain completes.
+        assert start_ralph._evolve_handler.evolutionary_loop is not None
 
     def test_rebuild_preserves_an_injected_successor_stack(self) -> None:
         """Rebuilding for another runtime must not drop the server's wiring."""

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -2886,3 +2886,59 @@ class TestAutoHandlerLeaseRelease:
 
         assert result.is_ok
         assert not lease_path.exists()
+
+
+class TestAutoRunSuccessorWiring:
+    """Auto-created run handlers must be able to enqueue the chain they delegate to.
+
+    #2120 turned the successor chain back on for default Auto, but Auto builds
+    its own ``StartExecuteSeedHandler``. Without the successor stack that
+    delegation silently degrades to
+    ``evaluation_status="enqueue_failed"`` — the run finishes and nothing
+    grades it, which is the exact failure the delegation was meant to remove.
+    """
+
+    def test_mcp_execution_start_handler_can_enqueue_successors(self) -> None:
+        from ouroboros.mcp.tools.auto_handler import _execution_start_handler
+
+        handler = _execution_start_handler(
+            None,
+            llm_backend=None,
+            agent_runtime_backend="claude",
+            opencode_mode=None,
+            mcp_manager=None,
+            mcp_tool_prefix="",
+        )
+
+        start_evaluate = handler.start_evaluate_handler
+        assert start_evaluate is not None
+        # ...and the link below it, or a rejected verdict cannot start Ralph.
+        assert start_evaluate.start_ralph_handler is not None
+
+    def test_rebuild_preserves_an_injected_successor_stack(self) -> None:
+        """Rebuilding for another runtime must not drop the server's wiring."""
+        from ouroboros.mcp.tools.auto_handler import _execution_start_handler
+        from ouroboros.mcp.tools.execution_handlers import (
+            ExecuteSeedHandler,
+            StartExecuteSeedHandler,
+        )
+        from ouroboros.mcp.tools.run_successors import build_run_successor_handler
+
+        injected = build_run_successor_handler(agent_runtime_backend="claude")
+        original = StartExecuteSeedHandler(
+            execute_handler=ExecuteSeedHandler(agent_runtime_backend="claude"),
+            agent_runtime_backend="claude",
+            start_evaluate_handler=injected,
+        )
+
+        rebuilt = _execution_start_handler(
+            original,
+            llm_backend=None,
+            agent_runtime_backend="codex",
+            opencode_mode=None,
+            mcp_manager=None,
+            mcp_tool_prefix="",
+        )
+
+        assert rebuilt is not original
+        assert rebuilt.start_evaluate_handler is injected

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -1575,6 +1575,41 @@ class TestBackgroundJobPath:
         assert kwargs["evaluator"] is None
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("complete_product", [False, True])
+    async def test_run_starter_owns_successors_only_in_complete_product_mode(
+        self, event_store, tmp_path, monkeypatch: pytest.MonkeyPatch, complete_product: bool
+    ) -> None:
+        """Exactly one owner for the post-run evaluation.
+
+        Complete-product Auto drives RALPH_HANDOFF → EVALUATE itself, so the run
+        job's own chain is suppressed. Default Auto has no such path — it stops
+        at COMPLETE once the run has a handle — so the run job keeps its
+        run → evaluate → ralph chain instead of finishing unevaluated.
+        """
+
+        captured: dict[str, object] = {}
+
+        class FakeAutoPipeline:
+            def __init__(self, *_args, **kwargs):
+                captured["pipeline_kwargs"] = kwargs
+
+            async def run(self, state):
+                return AutoPipelineResult(
+                    status="blocked",
+                    auto_session_id=state.auto_session_id,
+                    phase=str(state.phase.value),
+                )
+
+        monkeypatch.setattr("ouroboros.mcp.tools.auto_handler.AutoPipeline", FakeAutoPipeline)
+
+        h = AutoHandler(store=AutoStore(tmp_path), event_store=event_store)
+
+        await h._run({"goal": "build a CLI", "complete_product": complete_product})
+
+        kwargs = captured["pipeline_kwargs"]
+        assert kwargs["run_starter"].owns_successors is complete_product
+
+    @pytest.mark.asyncio
     async def test_plugin_mode_returns_subagent_without_enqueue(
         self, event_store, tmp_path, fake_inner_auto
     ) -> None:


### PR DESCRIPTION
## Summary

Default `ooo auto` had no evaluation owner. `HandlerRunStarter` sent `auto_evaluate=False, auto_evolve=False` on every Auto-started run (added in #1916) because "Auto owns its own RALPH_HANDOFF and final-evaluation path" — but that ownership only exists under `complete_product`:

- `_ALLOWED_TRANSITIONS[RUN] = {COMPLETE, RALPH_HANDOFF, BLOCKED, FAILED}` — there is no `RUN → EVALUATE` edge
- `EVALUATE` is reachable only from `RALPH_HANDOFF`, entered only under `complete_product`
- default Auto reaches `COMPLETE` as soon as the run has a durable handle

So default Auto suppressed the run job's successors *and* had nothing of its own: the run finished and nobody graded it.

The starter now takes `owns_successors`, true only for complete-product Auto:

| mode | override sent | effect |
|---|---|---|
| `complete_product=true` | `auto_evaluate/auto_evolve = False` | unchanged — Auto drives RALPH_HANDOFF → EVALUATE, no competing owner or Ralph lineage |
| default | **none** | `execution.auto_evaluate` / `execution.auto_evolve` govern, exactly as for a direct `ooo run` |

Sending an explicit `True` was rejected deliberately: it would override a config that intentionally disabled the chain — the same class of bug in the opposite direction. Delegating means an Auto-started run behaves like `ooo run`, which is the point.

The CLI constructs `HandlerRunStarter` only in the non-complete-product branch, so it is correct by construction; the MCP handler passes `owns_successors=complete_product`.

This is one step of #2118 — it fixes the missing owner, and does not yet unify the two different judges. That is the follow-up.

## Test plan

- [x] `uv run pytest tests/unit -q` — 20148 passed, 88 skipped
- [x] `uv run ruff check src/ tests/` and `ruff format --check` clean
- [x] `uv run mypy src/` clean

New coverage: the delegation contract (no override sent when Auto does not own successors), the preserved single-owner contract under complete-product, and a parametrized wiring guard that `run_starter.owns_successors is complete_product` — the wiring is exactly what regressed before.

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [ ] within 1.5× / [ ] regression flagged with mitigation /
[x] N/A (no per-round comparison applies)

The change is two dictionary keys on the run handoff arguments; the interview round loop is untouched, so there is no per-round cost to compare.

Worth stating plainly: an Auto-started run now enqueues an evaluation, and a rejected verdict enqueues a bounded Ralph loop. That is more work per session than before — it is the work that was supposed to happen and was being suppressed. Both remain switchable through `execution.auto_evaluate` / `execution.auto_evolve`.

## Related issues

Refs #2118
