### PR TITLE
test: mock retry-backoff sleeps, keep the retries

### DIFF
--- a/tests/unit/auto/test_seed_repairer_bounded.py
+++ b/tests/unit/auto/test_seed_repairer_bounded.py
@@ -363,7 +363,10 @@ async def test_pipeline_blocks_when_repair_phase_exceeds_timeout(tmp_path) -> No
         return _seed()
 
     timeout = 1  # whole seconds — phase_timeout_seconds rejects non-positive ints
-    sleepy = _SleepyReviewer(sleep_seconds=timeout * 2)
+    # Outlive the phase budget by a margin, not a multiple: the worker thread's
+    # sleep is uninterruptible, so every extra second is wall clock the test
+    # spends waiting for it to unwind.
+    sleepy = _SleepyReviewer(sleep_seconds=timeout + 0.25)
     repairer = SeedRepairer(reviewer=sleepy)
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
@@ -457,7 +460,7 @@ async def test_resume_recovers_session_blocked_by_repair_timeout(tmp_path) -> No
 
     # First run: sleepy reviewer trips wait_for and blocks the session.
     timeout = 1
-    sleepy = _SleepyReviewer(sleep_seconds=timeout * 2)
+    sleepy = _SleepyReviewer(sleep_seconds=timeout + 0.25)
     blocking_repairer = SeedRepairer(reviewer=sleepy)
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))

--- a/tests/unit/orchestrator/test_effort_routed_event.py
+++ b/tests/unit/orchestrator/test_effort_routed_event.py
@@ -496,13 +496,18 @@ async def test_cancellation_seal_failure_is_fail_closed() -> None:
 
 
 @pytest.mark.asyncio
-async def test_effort_event_store_failure_does_not_abort_ac() -> None:
+async def test_effort_event_store_failure_does_not_abort_ac(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A degraded event store degrades the proof event to a warning, not an AC failure.
 
     The routing event is auxiliary proof telemetry — it is emitted through
     ``_safe_emit_event``, so a persistently failing ``event_store.append`` must NOT
     propagate out of ``_execute_atomic_ac`` and abort the AC before runtime dispatch.
     """
+    # The append retry ladder backs off for real seconds; keep the retries,
+    # drop the waiting.
+    monkeypatch.setattr("ouroboros.orchestrator.parallel_executor.anyio.sleep", AsyncMock())
     store = AsyncMock()
     effort_append_attempts = 0
 

--- a/tests/unit/orchestrator/test_model_routing_wiring.py
+++ b/tests/unit/orchestrator/test_model_routing_wiring.py
@@ -547,8 +547,13 @@ class TestModelRoutedEvent:
         assert data["runtime_backend"] == "claude"
 
     @pytest.mark.asyncio
-    async def test_model_event_store_failure_does_not_abort_ac(self) -> None:
+    async def test_model_event_store_failure_does_not_abort_ac(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """A degraded event store degrades the proof event to a warning, not an AC failure."""
+        # The append retry ladder backs off for real seconds; keep the retries,
+        # drop the waiting.
+        monkeypatch.setattr("ouroboros.orchestrator.parallel_executor.anyio.sleep", AsyncMock())
         store = AsyncMock()
         model_append_attempts = 0
 

--- a/tests/unit/test_kiro_adapters.py
+++ b/tests/unit/test_kiro_adapters.py
@@ -225,9 +225,12 @@ class TestKiroCodeAdapterComplete:
                 return _make_proc(stderr=b"err", returncode=1)
             return _make_proc(stdout=b"ok", returncode=0)
 
-        with patch(
-            "ouroboros.providers.kiro_adapter.asyncio.create_subprocess_exec",
-            side_effect=_factory,
+        with (
+            patch(
+                "ouroboros.providers.kiro_adapter.asyncio.create_subprocess_exec",
+                side_effect=_factory,
+            ),
+            patch("ouroboros.providers.kiro_adapter.asyncio.sleep", new=AsyncMock()),
         ):
             from ouroboros.providers.base import CompletionConfig, Message, MessageRole
 
@@ -741,9 +744,12 @@ class TestKiroAgentAdapterExecuteTaskToResult:
     @pytest.mark.asyncio
     async def test_non_retryable_error_fails_immediately(self) -> None:
         proc = _make_proc(stderr=b"permission denied", returncode=126)
-        with patch(
-            "ouroboros.orchestrator.kiro_adapter.asyncio.create_subprocess_exec",
-            return_value=proc,
+        with (
+            patch(
+                "ouroboros.orchestrator.kiro_adapter.asyncio.create_subprocess_exec",
+                return_value=proc,
+            ),
+            patch("ouroboros.orchestrator.kiro_adapter.asyncio.sleep", new=AsyncMock()),
         ):
             from ouroboros.orchestrator.kiro_adapter import KiroAgentAdapter
 


### PR DESCRIPTION
## Why
Several tests that assert a retry/degradation contract (event-store append failure must not abort the AC; non-retryable kiro errors fail immediately) waited out the production backoff ladder for real — each showing up as an exact ~3.0s in the durations profile.

## What
Mock `anyio.sleep`/`asyncio.sleep` in those tests only; the retry attempt counts are still asserted. `test_seed_repairer_bounded` additionally trims the sleepy reviewer's overshoot from a multiple (2× timeout) to a margin (timeout + 0.25s) — the worker thread's sleep is uninterruptible, so overshoot is pure wall clock.

Files: `test_effort_routed_event.py`, `test_model_routing_wiring.py`, `test_kiro_adapters.py`, `test_seed_repairer_bounded.py`.

## Evidence
Each affected test ~3.0s → ~0.01s (repairer 3.3s → 2.3s, bounded by its real timeout contract); all files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaihJktuA9meD7FmGc77dq