### PR TITLE
fix(test): check every documented install one-liner, not just the first

### DIFF
--- a/tests/unit/test_install_ref_docs_contract.py
+++ b/tests/unit/test_install_ref_docs_contract.py
@@ -18,11 +18,15 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
+# Each surface may carry more than one one-liner (#2122 added a hero copy above
+# the demo table). Every occurrence is checked, not just the first: a `search`
+# that stops at the first match is how the hero copy landed without this
+# contract noticing it at all.
 DOC_SURFACES = {
-    "README.md": "readme",
-    "README.ko.md": "readme-ko",
-    "README.zh-CN.md": "readme-zh",
-    "docs/getting-started.md": "docs-getting-started",
+    "README.md": ("readme", "readme-hero"),
+    "README.ko.md": ("readme-ko", "readme-hero-ko"),
+    "README.zh-CN.md": ("readme-zh", "readme-hero-zh"),
+    "docs/getting-started.md": ("docs-getting-started",),
 }
 
 ONE_LINER_RE = re.compile(
@@ -31,14 +35,35 @@ ONE_LINER_RE = re.compile(
 )
 
 
-@pytest.mark.parametrize("doc_path,expected_token", sorted(DOC_SURFACES.items()))
-def test_install_ref_one_liner_puts_assignment_on_bash_side(
-    doc_path: str, expected_token: str
+@pytest.mark.parametrize("doc_path,expected_tokens", sorted(DOC_SURFACES.items()))
+def test_install_ref_one_liners_put_assignment_on_bash_side(
+    doc_path: str, expected_tokens: tuple[str, ...]
 ) -> None:
     text = (REPO_ROOT / doc_path).read_text(encoding="utf-8")
-    match = ONE_LINER_RE.search(text)
-    assert match, f"{doc_path} is missing the expected OUROBOROS_INSTALL_REF one-liner shape"
-    assert match.group("token") == expected_token
+    tokens = tuple(match.group("token") for match in ONE_LINER_RE.finditer(text))
+    assert tokens, f"{doc_path} is missing the expected OUROBOROS_INSTALL_REF one-liner shape"
+    assert sorted(tokens) == sorted(expected_tokens), (
+        f"{doc_path} one-liner attribution tokens drifted: {tokens!r}"
+    )
+
+
+@pytest.mark.parametrize("doc_path", sorted(DOC_SURFACES))
+def test_every_documented_install_command_uses_the_guarded_shape(doc_path: str) -> None:
+    """No install one-liner may exist outside the shape this file guards.
+
+    The token check above only sees commands that already match
+    ``ONE_LINER_RE``. A command written some other way would be invisible to it
+    — which is exactly the failure mode this file exists to prevent — so count
+    the raw mentions of the install script and require them all to be accounted
+    for.
+    """
+    text = (REPO_ROOT / doc_path).read_text(encoding="utf-8")
+    piped_to_bash = len(re.findall(r"scripts/install\.sh[^\n]*\|[^\n]*bash", text))
+    guarded = len(ONE_LINER_RE.findall(text))
+    assert piped_to_bash == guarded, (
+        f"{doc_path} pipes install.sh to bash {piped_to_bash} time(s) but only "
+        f"{guarded} match the guarded OUROBOROS_INSTALL_REF shape"
+    )
 
 
 @pytest.mark.parametrize("doc_path", sorted(DOC_SURFACES))


### PR DESCRIPTION
## Summary

`main` has been red since #2122, and every open PR inherits it because CI tests the merge with `main`.

#2122 added a second install one-liner above the hero demo table with its own attribution token (`readme-hero` / `readme-hero-ko` / `readme-hero-zh`). The contract used `ONE_LINER_RE.search(text)` — which stops at the first match — so it compared the *hero* token against the *body* token and failed on all three READMEs:

```
At index 6 diff: 'readme-hero' != 'readme'
```

## Why this isn't just "add the new token"

A `search`-based contract can only ever validate one command per file. That means:

- #2122's one-liner was **invisible** to this guard — it neither validated nor objected to it
- any future one-liner would be equally invisible
- a one-liner in the **broken** shape (`VAR=x curl ... | bash` — the exact bug this file exists to prevent, per its own docstring) would be missed whenever a correct one appears earlier in the file

The file's stated purpose is "so the mistake can't come back silently". It could.

## What changed

- token check enumerates **every** occurrence (`finditer`) and compares the full token set per surface
- new companion test counts raw `install.sh | ... bash` mentions and requires every one of them to match the guarded shape, so a command written some other way cannot go unseen

Both READMEs' hero tokens are now part of the declared contract rather than an accident that broke it.

## Test plan

- [x] `uv run pytest tests/unit/test_install_ref_docs_contract.py -q` — 14 passed (was 3 failed / 7 passed on `main`)
- [x] `uv run ruff check tests/` clean

Verified the diagnosis against `origin/main` rather than a local checkout: `README.md` carries `readme-hero` at line 50 and `readme` at line 141; `docs/getting-started.md` carries one token and was the only surface still passing.

## Impact

Unblocks merge on #2119, #2120, #2121, #2127, #2128.

## Related issues

Fixes #2129
