### PR TITLE
docs(readme): add one-line install above the hero demo table

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -40,6 +40,12 @@
   <a href="https://ouroboros.page/learn/">가이드</a>
 </p>
 
+```bash
+curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | OUROBOROS_INSTALL_REF=readme-hero-ko bash
+```
+
+<p align="center"><sub>설치는 위 한 줄입니다. 이후 코딩 에이전트 안에서 <code>ooo setup</code>을 한 번 실행하세요. 자세한 내용은 <a href="#빠른-시작">빠른 시작</a>에 있습니다.</sub></p>
+
 <p align="center"><sub><b>서로 다른 네 번의 실행, 네 개의 호스트. 과제가 다른 건 의도한 것입니다 — 공유되는 건 엔진이지 프롬프트가 아닙니다</b></sub></p>
 
 <table align="center">

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@
   <a href="https://ouroboros.page/learn/en/">Guide</a>
 </p>
 
+```bash
+curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | OUROBOROS_INSTALL_REF=readme-hero bash
+```
+
+<p align="center"><sub>One command installs it. Then run <code>ooo setup</code> once inside your coding agent — details in <a href="#quick-start">Quick Start</a>.</sub></p>
+
 <p align="center"><sub><b>Four separate runs, four hosts. Different tasks on purpose — the engine is what is shared, not the prompt</b></sub></p>
 
 <table align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,6 +41,12 @@
   <a href="https://ouroboros.page/learn/zh/">指南</a>
 </p>
 
+```bash
+curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | OUROBOROS_INSTALL_REF=readme-hero-zh bash
+```
+
+<p align="center"><sub>一行命令完成安装。然后在你的编码 agent 里运行一次 <code>ooo setup</code>，详见<a href="#快速开始">快速开始</a>。</sub></p>
+
 <p align="center"><sub><b>四次各自独立的运行，四个宿主。任务不同是故意的——共享的是引擎，不是提示词</b></sub></p>
 
 <table align="center">


### PR DESCRIPTION
Refs #2123

## What

Adds the canonical installer one-liner to the hero of all three README locales (en / ko / zh-CN), right above the demo GIF table. 6 lines per file, no other changes.

## Why

- The install command first appears in **Quick Start (~line 130)** — below the fold on every locale. A visitor who is convinced by the hero demos has to scroll to find out how to try it.
- Activation data shows the funnel's real cliff is **install → `setup`** (installs without setup rarely reach a first command), so the hero caption names `ooo setup` as the required next step instead of stopping at install.

## Measurement

Each locale's hero line carries its own `OUROBOROS_INSTALL_REF` (`readme-hero` / `readme-hero-ko` / `readme-hero-zh`), so hero-attributed installs are separable from the existing Quick Start refs (`readme` / `readme-ko` / `readme-zh`). `install.sh` treats the ref as a free-form channel tag (`INSTALL_REF=${OUROBOROS_INSTALL_REF:-direct}`), so no installer change is needed.

## Not changed

Quick Start keeps its existing refs and remains the detailed path (the hero caption links to it). No copy elsewhere touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnvN3DjJZZTtyj7X4jWTCa
