### PR TITLE
fix(auto): stop calling a Seed that never ran a verified product

### DIFF
--- a/src/ouroboros/auto/artifact_state.py
+++ b/src/ouroboros/auto/artifact_state.py
@@ -1,0 +1,52 @@
+"""Classify what an Auto session actually produced, separately from its status.
+
+``status`` answers "what did the orchestration do?"; this answers "what exists,
+and was it checked?". Keeping them apart is what stops a renderer from implying
+completion when a BLOCKED run still left useful files behind — or, in the other
+direction, from calling a Seed that never ran a verified product.
+"""
+
+from __future__ import annotations
+
+from ouroboros.auto.handoff_contract import RUN_HANDOFF_STARTED_STATUS
+from ouroboros.auto.state import AutoPhase
+
+COMPLETE_VERIFIED = "complete_verified"
+COMPLETE_UNVERIFIED = "complete_unverified"
+PARTIAL_ARTIFACT_GENERATED = "partial_artifact_generated"
+ARTIFACT_IN_PROGRESS = "artifact_in_progress"
+NOT_GENERATED = "not_generated"
+
+
+def artifact_state_for_result(
+    *,
+    status: str,
+    phase: AutoPhase,
+    seed_path: str | None,
+    execution_id: str | None,
+    job_id: str | None,
+    run_session_id: str | None,
+    partial_product: bool,
+    run_handoff_status: str | None = None,
+    product_verified: bool = False,
+) -> str:
+    """Classify the generated-artifact outcome separately from orchestration."""
+    has_run = bool(execution_id or job_id or run_session_id)
+    has_generated_artifact = bool(seed_path) or has_run
+    if status in {AutoPhase.BLOCKED.value, AutoPhase.FAILED.value}:
+        return PARTIAL_ARTIFACT_GENERATED if has_generated_artifact else status
+    if status == AutoPhase.COMPLETE.value:
+        if partial_product:
+            return COMPLETE_UNVERIFIED
+        if product_verified:
+            return COMPLETE_VERIFIED
+        # Nothing ran, or the run was only handed off: there is no product whose
+        # verification could have happened. A skip-run session completes with a
+        # Seed, and calling that "verified" is how a renderer ends up printing
+        # "Product status: verified" for work that was never executed.
+        if not has_run or run_handoff_status == RUN_HANDOFF_STARTED_STATUS:
+            return COMPLETE_UNVERIFIED
+        return COMPLETE_VERIFIED
+    if phase in {AutoPhase.BLOCKED, AutoPhase.FAILED}:
+        return PARTIAL_ARTIFACT_GENERATED if has_generated_artifact else phase.value
+    return ARTIFACT_IN_PROGRESS if has_generated_artifact else NOT_GENERATED

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -19,6 +19,7 @@ import yaml
 
 from ouroboros.auto.adapters import EvaluateResult, LateralResult
 from ouroboros.auto.answerer import AutoAnswerer
+from ouroboros.auto.artifact_state import artifact_state_for_result as _artifact_state_for_result
 from ouroboros.auto.blocker_attribution import record_authoring_backend
 from ouroboros.auto.checkpoint_commits import checkpoint_final_auto
 from ouroboros.auto.domain_inference import derive_domain_from_ledger
@@ -4640,41 +4641,6 @@ class AutoPipeline:
         except Exception:
             # Observers must never break the pipeline. Swallow callback errors.
             pass
-
-
-def _artifact_state_for_result(
-    *,
-    status: str,
-    phase: AutoPhase,
-    seed_path: str | None,
-    execution_id: str | None,
-    job_id: str | None,
-    run_session_id: str | None,
-    partial_product: bool,
-    run_handoff_status: str | None = None,
-    product_verified: bool = False,
-) -> str:
-    """Classify the generated-artifact outcome separately from orchestration.
-
-    ``status`` remains the authoritative orchestration state. This companion
-    value prevents final renderers from implying completion when a BLOCKED or
-    FAILED run still left useful generated files behind.
-    """
-
-    has_generated_artifact = bool(seed_path or execution_id or job_id or run_session_id)
-    if status in {AutoPhase.BLOCKED.value, AutoPhase.FAILED.value}:
-        return "partial_artifact_generated" if has_generated_artifact else status
-    if status == AutoPhase.COMPLETE.value:
-        if partial_product:
-            return "complete_unverified"
-        if product_verified:
-            return "complete_verified"
-        if run_handoff_status == RUN_HANDOFF_STARTED_STATUS:
-            return "complete_unverified"
-        return "complete_verified"
-    if phase in {AutoPhase.BLOCKED, AutoPhase.FAILED}:
-        return "partial_artifact_generated" if has_generated_artifact else phase.value
-    return "artifact_in_progress" if has_generated_artifact else "not_generated"
 
 
 def _has_verified_product_completion(state: AutoPipelineState) -> bool:

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -2766,3 +2766,48 @@ def test_auto_handler_surfaces_orchestration_and_artifact_state_for_blocked_resu
     assert "Status: blocked" in text
     assert "Artifact state: partial_artifact_generated" in text
     assert "Status: complete" not in text
+
+
+def test_auto_artifact_state_does_not_call_a_seed_that_never_ran_verified() -> None:
+    """A skip-run session completes with a Seed, not with a verified product.
+
+    Nothing executed, so there is no product whose verification could have
+    happened; reporting `complete_verified` is how a renderer ends up printing
+    "Product status: verified" for work that was never run.
+    """
+    from ouroboros.auto.artifact_state import artifact_state_for_result
+
+    assert (
+        artifact_state_for_result(
+            status="complete",
+            phase=AutoPhase.COMPLETE,
+            seed_path="/tmp/seed.yaml",
+            execution_id=None,
+            job_id=None,
+            run_session_id=None,
+            partial_product=False,
+            run_handoff_status=None,
+            product_verified=False,
+        )
+        == "complete_unverified"
+    )
+
+
+def test_auto_artifact_state_still_verifies_a_completed_run() -> None:
+    """The narrowing must not withhold verification from work that did run."""
+    from ouroboros.auto.artifact_state import artifact_state_for_result
+
+    assert (
+        artifact_state_for_result(
+            status="complete",
+            phase=AutoPhase.COMPLETE,
+            seed_path="/tmp/seed.yaml",
+            execution_id="exec_123",
+            job_id="job_123",
+            run_session_id=None,
+            partial_product=False,
+            run_handoff_status="completed",
+            product_verified=True,
+        )
+        == "complete_verified"
+    )


### PR DESCRIPTION
## Summary

`ooo auto --skip-run` stops after producing an A-grade Seed — nothing executes, no artifact is judged, no verdict exists. It reported `artifact_state="complete_verified"`.

That value is consumed as a product claim: renderers print "Product status: not verified complete" for its opposite, so `complete_verified` reads as "the product was checked and is good". `_artifact_state_for_result` fell through to it for any COMPLETE that was not a partial product and whose `run_handoff_status` was not `started`, with no verdict involved.

`complete_verified` now requires that something actually ran:

| session | before | after |
|---|---|---|
| skip-run (no execution at all) | `complete_verified` | **`complete_unverified`** |
| run handed off, still going | `complete_unverified` | `complete_unverified` |
| completed run / Ralph terminal / passing QA | `complete_verified` | `complete_verified` |

The verified paths are untouched — they all reach the value through `product_verified`.

The classifier moved to `auto/artifact_state.py`. It is a pure function with no pipeline state, `pipeline.py` is at its #1797 ratchet budget (so the gate's own instruction is to put the change in a new module), and the state vocabulary now has one home. `pipeline.py` keeps importing it under the old private name, so no call site changed.

## Provenance

Found while reviewing #2119. A reviewer attributed a `complete_verified` skip-run terminal to a stale `last_qa_passed=True`; that PR clears the stale verdict, and the outcome does **not** change — the fall-through produces it with no verdict at all. Separate defect, separate PR, rather than widening #2119 into the completion-state contract.

## Test plan

- [x] `uv run pytest tests/unit/auto tests/unit/cli/test_auto_command.py tests/unit/mcp/tools/test_start_auto.py -q` — 2082 passed
- [x] `uv run ruff check src/ tests/` and `ruff format --check` clean
- [x] `uv run mypy src/` clean (576 files)
- [x] `uv run python scripts/check-module-size.py` — OK

Notably no existing test asserted the old behaviour: nothing encoded "a skip-run session is verified". New tests pin both directions — a session that ran nothing is not verified, and a completed run still is.

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [ ] within 1.5× / [ ] regression flagged with mitigation /
[x] N/A (no per-round comparison applies)

A pure classifier moved between modules with one branch narrowed; no execution path or round loop is touched.

## Related issues

Fixes #2126
