### PR TITLE
test(scripts): cache install.sh test stubs to dodge macOS first-exec scans

### DIFF
--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import atexit
+import hashlib
 import json
 import os
 from pathlib import Path
 import re
 import shlex
+import shutil
 import subprocess
 import sys
+import tempfile
 import time
 
 import pytest
@@ -16,10 +20,55 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[3]
 INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 
+# Test-only variables read by the fake commands below (never by install.sh):
+# keeping the stub bodies free of per-test paths makes their content identical
+# across tests, which is what lets _write_executable share one on-disk copy.
+CALLS_LOG_VAR = "OUROBOROS_TEST_CALLS_LOG"
+TOOL_BIN_VAR = "OUROBOROS_TEST_TOOL_BIN"
+OUROBOROS_STUB_VAR = "OUROBOROS_TEST_OUROBOROS_STUB"
+# Where the fake curl records the requests it was asked to send.
+CAPTURES_LOG_VAR = "OUROBOROS_TEST_CURL_LOG"
+# Shell reference the fake commands append their call log to.
+CALLS_LOG_REF = f'"${CALLS_LOG_VAR}"'
+
+_STUB_CACHE: dict[str, Path] = {}
+_STUB_CACHE_DIR: Path | None = None
+
+_OUROBOROS_STUB = f"""#!/bin/sh
+printf 'ouroboros %s\\n' "$*" >> {CALLS_LOG_REF}
+exit 0
+"""
+
+
+def _cached_executable(content: str) -> Path:
+    """Return a warm executable holding `content`, creating it at most once.
+
+    macOS scans every newly created executable the first time it is exec'd
+    (~0.3s per file), and the installer harness runs a handful of stubs per
+    test. Writing each distinct stub body once and reusing that file keeps the
+    scan to a single occurrence per body instead of one per test.
+    """
+    global _STUB_CACHE_DIR
+
+    digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    cached = _STUB_CACHE.get(digest)
+    if cached is not None:
+        return cached
+
+    if _STUB_CACHE_DIR is None:
+        _STUB_CACHE_DIR = Path(tempfile.mkdtemp(prefix="install-sh-stubs-"))
+        atexit.register(shutil.rmtree, _STUB_CACHE_DIR, ignore_errors=True)
+
+    cached = _STUB_CACHE_DIR / digest
+    cached.write_text(content, encoding="utf-8")
+    cached.chmod(0o755)
+    _STUB_CACHE[digest] = cached
+    return cached
+
 
 def _write_executable(path: Path, content: str) -> None:
-    path.write_text(content, encoding="utf-8")
-    path.chmod(0o755)
+    path.unlink(missing_ok=True)
+    path.symlink_to(_cached_executable(content))
 
 
 def _run_installer(
@@ -46,28 +95,17 @@ if [ "$1" = "--version" ]; then
   exit 0
 fi
 if [ "$1" = "tool" ] && [ "$2" = "dir" ] && [ "$3" = "--bin" ]; then
-  echo "{tool_bin_dir!s}"
+  echo "${TOOL_BIN_VAR}"
   exit 0
 fi
 if [ "$1" = "tool" ] && [ "$2" = "install" ]; then
-  cat > "{tool_bin_dir!s}/ouroboros" <<'SH'
-#!/bin/sh
-printf 'ouroboros %s\\n' "$*" >> "{calls!s}"
-exit 0
-SH
-  chmod 755 "{tool_bin_dir!s}/ouroboros"
+  ln -sf "${OUROBOROS_STUB_VAR}" "${TOOL_BIN_VAR}/ouroboros"
 fi
-printf 'uv %s\\n' "$*" >> {calls!s}
+printf 'uv %s\\n' "$*" >> {CALLS_LOG_REF}
 exit 0
 """,
         )
-    _write_executable(
-        bin_dir / "ouroboros",
-        f"""#!/bin/sh
-printf 'ouroboros %s\\n' "$*" >> {calls!s}
-exit 0
-""",
-    )
+    _write_executable(bin_dir / "ouroboros", _OUROBOROS_STUB)
 
     if not include_uv:
         # Keep pipx/pip interpreter-selection tests independent of Python
@@ -93,6 +131,10 @@ exit 0
         {
             "HOME": str(tmp_path / "home"),
             "PATH": f"{bin_dir}:/usr/bin:/bin",
+            CALLS_LOG_VAR: str(calls),
+            TOOL_BIN_VAR: str(tool_bin_dir),
+            OUROBOROS_STUB_VAR: str(_cached_executable(_OUROBOROS_STUB)),
+            CAPTURES_LOG_VAR: str(tmp_path / "telemetry.log"),
         }
     )
     if env:
@@ -146,27 +188,26 @@ def test_install_script_syntax_is_valid() -> None:
     assert result.returncode == 0, result.stderr
 
 
-def _telemetry_probe_curl(tmp_path: Path) -> str:
-    captures = tmp_path / "telemetry.log"
-    return f'''#!/bin/sh
+def _telemetry_probe_curl() -> str:
+    return f"""#!/bin/sh
 case "$*" in
   *"/capture/"*) ;;
   *) printf '{{"info":{{"version":"0.50.0"}}}}\n'; exit 0 ;;
 esac
 state="$HOME/.ouroboros/telemetry.json"
 if ! grep -q '"notice_shown"[[:space:]]*:[[:space:]]*true' "$state" 2>/dev/null; then
-  printf 'capture-before-notice\\n' >> "{captures!s}"
+  printf 'capture-before-notice\\n' >> "${CAPTURES_LOG_VAR}"
   exit 0
 fi
-printf '%s\\n' "$*" >> "{captures!s}"
+printf '%s\\n' "$*" >> "${CAPTURES_LOG_VAR}"
 exit 0
-'''
+"""
 
 
-def _telemetry_fake_commands(tmp_path: Path) -> dict[str, str]:
+def _telemetry_fake_commands() -> dict[str, str]:
     """Use the test environment's schema while recording installer captures."""
     return {
-        "curl": _telemetry_probe_curl(tmp_path),
+        "curl": _telemetry_probe_curl(),
         "python3": (f'#!/bin/sh\nexec {shlex.quote(sys.executable)} "$@"\n'),
     }
 
@@ -189,7 +230,7 @@ def test_installer_absent_config_retains_disclosed_default_on(tmp_path: Path) ->
         tmp_path,
         local_repo=False,
         env={"OUROBOROS_TELEMETRY": ""},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -211,7 +252,7 @@ def test_installer_persists_first_command_surface_hint(
         tmp_path,
         local_repo=False,
         env={"OUROBOROS_TELEMETRY": "", "OUROBOROS_INSTALL_REF": install_ref},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -230,7 +271,7 @@ def test_installer_does_not_relabel_existing_first_command_surface_hint(
         tmp_path,
         local_repo=False,
         env={"OUROBOROS_TELEMETRY": "", "OUROBOROS_INSTALL_REF": "docs-getting-started"},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -246,7 +287,7 @@ def test_copied_installer_dangling_config_symlink_fails_closed(tmp_path: Path) -
         tmp_path,
         local_repo=False,
         env={"OUROBOROS_TELEMETRY": ""},
-        fake_commands={"curl": _telemetry_probe_curl(tmp_path)},
+        fake_commands={"curl": _telemetry_probe_curl()},
     )
 
     assert result.returncode == 0, result.stderr
@@ -265,7 +306,7 @@ def test_installer_persisted_opt_out_suppresses_all_collection(tmp_path: Path) -
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_TELEMETRY": ""},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -281,7 +322,7 @@ def test_installer_malformed_config_fails_closed(tmp_path: Path) -> None:
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_TELEMETRY": ""},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -306,7 +347,7 @@ def test_installer_unrelated_invalid_config_fails_closed(
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_TELEMETRY": ""},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -322,7 +363,7 @@ def test_installer_explicit_enable_cannot_override_persisted_opt_out(tmp_path: P
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_TELEMETRY": "1"},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -338,7 +379,7 @@ def test_installer_explicit_enable_cannot_override_malformed_config(tmp_path: Pa
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_TELEMETRY": "1"},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -354,7 +395,7 @@ def test_installer_honors_user_env_opt_out(tmp_path: Path) -> None:
     result = _run_installer(
         tmp_path,
         drop_env=("OUROBOROS_TELEMETRY",),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -370,7 +411,7 @@ def test_installer_honors_quoted_user_env_opt_out_with_comment(tmp_path: Path) -
     result = _run_installer(
         tmp_path,
         drop_env=("OUROBOROS_TELEMETRY",),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -386,7 +427,7 @@ def test_installer_honors_quoted_do_not_track_with_comment(tmp_path: Path) -> No
     result = _run_installer(
         tmp_path,
         drop_env=("OUROBOROS_TELEMETRY", "DO_NOT_TRACK"),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -402,7 +443,7 @@ def test_installer_honors_user_env_opt_out_two_spaces_after_export(tmp_path: Pat
     result = _run_installer(
         tmp_path,
         drop_env=("OUROBOROS_TELEMETRY",),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -418,7 +459,7 @@ def test_installer_honors_user_env_opt_out_tab_after_export(tmp_path: Path) -> N
     result = _run_installer(
         tmp_path,
         drop_env=("OUROBOROS_TELEMETRY",),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -436,7 +477,7 @@ def test_installer_honors_export_multi_space_quoted_do_not_track_with_comment(
     result = _run_installer(
         tmp_path,
         drop_env=("OUROBOROS_TELEMETRY", "DO_NOT_TRACK"),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -448,7 +489,7 @@ def test_installer_honors_uppercase_telemetry_off_flag(tmp_path: Path) -> None:
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_TELEMETRY": "OFF"},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -460,7 +501,7 @@ def test_installer_honors_uppercase_do_not_track_yes_flag(tmp_path: Path) -> Non
     result = _run_installer(
         tmp_path,
         env={"DO_NOT_TRACK": "YES", "OUROBOROS_TELEMETRY": "1"},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -476,7 +517,7 @@ def test_installer_honors_single_quoted_user_env_opt_out_with_comment(tmp_path: 
     result = _run_installer(
         tmp_path,
         drop_env=("OUROBOROS_TELEMETRY",),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -492,7 +533,7 @@ def test_installer_honors_quoted_user_env_opt_out_without_comment(tmp_path: Path
     result = _run_installer(
         tmp_path,
         drop_env=("OUROBOROS_TELEMETRY",),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -519,7 +560,7 @@ def test_installer_fails_closed_on_unclosed_quote_at_eof(tmp_path: Path) -> None
         tmp_path,
         local_repo=False,
         drop_env=("OUROBOROS_TELEMETRY",),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -543,7 +584,7 @@ def test_installer_fails_closed_on_genuinely_multiline_telemetry_opt_out(
         tmp_path,
         local_repo=False,
         drop_env=("OUROBOROS_TELEMETRY",),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -560,7 +601,7 @@ def test_installer_fails_closed_on_genuinely_multiline_do_not_track(tmp_path: Pa
         tmp_path,
         local_repo=False,
         drop_env=("OUROBOROS_TELEMETRY", "DO_NOT_TRACK"),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -583,7 +624,7 @@ def test_installer_fails_closed_on_multiline_value_that_looks_enabling(
         tmp_path,
         local_repo=False,
         drop_env=("OUROBOROS_TELEMETRY",),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -600,7 +641,7 @@ def test_installer_user_env_trailing_garbage_after_quote_is_skipped(tmp_path: Pa
         tmp_path,
         local_repo=False,
         drop_env=("OUROBOROS_TELEMETRY",),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -622,7 +663,7 @@ def test_installer_honors_user_env_destination_override(tmp_path: Path) -> None:
         tmp_path,
         local_repo=False,
         env={"OUROBOROS_TELEMETRY": ""},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -646,7 +687,7 @@ def test_installer_process_env_wins_over_user_env_file(tmp_path: Path) -> None:
             "OUROBOROS_TELEMETRY": "",
             "OUROBOROS_POSTHOG_HOST": "https://telemetry-process.invalid",
         },
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -670,7 +711,7 @@ def test_installer_user_env_duplicate_telemetry_key_resolves_last_wins(tmp_path:
     result = _run_installer(
         tmp_path,
         drop_env=("OUROBOROS_TELEMETRY",),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -686,7 +727,7 @@ def test_installer_user_env_duplicate_do_not_track_resolves_last_wins(tmp_path: 
     result = _run_installer(
         tmp_path,
         drop_env=("OUROBOROS_TELEMETRY", "DO_NOT_TRACK"),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -710,7 +751,7 @@ def test_installer_user_env_duplicate_telemetry_key_reverse_order_enables(
     result = _run_installer(
         tmp_path,
         drop_env=("OUROBOROS_TELEMETRY",),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -733,7 +774,7 @@ def test_installer_real_process_env_wins_over_duplicated_user_env_file(
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_TELEMETRY": "0"},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -757,7 +798,7 @@ def test_installer_fails_closed_on_escape_bearing_quoted_value(tmp_path: Path) -
     result = _run_installer(
         tmp_path,
         drop_env=("OUROBOROS_TELEMETRY",),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -776,7 +817,7 @@ def test_installer_honors_single_quoted_key(tmp_path: Path) -> None:
     result = _run_installer(
         tmp_path,
         drop_env=("OUROBOROS_TELEMETRY",),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -792,7 +833,7 @@ def test_installer_honors_double_quoted_key(tmp_path: Path) -> None:
     result = _run_installer(
         tmp_path,
         drop_env=("OUROBOROS_TELEMETRY", "DO_NOT_TRACK"),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -816,7 +857,7 @@ def test_installer_fails_closed_on_escape_bearing_value_even_when_it_looks_enabl
     result = _run_installer(
         tmp_path,
         drop_env=("OUROBOROS_TELEMETRY",),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -838,7 +879,7 @@ def test_installer_plain_quoted_value_without_backslash_still_enables(
     result = _run_installer(
         tmp_path,
         drop_env=("OUROBOROS_TELEMETRY",),
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -851,7 +892,7 @@ def test_installer_do_not_track_precedes_explicit_enable(tmp_path: Path) -> None
     result = _run_installer(
         tmp_path,
         env={"DO_NOT_TRACK": "1", "OUROBOROS_TELEMETRY": "1"},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -872,7 +913,7 @@ def test_installer_unreadable_config_fails_closed(tmp_path: Path) -> None:
         result = _run_installer(
             tmp_path,
             env={"OUROBOROS_TELEMETRY": ""},
-            fake_commands=_telemetry_fake_commands(tmp_path),
+            fake_commands=_telemetry_fake_commands(),
         )
     finally:
         config.chmod(0o600)
@@ -889,7 +930,7 @@ def test_installer_notice_is_persisted_before_first_capture(tmp_path: Path) -> N
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_TELEMETRY": ""},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -918,7 +959,7 @@ def test_installer_repairs_corrupt_telemetry_json_and_persists_events(tmp_path: 
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_TELEMETRY": ""},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -961,7 +1002,7 @@ def test_installer_replaces_non_uuid_distinct_id_with_fresh_uuid(tmp_path: Path)
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_TELEMETRY": ""},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -989,7 +1030,7 @@ def test_installer_salvages_uuid_from_malformed_json_and_lowercases_it(tmp_path:
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_TELEMETRY": ""},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -1019,7 +1060,7 @@ def test_installer_canonicalizes_uppercase_uuid_in_valid_json(tmp_path: Path) ->
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_TELEMETRY": ""},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -1050,7 +1091,7 @@ def test_installer_repaired_telemetry_json_matches_fresh_install_shape(tmp_path:
     fresh_result = _run_installer(
         fresh_home,
         env={"OUROBOROS_TELEMETRY": ""},
-        fake_commands=_telemetry_fake_commands(fresh_home),
+        fake_commands=_telemetry_fake_commands(),
     )
     assert fresh_result.returncode == 0, fresh_result.stderr
     fresh_text = (fresh_home / "home" / ".ouroboros" / "telemetry.json").read_text(encoding="utf-8")
@@ -1065,7 +1106,7 @@ def test_installer_repaired_telemetry_json_matches_fresh_install_shape(tmp_path:
     repaired_result = _run_installer(
         repaired_home,
         env={"OUROBOROS_TELEMETRY": ""},
-        fake_commands=_telemetry_fake_commands(repaired_home),
+        fake_commands=_telemetry_fake_commands(),
     )
     assert repaired_result.returncode == 0, repaired_result.stderr
     repaired_text = corrupt_state.read_text(encoding="utf-8")
@@ -1103,7 +1144,7 @@ def test_installer_drops_telemetry_when_identity_storage_is_unwritable(tmp_path:
         result = _run_installer(
             tmp_path,
             env={"OUROBOROS_TELEMETRY": ""},
-            fake_commands=_telemetry_fake_commands(tmp_path),
+            fake_commands=_telemetry_fake_commands(),
         )
     finally:
         state_dir.chmod(0o700)  # restore write access so tmp cleanup can proceed
@@ -1137,7 +1178,7 @@ def test_installer_sends_telemetry_from_valid_identity_in_unwritable_dir(tmp_pat
         result = _run_installer(
             tmp_path,
             env={"OUROBOROS_TELEMETRY": ""},
-            fake_commands=_telemetry_fake_commands(tmp_path),
+            fake_commands=_telemetry_fake_commands(),
         )
     finally:
         state_dir.chmod(0o700)
@@ -1170,7 +1211,7 @@ def test_installer_shows_notice_when_only_nested_and_persists_top_level(
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_TELEMETRY": ""},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -1206,7 +1247,7 @@ def test_installer_shows_notice_when_top_level_value_is_a_string_not_bool(
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_TELEMETRY": ""},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -1224,7 +1265,7 @@ _HOSTILE_UNAME_SCRIPT = (
 )
 
 
-def _capture_dashd_curl(captures: Path) -> str:
+def _capture_dashd_curl() -> str:
     """Fake curl that logs ONLY the raw `-d` argument of each call, one per
     line -- lets a test `json.loads()` the exact payload instead of
     substring-matching the whole curl invocation (which also contains
@@ -1234,7 +1275,7 @@ def _capture_dashd_curl(captures: Path) -> str:
 prev=""
 for arg in "$@"; do
   if [ "$prev" = "-d" ]; then
-    printf '%s\\n' "$arg" >> {captures!s}
+    printf '%s\\n' "$arg" >> "${CAPTURES_LOG_VAR}"
   fi
   prev="$arg"
 done
@@ -1269,7 +1310,7 @@ def _build_no_python3_path(target_dir: Path) -> str:
 
 
 def _drive_telemetry_ping(
-    tmp_path: Path, *, home: Path, path_env: str, extra_setup: str = ""
+    tmp_path: Path, *, home: Path, path_env: str, captures: Path, extra_setup: str = ""
 ) -> subprocess.CompletedProcess[str]:
     """Extract `_telemetry_distinct_id` + `_telemetry_ping` verbatim from
     install.sh and run them in an isolated driver, bypassing `_telemetry_enabled`
@@ -1297,6 +1338,7 @@ wait
     run_env = os.environ.copy()
     run_env["HOME"] = str(home)
     run_env["PATH"] = path_env
+    run_env[CAPTURES_LOG_VAR] = str(captures)
     return subprocess.run(
         ["bash", str(driver)],
         env=run_env,
@@ -1318,12 +1360,13 @@ def test_installer_ping_escapes_hostile_uname_output_with_python3(tmp_path: Path
     bin_dir.mkdir()
     captures = tmp_path / "captures.log"
     _write_executable(bin_dir / "uname", _HOSTILE_UNAME_SCRIPT)
-    _write_executable(bin_dir / "curl", _capture_dashd_curl(captures))
+    _write_executable(bin_dir / "curl", _capture_dashd_curl())
 
     result = _drive_telemetry_ping(
         tmp_path,
         home=tmp_path / "home",
         path_env=f"{bin_dir}:/usr/bin:/bin",
+        captures=captures,
     )
 
     assert result.returncode == 0, result.stderr
@@ -1347,7 +1390,7 @@ def test_installer_ping_escapes_hostile_uname_output_without_python3(tmp_path: P
     bin_dir.mkdir()
     captures = tmp_path / "captures.log"
     _write_executable(bin_dir / "uname", _HOSTILE_UNAME_SCRIPT)
-    _write_executable(bin_dir / "curl", _capture_dashd_curl(captures))
+    _write_executable(bin_dir / "curl", _capture_dashd_curl())
     no_python_dir = _build_no_python3_path(tmp_path / "no-python-bin")
 
     home = tmp_path / "home"
@@ -1366,6 +1409,7 @@ def test_installer_ping_escapes_hostile_uname_output_without_python3(tmp_path: P
         tmp_path,
         home=home,
         path_env=f"{bin_dir}:{no_python_dir}",
+        captures=captures,
     )
 
     assert result.returncode == 0, result.stderr
@@ -1390,8 +1434,8 @@ def test_installer_ping_uses_exact_declared_property_structure(tmp_path: Path) -
         tmp_path,
         env={"OUROBOROS_TELEMETRY": ""},
         fake_commands={
-            **_telemetry_fake_commands(tmp_path),
-            "curl": _capture_dashd_curl(tmp_path / "telemetry.log"),
+            **_telemetry_fake_commands(),
+            "curl": _capture_dashd_curl(),
         },
     )
 
@@ -1439,8 +1483,8 @@ def test_installer_ping_ref_defaults_to_direct_when_unset(tmp_path: Path) -> Non
         env={"OUROBOROS_TELEMETRY": ""},
         drop_env=("OUROBOROS_INSTALL_REF",),
         fake_commands={
-            **_telemetry_fake_commands(tmp_path),
-            "curl": _capture_dashd_curl(tmp_path / "telemetry.log"),
+            **_telemetry_fake_commands(),
+            "curl": _capture_dashd_curl(),
         },
     )
 
@@ -1466,8 +1510,8 @@ def test_installer_ping_ref_carries_valid_channel_token(tmp_path: Path) -> None:
         tmp_path,
         env={"OUROBOROS_TELEMETRY": "", "OUROBOROS_INSTALL_REF": "hellogithub"},
         fake_commands={
-            **_telemetry_fake_commands(tmp_path),
-            "curl": _capture_dashd_curl(tmp_path / "telemetry.log"),
+            **_telemetry_fake_commands(),
+            "curl": _capture_dashd_curl(),
         },
     )
 
@@ -1496,8 +1540,8 @@ def test_installer_ping_ref_degrades_hostile_value_to_direct(tmp_path: Path) -> 
         tmp_path,
         env={"OUROBOROS_TELEMETRY": "", "OUROBOROS_INSTALL_REF": "evil; rm -rf /"},
         fake_commands={
-            **_telemetry_fake_commands(tmp_path),
-            "curl": _capture_dashd_curl(tmp_path / "telemetry.log"),
+            **_telemetry_fake_commands(),
+            "curl": _capture_dashd_curl(),
         },
     )
 
@@ -1542,7 +1586,7 @@ def test_installer_ignores_nested_distinct_id_in_valid_json_and_mints_fresh(
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_TELEMETRY": ""},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -1581,7 +1625,7 @@ def test_installer_adopts_last_value_for_duplicate_top_level_distinct_id(
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_TELEMETRY": ""},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -1612,7 +1656,7 @@ def test_installer_still_salvages_uuid_from_unparseable_text_with_nested_shape(
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_TELEMETRY": ""},
-        fake_commands=_telemetry_fake_commands(tmp_path),
+        fake_commands=_telemetry_fake_commands(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -1918,11 +1962,11 @@ def test_explicit_runtime_setup_failure_fails_install(tmp_path: Path) -> None:
         env={"OUROBOROS_INSTALL_RUNTIME": "pi"},
         fake_commands={
             "pipx": "#!/bin/sh\nprintf 'pipx %s\\n' \"$*\" >> __CALLS__\nexit 0\n".replace(
-                "__CALLS__", str(tmp_path / "calls.log")
+                "__CALLS__", CALLS_LOG_REF
             ),
             "python3.12": '#!/bin/sh\nif [ "$1" = "-c" ]; then echo 3.12; exit 0; fi\necho \'Python 3.12.0\'\n',
             "pi": "#!/bin/sh\nexit 0\n",
-            "ouroboros": f'#!/bin/sh\nprintf \'ouroboros %s\\n\' "$*" >> {tmp_path / "calls.log"}\nif [ "$1" = "setup" ] && [ "$2" = "--runtime" ]; then exit 42; fi\nexit 0\n',
+            "ouroboros": f'#!/bin/sh\nprintf \'ouroboros %s\\n\' "$*" >> {CALLS_LOG_REF}\nif [ "$1" = "setup" ] && [ "$2" = "--runtime" ]; then exit 42; fi\nexit 0\n',
         },
     )
 
@@ -1964,7 +2008,7 @@ def test_uv_install_setup_prefers_fresh_tool_bin_over_stale_path_command(tmp_pat
         env={"OUROBOROS_INSTALL_RUNTIME": "pi"},
         fake_commands={
             "pi": "#!/bin/sh\nexit 0\n",
-            "ouroboros": f"#!/bin/sh\nprintf 'stale-ouroboros %s\\n' \"$*\" >> {tmp_path / 'calls.log'}\nexit 0\n",
+            "ouroboros": f"#!/bin/sh\nprintf 'stale-ouroboros %s\\n' \"$*\" >> {CALLS_LOG_REF}\nexit 0\n",
         },
     )
 
@@ -1981,7 +2025,7 @@ def test_uv_install_setup_prefers_fresh_tool_bin_over_stale_home_local_bin(
     home_local_bin.mkdir(parents=True)
     _write_executable(
         home_local_bin / "ouroboros",
-        f"#!/bin/sh\nprintf 'stale-local-ouroboros %s\\n' \"$*\" >> {tmp_path / 'calls.log'}\nexit 0\n",
+        f"#!/bin/sh\nprintf 'stale-local-ouroboros %s\\n' \"$*\" >> {CALLS_LOG_REF}\nexit 0\n",
     )
 
     result = _run_installer(
@@ -2003,7 +2047,7 @@ def test_pipx_install_setup_prefers_existing_path_command_over_stale_home_local_
     home_local_bin.mkdir(parents=True)
     _write_executable(
         home_local_bin / "ouroboros",
-        f"#!/bin/sh\nprintf 'stale-home-ouroboros %s\\n' \"$*\" >> {tmp_path / 'calls.log'}\nexit 0\n",
+        f"#!/bin/sh\nprintf 'stale-home-ouroboros %s\\n' \"$*\" >> {CALLS_LOG_REF}\nexit 0\n",
     )
 
     python = '#!/bin/sh\nif [ "$1" = "-c" ]; then echo 3.12; exit 0; fi\necho \'Python 3.12.0\'\n'
@@ -2013,7 +2057,7 @@ def test_pipx_install_setup_prefers_existing_path_command_over_stale_home_local_
         env={"OUROBOROS_INSTALL_RUNTIME": "pi"},
         fake_commands={
             "pipx": '#!/bin/sh\nif [ "$1" = "--version" ]; then echo \'pipx 0.0.0-test\'; exit 0; fi\nprintf \'pipx %s\\n\' "$*" >> __CALLS__\nexit 0\n'.replace(
-                "__CALLS__", str(tmp_path / "calls.log")
+                "__CALLS__", CALLS_LOG_REF
             ),
             "python3.12": python,
             "pi": "#!/bin/sh\nexit 0\n",
@@ -2068,7 +2112,7 @@ def test_all_runtime_pipx_selects_python_313_when_314_is_available(tmp_path: Pat
         env={"OUROBOROS_INSTALL_RUNTIME": "all"},
         fake_commands={
             "pipx": '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "pipx 0.0.0-test"; exit 0; fi\nprintf "pipx %s\\n" "$*" >> __CALLS__\nexit 0\n'.replace(
-                "__CALLS__", str(tmp_path / "calls.log")
+                "__CALLS__", CALLS_LOG_REF
             ),
             "python3.14": python_314,
             "python3.13": python_313,
@@ -2093,7 +2137,7 @@ def test_all_runtime_pipx_fails_before_install_when_only_python_314_exists(
         env={"OUROBOROS_INSTALL_RUNTIME": "all"},
         fake_commands={
             "pipx": '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "pipx 0.0.0-test"; exit 0; fi\nprintf "pipx %s\\n" "$*" >> __CALLS__\nexit 0\n'.replace(
-                "__CALLS__", str(tmp_path / "calls.log")
+                "__CALLS__", CALLS_LOG_REF
             ),
             "python3.14": python_314,
         },
@@ -2116,7 +2160,7 @@ def test_all_runtime_pipx_rejects_python_315_for_litellm_range(tmp_path: Path) -
         env={"OUROBOROS_INSTALL_RUNTIME": "all"},
         fake_commands={
             "pipx": '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "pipx 0.0.0-test"; exit 0; fi\nprintf "pipx %s\\n" "$*" >> __CALLS__\nexit 0\n'.replace(
-                "__CALLS__", str(tmp_path / "calls.log")
+                "__CALLS__", CALLS_LOG_REF
             ),
             "python3.15": python_315,
             "python3": python_315,
@@ -2158,7 +2202,7 @@ def test_all_runtime_pip_fallback_selects_313_when_generic_python3_is_314(
         'if [ "$1" = "-c" ]; then echo 3.13; exit 0; fi\n'
         'if [ "$1" = "-m" ] && [ "$2" = "pip" ]; then printf \'pip313 %s\\n\' "$*" >> __CALLS__; exit 0; fi\n'
         "echo 'Python 3.13.0'\n"
-    ).replace("__CALLS__", str(tmp_path / "calls.log"))
+    ).replace("__CALLS__", CALLS_LOG_REF)
     result = _run_installer(
         tmp_path,
         include_uv=False,
@@ -2180,7 +2224,7 @@ def test_all_runtime_pip_fallback_uses_compatible_python(tmp_path: Path) -> None
         'if [ "$1" = "-c" ]; then echo 3.13; exit 0; fi\n'
         'if [ "$1" = "-m" ] && [ "$2" = "pip" ]; then printf \'pip %s\\n\' "$*" >> __CALLS__; exit 0; fi\n'
         "echo 'Python 3.13.0'\n"
-    ).replace("__CALLS__", str(tmp_path / "calls.log"))
+    ).replace("__CALLS__", CALLS_LOG_REF)
     result = _run_installer(
         tmp_path,
         include_uv=False,
@@ -2252,9 +2296,7 @@ def test_preserved_codex_runtime_refreshes_claude_skills_when_detected(tmp_path:
     result = _run_installer(
         tmp_path,
         fake_commands={
-            "claude": (
-                f'#!/bin/sh\nprintf "claude %s\\n" "$*" >> {tmp_path / "calls.log"}\nexit 0\n'
-            ),
+            "claude": (f'#!/bin/sh\nprintf "claude %s\\n" "$*" >> {CALLS_LOG_REF}\nexit 0\n'),
         },
     )
 


### PR DESCRIPTION
## Why
`test_install_runtime_selection.py` was the biggest CPU sink in the suite (~80s: twenty tests at 3–8s each). Root cause on macOS: every newly created executable pays a ~0.3s system scan on first exec, and the installer harness wrote fresh stub scripts per test.

## What
Hash-cache each distinct stub body once in a session temp dir and symlink per-test paths to it, so the scan happens once per body instead of once per test. Stub bodies are made path-free by passing per-test paths through `OUROBOROS_TEST_*` env vars **read only by the fake commands, never by install.sh** — no new production env contract.

## Evidence
Worst test 7.59s → 0.64s; file total ~80s → ~33s. All 71 tests pass; install.sh untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaihJktuA9meD7FmGc77dq