### PR TITLE
ci(pr-hygiene): make api_retry backoff overridable for shell tests

### DIFF
--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -84,10 +84,13 @@ jobs:
           # stdout, so a warning printed there would be concatenated with the
           # count and turn a successful retry into `integer expression
           # expected` -- silently discarding a valid closing link.
+          # The backoff is overridable so the shell-level tests that exercise
+          # this function do not each pay a real five-second wait; CI leaves it
+          # unset and gets the five seconds.
           api_retry() {
             "$@" && return 0
             echo "::warning::GitHub API call failed; retrying once." >&2
-            sleep 5
+            sleep "${API_RETRY_DELAY_SECONDS:-5}"
             "$@" && return 0
             return 1
           }

--- a/tests/unit/scripts/test_pr_hygiene_workflow.py
+++ b/tests/unit/scripts/test_pr_hygiene_workflow.py
@@ -64,7 +64,9 @@ def run_bash(script: str, tmp_path: Path) -> subprocess.CompletedProcess[str]:
 
 
 class TestApiRetry:
-    HEADER = "set -euo pipefail\nRUNNER_TEMP=.\n"
+    # The retry backoff is the behaviour of the *runner*, not of these tests;
+    # waiting it out would cost five real seconds per case.
+    HEADER = "set -euo pipefail\nRUNNER_TEMP=.\nAPI_RETRY_DELAY_SECONDS=0\n"
 
     def test_success_on_first_try_prints_only_the_payload(self, tmp_path: Path) -> None:
         script = f"""{self.HEADER}


### PR DESCRIPTION
## Why
The three `TestApiRetry` shell tests each paid the workflow's real `sleep 5` (15s total) to test the retry contract, not the length of the nap.

## What
`sleep \"${API_RETRY_DELAY_SECONDS:-5}\"` — CI leaves the var unset and keeps the five seconds; the tests set it to 0 in their script header. Retry semantics (stderr warning, exit codes, stdout purity) are asserted exactly as before.

## Evidence
5.03s × 3 → <0.5s each; all tests in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaihJktuA9meD7FmGc77dq