### PR TITLE
fix(auto): retain Seed QA evaluator diagnostics

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -2855,8 +2855,10 @@ class AutoPipeline:
                 return await advisory("evaluator_error", f"Seed QA raised {type(exc).__name__}")
 
             if qa_result.error:
+                detail = " ".join(str(qa_result.error).split())[:200] or "unspecified"
                 return await advisory(
-                    "evaluator_transient_error", "Seed QA reported a transient evaluator error"
+                    "evaluator_transient_error",
+                    f"Seed QA reported a transient evaluator error: {detail}",
                 )
 
             state.last_qa_score = float(qa_result.score)
@@ -2966,6 +2968,7 @@ class AutoPipeline:
             state=state,
             seed=seed,
             reason=reason,
+            detail=detail,
             attempts=attempts,
             score=score,
             emit=self._emit_runtime_event,

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -2855,7 +2855,7 @@ class AutoPipeline:
                 return await advisory("evaluator_error", f"Seed QA raised {type(exc).__name__}")
 
             if qa_result.error:
-                detail = " ".join(str(qa_result.error).split())[:200] or "unspecified"
+                detail = _safe_seed_qa_error_detail(qa_result.error)
                 return await advisory(
                     "evaluator_transient_error",
                     f"Seed QA reported a transient evaluator error: {detail}",
@@ -5131,6 +5131,28 @@ def _safe_seed_qa_verdict(verdict: str) -> str:
     if normalized in {"fail", "pass", "revise"}:
         return normalized
     return "unknown"
+
+
+def _safe_seed_qa_error_detail(error: object) -> str:
+    """Classify an evaluator error without persisting provider output.
+
+    Provider errors can embed stderr, paths, credentials, and user content in
+    their message. Only these allowlisted categories cross the durable event
+    and progress-message boundary.
+    """
+    lowered = str(error).casefold()
+    categories = (
+        (("rate limit", "too many requests", "429"), "provider rate limit"),
+        (
+            ("unauthorized", "authentication", "api key", "credential"),
+            "provider authentication failure",
+        ),
+        (("connection", "network", "unavailable", "timed out"), "provider connectivity failure"),
+    )
+    for markers, summary in categories:
+        if any(marker in lowered for marker in markers):
+            return summary
+    return "provider evaluator failure"
 
 
 def _first_nonempty(*values: str | None) -> str | None:

--- a/src/ouroboros/auto/seed_qa_advisory.py
+++ b/src/ouroboros/auto/seed_qa_advisory.py
@@ -50,6 +50,7 @@ async def publish_advisory(
     state: AutoPipelineState,
     seed: Seed,
     reason: str,
+    detail: str,
     attempts: int,
     score: float | None,
     emit: Callable[[str, str, dict[str, Any]], Awaitable[None]],
@@ -68,7 +69,14 @@ async def publish_advisory(
     await emit(
         SEED_QA_ADVISORY_EVENT,
         state.auto_session_id,
-        seed_qa_advisory_payload(state, seed, reason=reason, attempts=attempts, score=score),
+        seed_qa_advisory_payload(
+            state,
+            seed,
+            reason=reason,
+            detail=detail,
+            attempts=attempts,
+            score=score,
+        ),
     )
 
 
@@ -94,6 +102,7 @@ def seed_qa_advisory_payload(
     seed: Seed,
     *,
     reason: str,
+    detail: str,
     attempts: int,
     score: float | None,
 ) -> dict[str, Any]:
@@ -114,6 +123,7 @@ def seed_qa_advisory_payload(
         "differences": list(state.last_qa_differences[:_MAX_EVIDENCE]),
         "suggestions": list(state.last_qa_suggestions[:_MAX_EVIDENCE]),
         "reason": reason,
+        "detail": " ".join(detail.split())[:200],
     }
 
 

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -2004,7 +2004,7 @@ async def test_a_failed_evaluator_never_republishes_the_previous_verdict(
             passed=False,
             score=0.0,
             verdict="",
-            error="upstream adapter unavailable",
+            error="upstream adapter unavailable; stderr token=sk_live_do_not_persist /private/data",
         )
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
@@ -2045,7 +2045,10 @@ async def test_a_failed_evaluator_never_republishes_the_previous_verdict(
     assert advisory["differences"] == []
     assert advisory["suggestions"] == []
     if failure == "transient":
-        assert advisory["detail"].endswith("upstream adapter unavailable")
+        assert advisory["detail"].endswith("provider connectivity failure")
+        persisted = repr(advisory) + (state.last_progress_message or "")
+        assert "sk_live_do_not_persist" not in persisted
+        assert "/private/data" not in persisted
     assert result.status == "complete"
 
 

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -2000,7 +2000,12 @@ async def test_a_failed_evaluator_never_republishes_the_previous_verdict(
             raise AssertionError("unreachable")
         if failure == "exception":
             raise RuntimeError("evaluator crashed")
-        return EvaluateResult(passed=False, score=0.0, verdict="", error="transient")
+        return EvaluateResult(
+            passed=False,
+            score=0.0,
+            verdict="",
+            error="upstream adapter unavailable",
+        )
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
     state.max_repair_rounds = 1
@@ -2039,6 +2044,8 @@ async def test_a_failed_evaluator_never_republishes_the_previous_verdict(
     assert advisory["score"] is None
     assert advisory["differences"] == []
     assert advisory["suggestions"] == []
+    if failure == "transient":
+        assert advisory["detail"].endswith("upstream adapter unavailable")
     assert result.status == "complete"
 
 


### PR DESCRIPTION
Supersedes #2103.

The current main branch intentionally treats transient Seed QA evaluator failures as advisory and continues, so the older retry/blocking implementation cannot merge cleanly. Preserve the newer non-blocking contract while carrying a bounded, normalized transport diagnostic in the durable advisory event.

Tests: focused Seed QA advisory/evaluator-failure tests, Ruff, and format checks pass.

## R-run comparison

| Metric | Baseline (sha) | This PR (sha) | Ratio |
|---|---|---|---|
| Rounds completed in 600 s | N/A | N/A | n/a |
| Per-round wall-clock (s/round) | N/A | N/A | n/a |
| Terminal reason | N/A | N/A | n/a |
| EventStore event count | N/A | N/A | n/a |

Budget compliance: [x] N/A (bounded control-flow/diagnostic change; no per-round execution work)