### PR TITLE
test(conftest): render logged exceptions with plain tracebacks in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,47 @@ def isolate_heartbeat_locks_per_test_worker(tmp_path_factory):
         heartbeat.CANCELLATION_DIR = previous_cancellation_dir
 
 
+@pytest.fixture(scope="session", autouse=True)
+def render_logged_exceptions_with_plain_tracebacks():
+    """Keep structlog's DEV renderer from paying rich+pygments per exception.
+
+    ``ConsoleRenderer(colors=True)`` defaults to rich's traceback formatter,
+    which syntax-highlights the source context of every frame. Failure-path
+    tests that log a real exception (event-store append failures, adapter
+    errors, ...) each paid multiple seconds of pygments tokenization for
+    output nobody reads under pytest. Render with the stdlib formatter
+    instead — same information, plain text. Production DEV output is
+    untouched; this only rewrites the renderer inside the test session.
+    """
+    import structlog
+
+    from ouroboros.observability import logging as obs_logging
+
+    def _plain_renderer() -> structlog.dev.ConsoleRenderer:
+        return structlog.dev.ConsoleRenderer(
+            colors=True, exception_formatter=structlog.dev.plain_traceback
+        )
+
+    def _swap_in_place(processors: list) -> list:
+        for index, processor in enumerate(processors):
+            if isinstance(processor, structlog.dev.ConsoleRenderer):
+                # In-place: capture_logs() shares this exact list object.
+                processors[index] = _plain_renderer()
+        return processors
+
+    original_get_console_processors = obs_logging._get_console_processors
+
+    def _plain_console_processors(mode):
+        return _swap_in_place(original_get_console_processors(mode))
+
+    _swap_in_place(obs_logging._live_generation.processors)
+    obs_logging._get_console_processors = _plain_console_processors
+    try:
+        yield
+    finally:
+        obs_logging._get_console_processors = original_get_console_processors
+
+
 @pytest.fixture(autouse=True)
 def block_runner_real_llm_adapter(monkeypatch):
     """Block execute_seed's dependency analysis from spawning real agent CLIs.


### PR DESCRIPTION
## Why
structlog's DEV `ConsoleRenderer` defaults to rich's traceback formatter, which pygments-highlights the source context of every frame. Failure-path tests that log a real exception (event-store append failures, adapter errors, …) each paid multiple seconds of tokenization for output nobody reads under pytest. cProfile evidence: 13.7s of rich/pygments rendering in a single 6.5s test.

## What
One session-scoped autouse fixture swaps only the exception formatter to `structlog.dev.plain_traceback` — inside the test session. Production DEV output is untouched. The swap is done in-place on the processors list because `structlog.testing.capture_logs()` shares that exact container.

## Evidence
- runner workspace-lock cleanup test: 6.57s → 1.33s
- `ooo auto` CLI timeout test: 4.17s → 1.13s
- Full unit suite green (18,094 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaihJktuA9meD7FmGc77dq