### PR TITLE
ci(test): gate PRs on the 3.12 floor; full matrix and coverage on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12', '3.13', '3.14']
+        # PRs gate on the 3.12 floor only; pushes to main/develop run the full
+        # matrix (3.14 also exercises the litellm-free dependency profile), so
+        # version-specific regressions are caught at merge time, before release.
+        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.12"]') || fromJSON('["3.12", "3.13", "3.14"]') }}
 
     steps:
       - name: Checkout code
@@ -99,9 +102,16 @@ jobs:
         env:
           PYTHONFAULTHANDLER: "1"
         run: |
-          uv run --python "${{ matrix.python-version }}" --no-sync pytest tests/ -n 4 --dist worksteal --durations=25 --cov=src/ouroboros --cov-report=xml --cov-report=term-missing -v
+          # Coverage instrumentation costs a large constant factor per run, so
+          # PRs skip it; pushes to main/develop keep the full Codecov pipeline.
+          COV_ARGS=""
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            COV_ARGS="--cov=src/ouroboros --cov-report=xml --cov-report=term-missing"
+          fi
+          uv run --python "${{ matrix.python-version }}" --no-sync pytest tests/ -n 4 --dist worksteal --durations=25 $COV_ARGS -v
 
       - name: Upload coverage artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.python-version }}
@@ -111,6 +121,7 @@ jobs:
 
   coverage:
     name: Upload coverage
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
           PY
           uv pip check
 
-      - name: Run pytest with coverage
+      - name: Run pytest
         env:
           PYTHONFAULTHANDLER: "1"
         run: |
@@ -146,6 +146,9 @@ jobs:
         with:
           files: ./coverage/coverage-3.12/coverage.xml,./coverage/coverage-3.13/coverage.xml,./coverage/coverage-3.14/coverage.xml
           use_oidc: true
-          fail_ci_if_error: false
+          # This job now runs only on push (PRs skip coverage entirely), making
+          # it the sole coverage-publication path. A silent upload failure here
+          # would mean coverage stops updating with no signal, so surface it.
+          fail_ci_if_error: true
           flags: unittests
           name: codecov


### PR DESCRIPTION
## Why
Every PR ran the full suite three times (3.12/3.13/3.14, ~15 min each job) with coverage instrumentation. Wall-clock PR gate ≈ 15 min and three runners per PR.

## What
- **PRs**: Python 3.12 only (the `requires-python` floor), no `--cov` instrumentation.
- **Pushes to main/develop**: unchanged — full 3.12/3.13/3.14 matrix (3.14 also exercises the litellm-free dependency profile) + coverage artifacts + Codecov upload.

Version-specific regressions move from PR-time to merge-time detection — still strictly before release.

## ⚠️ MERGE COORDINATION REQUIRED
main's branch protection currently requires `Test Python 3.13` and `Test Python 3.14` as status checks. Those contexts will never report on PRs after this change, so **they must be removed from the required checks when (not before) this merges** — otherwise every subsequent PR blocks forever. `Test Python 3.12` stays required.

Expected effect: PR gate ~15 min → ~4–6 min, 3 runners → 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaihJktuA9meD7FmGc77dq