### PR TITLE
test(evolution): stub git identity and version probes in fingerprint tests

### DIFF
--- a/tests/unit/evolution/test_provider_usage.py
+++ b/tests/unit/evolution/test_provider_usage.py
@@ -199,6 +199,59 @@ async def _codex_runtime_summary(runtime: CodexCliRuntime):  # noqa: ANN202
 
 
 @pytest.fixture(autouse=True)
+def _answer_fake_cli_version_probes_without_spawning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Serve ``--version`` for the fake codex CLIs by parsing the script.
+
+    Every ``CodexCliRuntime`` attestation probe spawns ``<cli> --version``
+    (~45ms of subprocess wait each, dozens per fingerprint test). The fake
+    CLIs written by :func:`_write_fake_codex_cli` only echo a constant, so
+    answering from the script text preserves the probed identity — including
+    the version drift between fixtures — without the process spawns. Any
+    other invocation (real binaries, failure-shape fixtures) still executes.
+    """
+    import re
+    import subprocess
+
+    from ouroboros.orchestrator import cli_version_attestation
+
+    real_run = subprocess.run
+
+    def _run(args, **kwargs):  # noqa: ANN001, ANN202
+        if isinstance(args, list) and len(args) == 2 and args[1] == "--version":
+            try:
+                script = Path(args[0]).read_text(encoding="utf-8")
+            except (OSError, UnicodeError):
+                script = ""
+            match = re.search(r"echo 'codex ([^']+)'", script)
+            if match is not None:
+                return subprocess.CompletedProcess(
+                    args, 0, stdout=f"codex {match.group(1)}\n", stderr=""
+                )
+        return real_run(args, **kwargs)
+
+    monkeypatch.setattr(cli_version_attestation.subprocess, "run", _run)
+
+
+@pytest.fixture(autouse=True)
+def _resolve_project_identity_without_git(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the attestation's semantic-cwd resolution to a constant.
+
+    ``resolve_project_identity`` shells out to git several times per
+    ``CodexCliRuntime`` construction; the fingerprint tests here only need
+    the resolved ``workspace_path`` to be deterministic and identical across
+    variants. Tests that exercise cwd-relative identity re-patch this and
+    win (see the repository-relative cwd test below).
+    """
+    monkeypatch.setattr(
+        frugality_attestation_module,
+        "resolve_project_identity",
+        lambda _cwd: SimpleNamespace(workspace_path="."),
+    )
+
+
+@pytest.fixture(autouse=True)
 def _register_test_completion_schema(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         frugality_attestation_module,


### PR DESCRIPTION
## Why
Every `CodexCliRuntime` construction in `test_provider_usage.py` shelled out to real git 3–5 times (`resolve_project_identity`) plus a `--version` probe spawn — 54 subprocesses in the fingerprint-drift test alone, ~45ms of subprocess wait each.

## What
Two module-local autouse fixtures, no production change:
- Answer `--version` for the fake codex CLIs by parsing the fixture script (the probed identity, including the 1.0-vs-2.0 drift between fixtures, is preserved); any other invocation still executes.
- Pin `resolve_project_identity` to a constant `workspace_path` — the fingerprint tests only need it deterministic and identical across variants. The repository-relative-cwd test re-patches with its own resolver and wins, unchanged.

## Evidence
File total 22.5s → 1.7s (fingerprint test 5.25s → 0.65s); 63 passed (71 litellm-gated skips are a local-env artifact, unchanged by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaihJktuA9meD7FmGc77dq