### PR TITLE
feat(auto): add a follower for the run job's successor chain

### DIFF
--- a/src/ouroboros/auto/chain_follower.py
+++ b/src/ouroboros/auto/chain_follower.py
@@ -104,6 +104,13 @@ _EXPECTED_JOB_TYPES: dict[str, str] = {
     "ralph": "ralph",
 }
 MISMATCHED_LINK_STATUS = "link_type_mismatch"
+# A successor handle is a cross-job reference into durable state. It can name a
+# job that no longer exists (pruned history, a different store, a mis-copied
+# id), and ``JobManager.get_snapshot`` raises for an unknown id. The walk fails
+# closed on that too: an unreadable link is a non-approving terminal that keeps
+# its handles, never an exception that loses them.
+UNAVAILABLE_LINK_STATUS = "link_unavailable"
+TIMED_OUT_STATUS = "timed_out"
 
 
 async def follow_run_chain(
@@ -133,15 +140,16 @@ async def follow_run_chain(
 
     while True:
         kind = _JOB_KINDS[min(depth, len(_JOB_KINDS) - 1)]
-        snapshot = await _await_terminal(job_manager, job_id, poll_seconds, expiry)
+        observed = await _await_terminal(job_manager, job_id, poll_seconds, expiry)
         followed.append(job_id)
-        if snapshot is None:
+        if isinstance(observed, str):
             return ChainTerminal(
                 job_id=job_id,
                 job_kind=kind,
-                status="timed_out",
+                status=observed,
                 followed_job_ids=tuple(followed),
             )
+        snapshot = observed
         if getattr(snapshot, "job_type", None) != _EXPECTED_JOB_TYPES[kind]:
             # Refuse to interpret the metadata of a job that is not the link it
             # claims to be — neither its verdict nor its successor handle.
@@ -181,8 +189,12 @@ async def _await_terminal(
     job_id: str,
     poll_seconds: float,
     expiry: float | None,
-) -> _Snapshot | None:
-    """Poll one job until terminal; None when the deadline trips first.
+) -> _Snapshot | str:
+    """Poll one job until terminal.
+
+    Returns the snapshot, or a terminal status string when the job cannot be
+    observed: :data:`TIMED_OUT_STATUS` when the budget runs out,
+    :data:`UNAVAILABLE_LINK_STATUS` when the handle names no readable job.
 
     The read itself is bounded, not just the interval between reads: a snapshot
     that comes from persistence or a reconciliation path can block, and a
@@ -191,22 +203,24 @@ async def _await_terminal(
     """
     loop = asyncio.get_running_loop()
     while True:
-        if expiry is None:
-            snapshot = await job_manager.get_snapshot(job_id)
-        else:
-            remaining = expiry - loop.time()
-            if remaining <= 0:
-                return None
-            try:
+        try:
+            if expiry is None:
+                snapshot = await job_manager.get_snapshot(job_id)
+            else:
+                remaining = expiry - loop.time()
+                if remaining <= 0:
+                    return TIMED_OUT_STATUS
                 snapshot = await asyncio.wait_for(
                     job_manager.get_snapshot(job_id), timeout=remaining
                 )
-            except TimeoutError:
-                return None
+        except TimeoutError:
+            return TIMED_OUT_STATUS
+        except (ValueError, KeyError, LookupError):
+            return UNAVAILABLE_LINK_STATUS
         if snapshot.is_terminal:
             return snapshot
         if expiry is not None and loop.time() >= expiry:
-            return None
+            return TIMED_OUT_STATUS
         remaining_sleep = (
             poll_seconds if expiry is None else min(poll_seconds, expiry - loop.time())
         )

--- a/src/ouroboros/auto/chain_follower.py
+++ b/src/ouroboros/auto/chain_follower.py
@@ -1,0 +1,159 @@
+"""Follow a run job's ``run → evaluate → ralph`` successor chain to terminal.
+
+``ooo run`` already owns the successor policy: an evaluable terminal execution
+enqueues a formal evaluation, and a rejected verdict enqueues a bounded Ralph
+convergence loop. ``ooo auto`` used to re-implement that policy inside its own
+phase machine (``RALPH_HANDOFF`` → ``EVALUATE``) with a *different* judge, which
+is how the product ended up with several incompatible definitions of "done".
+
+This module lets Auto reuse the run chain instead of owning a second one: it
+walks the successor job ids the chain publishes on each job's result meta
+(``chained_evaluate_job_id`` → ``chained_ralph_job_id``) and reports the last
+terminal it reached. Auto then maps that single terminal onto its own phases.
+
+Nothing here starts work — the chain is started by the run job itself. This only
+observes, so a caller that does not wait (the default, non-``complete_product``
+Auto) simply never invokes it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+# Successor handles published by ``run_evaluate_chain`` / ``evaluate_ralph_chain``
+# on the *preceding* job's result meta, in the order the chain creates them.
+SUCCESSOR_META_KEYS: tuple[str, ...] = ("chained_evaluate_job_id", "chained_ralph_job_id")
+
+_DEFAULT_POLL_SECONDS = 2.0
+
+# The single Ralph stop reason that means the loop's own QA verdict passed
+# (``ralph_loop.py:305``). Kept as a constant so the approval test never drifts
+# into matching a budget terminal such as ``max_generations reached``.
+RALPH_APPROVED_STOP_REASON = "qa passed"
+
+
+class _Snapshot(Protocol):
+    job_id: str
+    status: Any
+    result_text: str | None
+    result_meta: dict[str, Any]
+
+    @property
+    def is_terminal(self) -> bool: ...
+
+
+class _JobManager(Protocol):
+    async def get_snapshot(self, job_id: str) -> _Snapshot: ...
+
+
+@dataclass(frozen=True)
+class ChainTerminal:
+    """Terminal state of the deepest successor the chain reached."""
+
+    job_id: str
+    job_kind: str
+    """``run`` / ``evaluate`` / ``ralph`` — which link produced this terminal."""
+    status: str
+    result_text: str = ""
+    result_meta: dict[str, Any] = field(default_factory=dict)
+    followed_job_ids: tuple[str, ...] = ()
+
+    @property
+    def approved(self) -> bool:
+        """True only when a link explicitly approved the product.
+
+        A ``completed`` run job is *not* approval — it means execution finished,
+        which is exactly the conflation this chain exists to remove. Approval is
+        the formal evaluation's ``final_approved``, or a Ralph loop that stopped
+        on :data:`RALPH_APPROVED_STOP_REASON` (every other Ralph stop reason is a
+        budget or regression terminal, not a passing verdict).
+        """
+        if self.result_meta.get("final_approved") is True:
+            return True
+        return (
+            self.job_kind == "ralph"
+            and self.result_meta.get("stop_reason") == RALPH_APPROVED_STOP_REASON
+        )
+
+
+_JOB_KINDS = ("run", "evaluate", "ralph")
+
+
+async def follow_run_chain(
+    job_manager: _JobManager,
+    run_job_id: str,
+    *,
+    poll_seconds: float = _DEFAULT_POLL_SECONDS,
+    deadline_seconds: float | None = None,
+) -> ChainTerminal:
+    """Await ``run_job_id`` and every successor it hands off to.
+
+    Returns the terminal of the deepest link reached. A link that finishes
+    without publishing a successor handle ends the walk — that is the normal
+    shape when evaluation approves the product (no Ralph) or when the chain is
+    disabled by configuration (no evaluation).
+
+    ``deadline_seconds`` bounds the whole walk; on expiry the last observed
+    terminal is returned with ``status="timed_out"`` so the caller keeps the
+    handles it needs to resume rather than losing the chain.
+    """
+    loop = asyncio.get_running_loop()
+    expiry = None if deadline_seconds is None else loop.time() + deadline_seconds
+    followed: list[str] = []
+    job_id = run_job_id
+    depth = 0
+    terminal: ChainTerminal | None = None
+
+    while True:
+        kind = _JOB_KINDS[min(depth, len(_JOB_KINDS) - 1)]
+        snapshot = await _await_terminal(job_manager, job_id, poll_seconds, expiry)
+        followed.append(job_id)
+        if snapshot is None:
+            return ChainTerminal(
+                job_id=job_id,
+                job_kind=kind,
+                status="timed_out",
+                followed_job_ids=tuple(followed),
+            )
+        meta = dict(snapshot.result_meta or {})
+        terminal = ChainTerminal(
+            job_id=job_id,
+            job_kind=kind,
+            status=str(getattr(snapshot.status, "value", snapshot.status)),
+            result_text=snapshot.result_text or "",
+            result_meta=meta,
+            followed_job_ids=tuple(followed),
+        )
+        successor = _next_job_id(meta, depth)
+        if successor is None:
+            return terminal
+        job_id = successor
+        depth += 1
+
+
+def _next_job_id(meta: dict[str, Any], depth: int) -> str | None:
+    """Return the successor handle published for the link at ``depth``."""
+    if depth >= len(SUCCESSOR_META_KEYS):
+        return None
+    value = meta.get(SUCCESSOR_META_KEYS[depth])
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+async def _await_terminal(
+    job_manager: _JobManager,
+    job_id: str,
+    poll_seconds: float,
+    expiry: float | None,
+) -> _Snapshot | None:
+    """Poll one job until terminal; None when the deadline trips first."""
+    loop = asyncio.get_running_loop()
+    while True:
+        snapshot = await job_manager.get_snapshot(job_id)
+        if snapshot.is_terminal:
+            return snapshot
+        if expiry is not None and loop.time() >= expiry:
+            return None
+        remaining = poll_seconds if expiry is None else min(poll_seconds, expiry - loop.time())
+        await asyncio.sleep(max(0.0, remaining))

--- a/src/ouroboros/auto/chain_follower.py
+++ b/src/ouroboros/auto/chain_follower.py
@@ -33,6 +33,11 @@ _DEFAULT_POLL_SECONDS = 2.0
 # into matching a budget terminal such as ``max_generations reached``.
 RALPH_APPROVED_STOP_REASON = "qa passed"
 
+# A verdict only counts from a job that actually finished cleanly. `failed`,
+# `cancelled`, `interrupted` and the follower's own `timed_out` never approve,
+# whatever their (possibly inherited) result meta says.
+_APPROVING_STATUSES = frozenset({"completed"})
+
 
 class _Snapshot(Protocol):
     job_id: str
@@ -69,13 +74,20 @@ class ChainTerminal:
         the formal evaluation's ``final_approved``, or a Ralph loop that stopped
         on :data:`RALPH_APPROVED_STOP_REASON` (every other Ralph stop reason is a
         budget or regression terminal, not a passing verdict).
+
+        Both signals are read **only from the link that owns them**. Result meta
+        is merged and forwarded along the chain, so an unqualified
+        ``final_approved`` lookup would let a run or a *failed* Ralph inherit an
+        approval it never issued — the same "someone else's verdict counts as
+        mine" defect at a different layer. A non-terminal status never approves.
         """
-        if self.result_meta.get("final_approved") is True:
-            return True
-        return (
-            self.job_kind == "ralph"
-            and self.result_meta.get("stop_reason") == RALPH_APPROVED_STOP_REASON
-        )
+        if self.status not in _APPROVING_STATUSES:
+            return False
+        if self.job_kind == "evaluate":
+            return self.result_meta.get("final_approved") is True
+        if self.job_kind == "ralph":
+            return self.result_meta.get("stop_reason") == RALPH_APPROVED_STOP_REASON
+        return False
 
 
 _JOB_KINDS = ("run", "evaluate", "ralph")

--- a/src/ouroboros/auto/chain_follower.py
+++ b/src/ouroboros/auto/chain_follower.py
@@ -41,6 +41,7 @@ _APPROVING_STATUSES = frozenset({"completed"})
 
 class _Snapshot(Protocol):
     job_id: str
+    job_type: str
     status: Any
     result_text: str | None
     result_meta: dict[str, Any]
@@ -92,6 +93,18 @@ class ChainTerminal:
 
 _JOB_KINDS = ("run", "evaluate", "ralph")
 
+# The durable ``job_type`` each link must actually be. A successor handle is
+# just a string on someone else's result meta: stale, mis-copied or misdirected
+# values are possible, and a link identified only by traversal depth would let
+# any completed job carrying ``final_approved`` be read as this chain's
+# evaluation. Depth proposes; the persisted job type disposes.
+_EXPECTED_JOB_TYPES: dict[str, str] = {
+    "run": "execute_seed",
+    "evaluate": "evaluate",
+    "ralph": "ralph",
+}
+MISMATCHED_LINK_STATUS = "link_type_mismatch"
+
 
 async def follow_run_chain(
     job_manager: _JobManager,
@@ -129,6 +142,16 @@ async def follow_run_chain(
                 status="timed_out",
                 followed_job_ids=tuple(followed),
             )
+        if getattr(snapshot, "job_type", None) != _EXPECTED_JOB_TYPES[kind]:
+            # Refuse to interpret the metadata of a job that is not the link it
+            # claims to be — neither its verdict nor its successor handle.
+            return ChainTerminal(
+                job_id=job_id,
+                job_kind=kind,
+                status=MISMATCHED_LINK_STATUS,
+                result_meta={"observed_job_type": getattr(snapshot, "job_type", None)},
+                followed_job_ids=tuple(followed),
+            )
         meta = dict(snapshot.result_meta or {})
         terminal = ChainTerminal(
             job_id=job_id,
@@ -159,13 +182,32 @@ async def _await_terminal(
     poll_seconds: float,
     expiry: float | None,
 ) -> _Snapshot | None:
-    """Poll one job until terminal; None when the deadline trips first."""
+    """Poll one job until terminal; None when the deadline trips first.
+
+    The read itself is bounded, not just the interval between reads: a snapshot
+    that comes from persistence or a reconciliation path can block, and a
+    deadline enforced only after the await would let one slow read outlive the
+    whole budget — or hang forever.
+    """
     loop = asyncio.get_running_loop()
     while True:
-        snapshot = await job_manager.get_snapshot(job_id)
+        if expiry is None:
+            snapshot = await job_manager.get_snapshot(job_id)
+        else:
+            remaining = expiry - loop.time()
+            if remaining <= 0:
+                return None
+            try:
+                snapshot = await asyncio.wait_for(
+                    job_manager.get_snapshot(job_id), timeout=remaining
+                )
+            except TimeoutError:
+                return None
         if snapshot.is_terminal:
             return snapshot
         if expiry is not None and loop.time() >= expiry:
             return None
-        remaining = poll_seconds if expiry is None else min(poll_seconds, expiry - loop.time())
-        await asyncio.sleep(max(0.0, remaining))
+        remaining_sleep = (
+            poll_seconds if expiry is None else min(poll_seconds, expiry - loop.time())
+        )
+        await asyncio.sleep(max(0.0, remaining_sleep))

--- a/src/ouroboros/auto/chain_follower.py
+++ b/src/ouroboros/auto/chain_follower.py
@@ -104,6 +104,16 @@ _EXPECTED_JOB_TYPES: dict[str, str] = {
     "ralph": "ralph",
 }
 MISMATCHED_LINK_STATUS = "link_type_mismatch"
+# Type alone does not prove *this* chain produced the job: a stale handle can
+# name an unrelated but perfectly valid evaluation. Each successor is therefore
+# also bound to an identity its predecessor published — the run's session for
+# the evaluation, the evaluation's lineage for Ralph. Reading (predecessor key,
+# successor key) per link keeps the binding a lookup rather than a special case.
+_LINK_BINDINGS: dict[str, tuple[str, str]] = {
+    "evaluate": ("session_id", "session_id"),
+    "ralph": ("chained_ralph_lineage_id", "lineage_id"),
+}
+UNBOUND_LINK_STATUS = "link_identity_mismatch"
 # A successor handle is a cross-job reference into durable state. It can name a
 # job that no longer exists (pruned history, a different store, a mis-copied
 # id), and ``JobManager.get_snapshot`` raises for an unknown id. The walk fails
@@ -136,6 +146,7 @@ async def follow_run_chain(
     followed: list[str] = []
     job_id = run_job_id
     depth = 0
+    previous_meta: dict[str, Any] = {}
     terminal: ChainTerminal | None = None
 
     while True:
@@ -161,6 +172,15 @@ async def follow_run_chain(
                 followed_job_ids=tuple(followed),
             )
         meta = dict(snapshot.result_meta or {})
+        if not _binds_to_predecessor(kind, previous_meta, meta):
+            # An unauthenticated link decides nothing: this boundary grants
+            # approval, so an identity that cannot be matched fails closed.
+            return ChainTerminal(
+                job_id=job_id,
+                job_kind=kind,
+                status=UNBOUND_LINK_STATUS,
+                followed_job_ids=tuple(followed),
+            )
         terminal = ChainTerminal(
             job_id=job_id,
             job_kind=kind,
@@ -173,7 +193,20 @@ async def follow_run_chain(
         if successor is None:
             return terminal
         job_id = successor
+        previous_meta = meta
         depth += 1
+
+
+def _binds_to_predecessor(kind: str, previous_meta: dict[str, Any], meta: dict[str, Any]) -> bool:
+    """Return whether this link carries the identity its predecessor published."""
+    binding = _LINK_BINDINGS.get(kind)
+    if binding is None:
+        return True  # the root run has no predecessor to bind to
+    expected = previous_meta.get(binding[0])
+    observed = meta.get(binding[1])
+    if not isinstance(expected, str) or not expected.strip():
+        return False
+    return observed == expected
 
 
 def _next_job_id(meta: dict[str, Any], depth: int) -> str | None:

--- a/tests/unit/auto/test_chain_follower.py
+++ b/tests/unit/auto/test_chain_follower.py
@@ -10,6 +10,7 @@ import pytest
 
 from ouroboros.auto.chain_follower import (
     MISMATCHED_LINK_STATUS,
+    UNAVAILABLE_LINK_STATUS,
     RALPH_APPROVED_STOP_REASON,
     ChainTerminal,
     follow_run_chain,
@@ -56,6 +57,9 @@ class _FakeJobManager:
         delay = self._delays.get(job_id)
         if delay:
             await asyncio.sleep(delay)
+        if job_id not in self._timelines:
+            # Mirrors JobManager.get_snapshot for an unknown durable id.
+            raise ValueError(f"Job not found: {job_id}")
         timeline = self._timelines[job_id]
         return timeline.pop(0) if len(timeline) > 1 else timeline[0]
 
@@ -264,3 +268,29 @@ async def test_deadline_returns_handles_instead_of_losing_the_chain() -> None:
     assert terminal.status == "timed_out"
     assert terminal.followed_job_ids == ("job_run",)
     assert isinstance(terminal, ChainTerminal)
+
+
+@pytest.mark.asyncio
+async def test_a_successor_handle_naming_no_readable_job_fails_closed() -> None:
+    """A handle can outlive the job it names; that must not lose the chain.
+
+    Successor ids are cross-job references into durable state — pruned history,
+    a different store, or a mis-copied id all resolve to nothing, and
+    ``JobManager.get_snapshot`` raises for an unknown id. The walk must return a
+    non-approving terminal that keeps its handles rather than propagate that
+    exception to the caller.
+    """
+    manager = _FakeJobManager(
+        {
+            "job_run": [
+                _FakeSnapshot("job_run", "completed", "ran", {"chained_evaluate_job_id": "missing"})
+            ]
+        }
+    )
+
+    terminal = await follow_run_chain(manager, "job_run", poll_seconds=0.0)
+
+    assert terminal.status == UNAVAILABLE_LINK_STATUS
+    assert terminal.job_kind == "evaluate"
+    assert terminal.approved is False
+    assert terminal.followed_job_ids == ("job_run", "missing")

--- a/tests/unit/auto/test_chain_follower.py
+++ b/tests/unit/auto/test_chain_follower.py
@@ -2,16 +2,22 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from typing import Any
 
 import pytest
 
 from ouroboros.auto.chain_follower import (
+    MISMATCHED_LINK_STATUS,
     RALPH_APPROVED_STOP_REASON,
     ChainTerminal,
     follow_run_chain,
 )
+
+# Durable job types for the scripted chain, so tests exercise the same
+# link-identity check production reads from persistence.
+_DEFAULT_JOB_TYPES = {"job_run": "execute_seed", "job_ev": "evaluate", "job_ralph": "ralph"}
 
 
 @dataclass
@@ -21,6 +27,11 @@ class _FakeSnapshot:
     result_text: str | None = None
     result_meta: dict[str, Any] = field(default_factory=dict)
     terminal: bool = True
+    job_type: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.job_type:
+            self.job_type = _DEFAULT_JOB_TYPES.get(self.job_id, "execute_seed")
 
     @property
     def is_terminal(self) -> bool:
@@ -28,14 +39,23 @@ class _FakeSnapshot:
 
 
 class _FakeJobManager:
-    """Serves a scripted snapshot sequence per job id."""
+    """Serves a scripted snapshot sequence per job id, optionally slowly."""
 
-    def __init__(self, timelines: dict[str, list[_FakeSnapshot]]) -> None:
+    def __init__(
+        self,
+        timelines: dict[str, list[_FakeSnapshot]],
+        *,
+        read_delay_seconds: dict[str, float] | None = None,
+    ) -> None:
         self._timelines = {job_id: list(items) for job_id, items in timelines.items()}
+        self._delays = read_delay_seconds or {}
         self.calls: list[str] = []
 
     async def get_snapshot(self, job_id: str) -> _FakeSnapshot:
         self.calls.append(job_id)
+        delay = self._delays.get(job_id)
+        if delay:
+            await asyncio.sleep(delay)
         timeline = self._timelines[job_id]
         return timeline.pop(0) if len(timeline) > 1 else timeline[0]
 
@@ -170,12 +190,67 @@ async def test_deadline_preserves_the_deepest_handles_reached() -> None:
         }
     )
 
-    terminal = await follow_run_chain(manager, "job_run", poll_seconds=0.0, deadline_seconds=0.0)
+    terminal = await follow_run_chain(manager, "job_run", poll_seconds=0.0, deadline_seconds=0.05)
 
     assert terminal.status == "timed_out"
     assert terminal.job_kind == "ralph"
     assert terminal.followed_job_ids == ("job_run", "job_ev", "job_ralph")
     assert terminal.approved is False
+
+
+@pytest.mark.asyncio
+async def test_a_slow_snapshot_read_cannot_outlive_the_deadline() -> None:
+    """The read itself is bounded, not just the interval between reads.
+
+    A snapshot served from persistence or a reconciliation path can block; a
+    deadline enforced only after the await would let one read outlive the whole
+    budget, or hang forever.
+    """
+    manager = _FakeJobManager(
+        {"job_run": [_FakeSnapshot("job_run", "completed", "ran", {})]},
+        read_delay_seconds={"job_run": 5.0},
+    )
+
+    terminal = await asyncio.wait_for(
+        follow_run_chain(manager, "job_run", poll_seconds=0.0, deadline_seconds=0.05),
+        timeout=2.0,
+    )
+
+    assert terminal.status == "timed_out"
+    assert terminal.followed_job_ids == ("job_run",)
+
+
+@pytest.mark.asyncio
+async def test_a_successor_handle_pointing_at_the_wrong_job_is_refused() -> None:
+    """A successor handle is just a string on someone else's result meta.
+
+    A stale or misdirected id can name any completed job; identifying the link
+    by traversal depth alone would let that job's ``final_approved`` be read as
+    this chain's evaluation verdict.
+    """
+    manager = _FakeJobManager(
+        {
+            "job_run": [
+                _FakeSnapshot("job_run", "completed", "ran", {"chained_evaluate_job_id": "job_ev"})
+            ],
+            # The handle resolves to another execution, not an evaluation.
+            "job_ev": [
+                _FakeSnapshot(
+                    "job_ev",
+                    "completed",
+                    "someone else's run",
+                    {"final_approved": True},
+                    job_type="execute_seed",
+                )
+            ],
+        }
+    )
+
+    terminal = await follow_run_chain(manager, "job_run", poll_seconds=0.0)
+
+    assert terminal.status == MISMATCHED_LINK_STATUS
+    assert terminal.approved is False
+    assert terminal.result_meta["observed_job_type"] == "execute_seed"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_chain_follower.py
+++ b/tests/unit/auto/test_chain_follower.py
@@ -11,6 +11,7 @@ import pytest
 from ouroboros.auto.chain_follower import (
     MISMATCHED_LINK_STATUS,
     UNAVAILABLE_LINK_STATUS,
+    UNBOUND_LINK_STATUS,
     RALPH_APPROVED_STOP_REASON,
     ChainTerminal,
     follow_run_chain,
@@ -69,14 +70,24 @@ async def test_follows_run_to_evaluate_to_ralph() -> None:
     manager = _FakeJobManager(
         {
             "job_run": [
-                _FakeSnapshot("job_run", "completed", "ran", {"chained_evaluate_job_id": "job_ev"})
+                _FakeSnapshot(
+                    "job_run",
+                    "completed",
+                    "ran",
+                    {"session_id": "orch_1", "chained_evaluate_job_id": "job_ev"},
+                )
             ],
             "job_ev": [
                 _FakeSnapshot(
                     "job_ev",
                     "completed",
                     "judged",
-                    {"final_approved": False, "chained_ralph_job_id": "job_ralph"},
+                    {
+                        "session_id": "orch_1",
+                        "final_approved": False,
+                        "chained_ralph_lineage_id": "lin_1",
+                        "chained_ralph_job_id": "job_ralph",
+                    },
                 )
             ],
             "job_ralph": [
@@ -84,7 +95,7 @@ async def test_follows_run_to_evaluate_to_ralph() -> None:
                     "job_ralph",
                     "completed",
                     "converged",
-                    {"stop_reason": RALPH_APPROVED_STOP_REASON},
+                    {"lineage_id": "lin_1", "stop_reason": RALPH_APPROVED_STOP_REASON},
                 )
             ],
         }
@@ -104,9 +115,21 @@ async def test_stops_where_the_chain_stops() -> None:
     manager = _FakeJobManager(
         {
             "job_run": [
-                _FakeSnapshot("job_run", "completed", "ran", {"chained_evaluate_job_id": "job_ev"})
+                _FakeSnapshot(
+                    "job_run",
+                    "completed",
+                    "ran",
+                    {"session_id": "orch_1", "chained_evaluate_job_id": "job_ev"},
+                )
             ],
-            "job_ev": [_FakeSnapshot("job_ev", "completed", "judged", {"final_approved": True})],
+            "job_ev": [
+                _FakeSnapshot(
+                    "job_ev",
+                    "completed",
+                    "judged",
+                    {"session_id": "orch_1", "final_approved": True},
+                )
+            ],
         }
     )
 
@@ -132,19 +155,32 @@ async def test_budget_terminal_is_not_approval() -> None:
     manager = _FakeJobManager(
         {
             "job_run": [
-                _FakeSnapshot("job_run", "completed", "ran", {"chained_evaluate_job_id": "job_ev"})
+                _FakeSnapshot(
+                    "job_run",
+                    "completed",
+                    "ran",
+                    {"session_id": "orch_1", "chained_evaluate_job_id": "job_ev"},
+                )
             ],
             "job_ev": [
                 _FakeSnapshot(
                     "job_ev",
                     "completed",
                     "judged",
-                    {"final_approved": False, "chained_ralph_job_id": "job_ralph"},
+                    {
+                        "session_id": "orch_1",
+                        "final_approved": False,
+                        "chained_ralph_lineage_id": "lin_1",
+                        "chained_ralph_job_id": "job_ralph",
+                    },
                 )
             ],
             "job_ralph": [
                 _FakeSnapshot(
-                    "job_ralph", "failed", "gave up", {"stop_reason": "max_generations reached"}
+                    "job_ralph",
+                    "failed",
+                    "gave up",
+                    {"lineage_id": "lin_1", "stop_reason": "max_generations reached"},
                 )
             ],
         }
@@ -165,7 +201,7 @@ async def test_budget_terminal_is_not_approval() -> None:
         ("ralph", "completed", {"final_approved": True}),
         # A link that did not finish cleanly never approves, whatever it carries.
         ("evaluate", "failed", {"final_approved": True}),
-        ("ralph", "failed", {"stop_reason": RALPH_APPROVED_STOP_REASON}),
+        ("ralph", "failed", {"lineage_id": "lin_1", "stop_reason": RALPH_APPROVED_STOP_REASON}),
     ],
 )
 def test_only_the_owning_link_can_approve(job_kind: str, status: str, meta: dict[str, Any]) -> None:
@@ -180,14 +216,24 @@ async def test_deadline_preserves_the_deepest_handles_reached() -> None:
     manager = _FakeJobManager(
         {
             "job_run": [
-                _FakeSnapshot("job_run", "completed", "ran", {"chained_evaluate_job_id": "job_ev"})
+                _FakeSnapshot(
+                    "job_run",
+                    "completed",
+                    "ran",
+                    {"session_id": "orch_1", "chained_evaluate_job_id": "job_ev"},
+                )
             ],
             "job_ev": [
                 _FakeSnapshot(
                     "job_ev",
                     "completed",
                     "judged",
-                    {"final_approved": False, "chained_ralph_job_id": "job_ralph"},
+                    {
+                        "session_id": "orch_1",
+                        "final_approved": False,
+                        "chained_ralph_lineage_id": "lin_1",
+                        "chained_ralph_job_id": "job_ralph",
+                    },
                 )
             ],
             "job_ralph": [_FakeSnapshot("job_ralph", "running", terminal=False)],
@@ -235,7 +281,12 @@ async def test_a_successor_handle_pointing_at_the_wrong_job_is_refused() -> None
     manager = _FakeJobManager(
         {
             "job_run": [
-                _FakeSnapshot("job_run", "completed", "ran", {"chained_evaluate_job_id": "job_ev"})
+                _FakeSnapshot(
+                    "job_run",
+                    "completed",
+                    "ran",
+                    {"session_id": "orch_1", "chained_evaluate_job_id": "job_ev"},
+                )
             ],
             # The handle resolves to another execution, not an evaluation.
             "job_ev": [
@@ -243,7 +294,7 @@ async def test_a_successor_handle_pointing_at_the_wrong_job_is_refused() -> None
                     "job_ev",
                     "completed",
                     "someone else's run",
-                    {"final_approved": True},
+                    {"session_id": "orch_1", "final_approved": True},
                     job_type="execute_seed",
                 )
             ],
@@ -294,3 +345,82 @@ async def test_a_successor_handle_naming_no_readable_job_fails_closed() -> None:
     assert terminal.job_kind == "evaluate"
     assert terminal.approved is False
     assert terminal.followed_job_ids == ("job_run", "missing")
+
+
+@pytest.mark.asyncio
+async def test_a_valid_evaluation_from_another_chain_is_refused() -> None:
+    """Type alone does not prove *this* chain produced the job.
+
+    A stale handle can name an unrelated but perfectly valid evaluation whose
+    ``final_approved`` would otherwise be accepted as this run's verdict, so the
+    link must also carry the identity its predecessor published.
+    """
+    manager = _FakeJobManager(
+        {
+            "job_run": [
+                _FakeSnapshot(
+                    "job_run",
+                    "completed",
+                    "ran",
+                    {"session_id": "orch_1", "chained_evaluate_job_id": "job_ev"},
+                )
+            ],
+            # A real evaluation — of somebody else's run.
+            "job_ev": [
+                _FakeSnapshot(
+                    "job_ev",
+                    "completed",
+                    "judged",
+                    {"session_id": "orch_other", "final_approved": True},
+                )
+            ],
+        }
+    )
+
+    terminal = await follow_run_chain(manager, "job_run", poll_seconds=0.0)
+
+    assert terminal.status == UNBOUND_LINK_STATUS
+    assert terminal.approved is False
+
+
+@pytest.mark.asyncio
+async def test_a_ralph_job_from_another_lineage_is_refused() -> None:
+    """The Ralph link is bound to the lineage the evaluation published."""
+    manager = _FakeJobManager(
+        {
+            "job_run": [
+                _FakeSnapshot(
+                    "job_run",
+                    "completed",
+                    "ran",
+                    {"session_id": "orch_1", "chained_evaluate_job_id": "job_ev"},
+                )
+            ],
+            "job_ev": [
+                _FakeSnapshot(
+                    "job_ev",
+                    "completed",
+                    "judged",
+                    {
+                        "session_id": "orch_1",
+                        "final_approved": False,
+                        "chained_ralph_lineage_id": "lin_1",
+                        "chained_ralph_job_id": "job_ralph",
+                    },
+                )
+            ],
+            "job_ralph": [
+                _FakeSnapshot(
+                    "job_ralph",
+                    "completed",
+                    "converged",
+                    {"lineage_id": "lin_other", "stop_reason": RALPH_APPROVED_STOP_REASON},
+                )
+            ],
+        }
+    )
+
+    terminal = await follow_run_chain(manager, "job_run", poll_seconds=0.0)
+
+    assert terminal.status == UNBOUND_LINK_STATUS
+    assert terminal.approved is False

--- a/tests/unit/auto/test_chain_follower.py
+++ b/tests/unit/auto/test_chain_follower.py
@@ -1,0 +1,145 @@
+"""Auto follows the run job's own successor chain instead of owning a second one."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from ouroboros.auto.chain_follower import (
+    RALPH_APPROVED_STOP_REASON,
+    ChainTerminal,
+    follow_run_chain,
+)
+
+
+@dataclass
+class _FakeSnapshot:
+    job_id: str
+    status: str
+    result_text: str | None = None
+    result_meta: dict[str, Any] = field(default_factory=dict)
+    terminal: bool = True
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.terminal
+
+
+class _FakeJobManager:
+    """Serves a scripted snapshot sequence per job id."""
+
+    def __init__(self, timelines: dict[str, list[_FakeSnapshot]]) -> None:
+        self._timelines = {job_id: list(items) for job_id, items in timelines.items()}
+        self.calls: list[str] = []
+
+    async def get_snapshot(self, job_id: str) -> _FakeSnapshot:
+        self.calls.append(job_id)
+        timeline = self._timelines[job_id]
+        return timeline.pop(0) if len(timeline) > 1 else timeline[0]
+
+
+@pytest.mark.asyncio
+async def test_follows_run_to_evaluate_to_ralph() -> None:
+    manager = _FakeJobManager(
+        {
+            "job_run": [
+                _FakeSnapshot("job_run", "completed", "ran", {"chained_evaluate_job_id": "job_ev"})
+            ],
+            "job_ev": [
+                _FakeSnapshot(
+                    "job_ev",
+                    "completed",
+                    "judged",
+                    {"final_approved": False, "chained_ralph_job_id": "job_ralph"},
+                )
+            ],
+            "job_ralph": [
+                _FakeSnapshot(
+                    "job_ralph",
+                    "completed",
+                    "converged",
+                    {"stop_reason": RALPH_APPROVED_STOP_REASON},
+                )
+            ],
+        }
+    )
+
+    terminal = await follow_run_chain(manager, "job_run", poll_seconds=0.0)
+
+    assert terminal.job_kind == "ralph"
+    assert terminal.job_id == "job_ralph"
+    assert terminal.approved is True
+    assert terminal.followed_job_ids == ("job_run", "job_ev", "job_ralph")
+
+
+@pytest.mark.asyncio
+async def test_stops_where_the_chain_stops() -> None:
+    """An approving evaluation publishes no Ralph handle, so the walk ends there."""
+    manager = _FakeJobManager(
+        {
+            "job_run": [
+                _FakeSnapshot("job_run", "completed", "ran", {"chained_evaluate_job_id": "job_ev"})
+            ],
+            "job_ev": [_FakeSnapshot("job_ev", "completed", "judged", {"final_approved": True})],
+        }
+    )
+
+    terminal = await follow_run_chain(manager, "job_run", poll_seconds=0.0)
+
+    assert terminal.job_kind == "evaluate"
+    assert terminal.approved is True
+
+
+@pytest.mark.asyncio
+async def test_finished_run_alone_is_not_approval() -> None:
+    """Execution finishing is not a verdict — that conflation is what the chain removes."""
+    manager = _FakeJobManager({"job_run": [_FakeSnapshot("job_run", "completed", "ran", {})]})
+
+    terminal = await follow_run_chain(manager, "job_run", poll_seconds=0.0)
+
+    assert terminal.job_kind == "run"
+    assert terminal.approved is False
+
+
+@pytest.mark.asyncio
+async def test_budget_terminal_is_not_approval() -> None:
+    manager = _FakeJobManager(
+        {
+            "job_run": [
+                _FakeSnapshot("job_run", "completed", "ran", {"chained_evaluate_job_id": "job_ev"})
+            ],
+            "job_ev": [
+                _FakeSnapshot(
+                    "job_ev",
+                    "completed",
+                    "judged",
+                    {"final_approved": False, "chained_ralph_job_id": "job_ralph"},
+                )
+            ],
+            "job_ralph": [
+                _FakeSnapshot(
+                    "job_ralph", "failed", "gave up", {"stop_reason": "max_generations reached"}
+                )
+            ],
+        }
+    )
+
+    terminal = await follow_run_chain(manager, "job_run", poll_seconds=0.0)
+
+    assert terminal.status == "failed"
+    assert terminal.approved is False
+
+
+@pytest.mark.asyncio
+async def test_deadline_returns_handles_instead_of_losing_the_chain() -> None:
+    manager = _FakeJobManager(
+        {"job_run": [_FakeSnapshot("job_run", "running", terminal=False)]},
+    )
+
+    terminal = await follow_run_chain(manager, "job_run", poll_seconds=0.0, deadline_seconds=0.0)
+
+    assert terminal.status == "timed_out"
+    assert terminal.followed_job_ids == ("job_run",)
+    assert isinstance(terminal, ChainTerminal)

--- a/tests/unit/auto/test_chain_follower.py
+++ b/tests/unit/auto/test_chain_follower.py
@@ -132,6 +132,52 @@ async def test_budget_terminal_is_not_approval() -> None:
     assert terminal.approved is False
 
 
+@pytest.mark.parametrize(
+    ("job_kind", "status", "meta"),
+    [
+        # Result meta is merged and forwarded along the chain, so a link must
+        # never inherit a verdict issued by a different link.
+        ("run", "completed", {"final_approved": True}),
+        ("ralph", "completed", {"final_approved": True}),
+        # A link that did not finish cleanly never approves, whatever it carries.
+        ("evaluate", "failed", {"final_approved": True}),
+        ("ralph", "failed", {"stop_reason": RALPH_APPROVED_STOP_REASON}),
+    ],
+)
+def test_only_the_owning_link_can_approve(job_kind: str, status: str, meta: dict[str, Any]) -> None:
+    terminal = ChainTerminal(job_id="job_x", job_kind=job_kind, status=status, result_meta=meta)
+
+    assert terminal.approved is False
+
+
+@pytest.mark.asyncio
+async def test_deadline_preserves_the_deepest_handles_reached() -> None:
+    """A timeout deep in the chain must keep every handle needed to resume."""
+    manager = _FakeJobManager(
+        {
+            "job_run": [
+                _FakeSnapshot("job_run", "completed", "ran", {"chained_evaluate_job_id": "job_ev"})
+            ],
+            "job_ev": [
+                _FakeSnapshot(
+                    "job_ev",
+                    "completed",
+                    "judged",
+                    {"final_approved": False, "chained_ralph_job_id": "job_ralph"},
+                )
+            ],
+            "job_ralph": [_FakeSnapshot("job_ralph", "running", terminal=False)],
+        }
+    )
+
+    terminal = await follow_run_chain(manager, "job_run", poll_seconds=0.0, deadline_seconds=0.0)
+
+    assert terminal.status == "timed_out"
+    assert terminal.job_kind == "ralph"
+    assert terminal.followed_job_ids == ("job_run", "job_ev", "job_ralph")
+    assert terminal.approved is False
+
+
 @pytest.mark.asyncio
 async def test_deadline_returns_handles_instead_of_losing_the_chain() -> None:
     manager = _FakeJobManager(

--- a/tests/unit/auto/test_chain_follower.py
+++ b/tests/unit/auto/test_chain_follower.py
@@ -10,9 +10,9 @@ import pytest
 
 from ouroboros.auto.chain_follower import (
     MISMATCHED_LINK_STATUS,
+    RALPH_APPROVED_STOP_REASON,
     UNAVAILABLE_LINK_STATUS,
     UNBOUND_LINK_STATUS,
-    RALPH_APPROVED_STOP_REASON,
     ChainTerminal,
     follow_run_chain,
 )


### PR DESCRIPTION
## Summary

Groundwork for #2118. Auto's complete-product mode re-implements the successor policy `ooo run` already owns — a private `RALPH_HANDOFF → EVALUATE` path with a different judge — which is how the product ended up with four incompatible definitions of "done".

This adds the piece that lets Auto reuse the run chain instead of owning a second one: a follower that walks the successor handles the chain publishes on each job's result meta (`chained_evaluate_job_id` → `chained_ralph_job_id`) and reports the terminal of the deepest link it reached.

The approval rule is the substance of the module:

```python
# a `completed` run job is NOT approval
if self.result_meta.get("final_approved") is True:
    return True
return self.job_kind == "ralph" and self.result_meta.get("stop_reason") == RALPH_APPROVED_STOP_REASON
```

Execution finishing is not a verdict. That conflation is exactly what lets a Ralph terminal count as a passing product in the CLI and plugin-mode complete-product paths today, where no evaluator is wired at all. `RALPH_APPROVED_STOP_REASON` is pinned to `"qa passed"` (`ralph_loop.py:305`) so the check can never drift into matching a budget terminal like `max_generations reached`.

A deadline returns the handles gathered so far with `status="timed_out"` rather than dropping the chain, so a caller can resume rather than lose the successors.

**Nothing here starts work.** The chain is started by the run job itself; this only observes, so the module is inert until a caller waits on it. Wiring complete-product to it — and deleting `_handoff_to_ralph`, `_resume_ralph_handoff`, Auto's `_run_evaluate` and `HandlerEvaluator` (~1.3k lines) — is the follow-up.

## Test plan

- [x] `uv run pytest tests/unit/auto/test_chain_follower.py -q` — 5 passed
- [x] `uv run pytest tests/unit -q` — 20148 passed, 88 skipped
- [x] `uv run ruff check src/ tests/` and `ruff format --check` clean
- [x] `uv run mypy src/` clean

Covers: the full run → evaluate → ralph walk; stopping where the chain stops (an approving evaluation publishes no Ralph handle); a finished run alone not counting as approval; a budget terminal not counting as approval; and a deadline returning handles instead of losing them.

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [ ] within 1.5× / [ ] regression flagged with mitigation /
[x] N/A (no per-round comparison applies)

New module with no call sites; no existing code path changes behaviour.

## Related issues

Refs #2118
