### PR TITLE
feat(pm): let advisory lanes answer from this session's earlier findings

### DIFF
--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -2486,6 +2486,11 @@ def create_ouroboros_server(
             agent_runtime_backend=interview_runtime_backend,
             opencode_mode=opencode_mode,
             fanout_registry=fanout_registry,
+            # The same workspace ``create_fanout_handlers`` builds the artifact
+            # store from, below. A lane is told where this session's earlier
+            # answers are, and one composition passing a different path than the
+            # one that wrote them would send it somewhere empty.
+            project_dir=effective_cwd,
         ),
         BrownfieldHandler(_store=brownfield_store),
         evaluate_handler,

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1610,7 +1610,7 @@ def create_ouroboros_server(
     )
     from ouroboros.mcp.tools.evaluation_composition import create_shared_evaluation_handlers
     from ouroboros.mcp.tools.fanout import FanoutRegistry
-    from ouroboros.mcp.tools.pm_handler import PMInterviewHandler
+    from ouroboros.mcp.tools.interview_composition import create_interview_handlers
     from ouroboros.mcp.tools.qa import QAHandler
     from ouroboros.mcp.tools.registry import ToolRegistry
     from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
@@ -2475,27 +2475,20 @@ def create_ouroboros_server(
             opencode_mode=opencode_mode,
         ),
         MeasureDriftHandler(event_store=event_store),
-        InterviewHandler(
+        # ``workspace`` is the same value ``create_fanout_handlers`` builds the
+        # artifact store from below, so the composition that writes fan-out
+        # results and the one that points a lane at them cannot name different
+        # directories.
+        *create_interview_handlers(
             interview_engine=interview_engine,
+            state_dir=state_dir_path,
+            workspace=effective_cwd,
             event_store=event_store,
+            fanout_registry=fanout_registry,
             llm_backend=interview_llm_backend,
             agent_runtime_backend=interview_runtime_backend,
             opencode_mode=opencode_mode,
-            fanout_registry=fanout_registry,
             suppress_tool_use_prompt_cues=interview_envelope_sealed,
-        ),
-        PMInterviewHandler(
-            data_dir=state_dir_path,
-            llm_backend=interview_llm_backend,
-            event_store=event_store,
-            agent_runtime_backend=interview_runtime_backend,
-            opencode_mode=opencode_mode,
-            fanout_registry=fanout_registry,
-            # The same workspace ``create_fanout_handlers`` builds the artifact
-            # store from, below. A lane is told where this session's earlier
-            # answers are, and one composition passing a different path than the
-            # one that wrote them would send it somewhere empty.
-            project_dir=effective_cwd,
         ),
         BrownfieldHandler(_store=brownfield_store),
         evaluate_handler,

--- a/src/ouroboros/mcp/tools/definitions.py
+++ b/src/ouroboros/mcp/tools/definitions.py
@@ -416,6 +416,9 @@ def evolve_rewind_handler() -> EvolveRewindHandler:
 # Tool handler tuple type and factory
 # ---------------------------------------------------------------------------
 from ouroboros.mcp.tools.brownfield_handler import BrownfieldHandler  # noqa: E402
+from ouroboros.mcp.tools.interview_composition import (  # noqa: E402
+    create_interview_handlers,
+)
 from ouroboros.mcp.tools.pm_handler import PMInterviewHandler  # noqa: E402
 
 OuroborosToolHandlers = tuple[
@@ -539,11 +542,16 @@ def get_ouroboros_tools(
     job_status = JobStatusHandler()
     job_wait = JobWaitHandler()
     job_result = JobResultHandler()
-    interview = InterviewHandler(
+    # Both interview handlers come from one wiring, shared with the server's
+    # composition root. This set has no event store, engine or state dir to
+    # give them, and passing less is the difference between the roots that is
+    # real; how the two are wired is not, and is no longer written twice.
+    interview, pm_interview = create_interview_handlers(
+        fanout_registry=fanout_registry,
+        workspace=project_dir,
         llm_backend=llm_backend,
         agent_runtime_backend=runtime_backend,
         opencode_mode=opencode_mode,
-        fanout_registry=fanout_registry,
     )
     generate_seed = GenerateSeedHandler(
         llm_backend=llm_backend,
@@ -650,13 +658,7 @@ def get_ouroboros_tools(
         EvolveRewindHandler(),
         CancelExecutionHandler(),
         BrownfieldHandler(),
-        PMInterviewHandler(
-            llm_backend=llm_backend,
-            agent_runtime_backend=runtime_backend,
-            opencode_mode=opencode_mode,
-            fanout_registry=fanout_registry,
-            project_dir=Path(project_dir) if project_dir is not None else None,
-        ),
+        pm_interview,
         QAHandler(
             llm_backend=llm_backend,
             agent_runtime_backend=runtime_backend,

--- a/src/ouroboros/mcp/tools/definitions.py
+++ b/src/ouroboros/mcp/tools/definitions.py
@@ -655,6 +655,7 @@ def get_ouroboros_tools(
             agent_runtime_backend=runtime_backend,
             opencode_mode=opencode_mode,
             fanout_registry=fanout_registry,
+            project_dir=Path(project_dir) if project_dir is not None else None,
         ),
         QAHandler(
             llm_backend=llm_backend,

--- a/src/ouroboros/mcp/tools/fanout.py
+++ b/src/ouroboros/mcp/tools/fanout.py
@@ -73,6 +73,11 @@ _DEFAULT_FANOUT_DIR = Path.home() / ".ouroboros" / "data" / "fanout"
 #: ``/tmp/forged.json``, and a check placed after that join is already too late.
 _FANOUT_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,128}")
 
+#: How many of a session's earlier fan-out ids a producer may hand a child.
+#: A cap rather than the whole history: the list is read by a subagent, and an
+#: hour-long interview should not spend its child's attention on round one.
+_SESSION_FANOUT_ID_LIMIT = 12
+
 # Fan-out re-entry kinds — each routes to one revived synthesizer.
 FANOUT_KIND_LATERAL_PERSONA_PANEL = "lateral_persona_panel"
 FANOUT_KIND_CODE_INVESTIGATION = "code_investigation"
@@ -306,6 +311,54 @@ class FanoutRegistry:
         # it was written to part of a promise. See ``rebase_default``.
         self._issued = True
         return resolved_id
+
+    def session_fanout_ids(
+        self,
+        session_id: str,
+        *,
+        kind: str,
+        limit: int = _SESSION_FANOUT_ID_LIMIT,
+    ) -> tuple[str, ...]:
+        """Return this session's fan-out ids of one kind, most recent first.
+
+        The join this walks already existed and was never traversed: a record
+        holds ``session_id``, and the artifact a submission publishes holds the
+        ``fanout_id`` the record is named by. So "what did this session's lanes
+        already find" needs no new index and no second copy of child output --
+        only these ids, which are the addresses the two sides meet at.
+
+        Returned to a *producer*, never to a submitter. Nothing here decides
+        whether a fan-out completes, so a record this misses costs a child one
+        place it could have looked rather than costing the fan-out its gate.
+        That is also why a corrupt or unreadable record is skipped rather than
+        raised on: the caller's turn is the question, and losing the lookup must
+        not cost the user their question.
+
+        Ordered by write time so "most recent first" means most recent round
+        first, and bounded, because the child reads this list and a session that
+        ran long should not hand it a longer one.
+        """
+        try:
+            entries = list(self._dir.glob("*.json"))
+        except OSError:
+            return ()
+        found: list[tuple[float, str]] = []
+        for path in entries:
+            try:
+                written = path.stat().st_mtime
+            except OSError:
+                continue
+            record = self.load(path.stem)
+            if record is None or record.kind != kind:
+                continue
+            if record.session_id != session_id:
+                continue
+            found.append((written, record.fanout_id))
+        # ``fanout_id`` breaks a same-timestamp tie, so two records written in
+        # one clock tick order the same way on every call rather than by
+        # whatever order the directory happened to be read in.
+        found.sort(key=lambda item: (-item[0], item[1]))
+        return tuple(fanout_id for _, fanout_id in found[:limit])
 
     def load(self, fanout_id: str) -> FanoutRecord | None:
         """Load a persisted fan-out record, or ``None`` if unknown/corrupt."""

--- a/src/ouroboros/mcp/tools/interview_composition.py
+++ b/src/ouroboros/mcp/tools/interview_composition.py
@@ -1,0 +1,82 @@
+"""Shared interview-family wiring for executable MCP composition roots.
+
+Two roots build handlers: ``create_ouroboros_server`` wires the MCP server a
+client connects to, and ``get_ouroboros_tools`` wires the lighter set an
+in-process runtime dispatches to. They are not copies of each other and should
+not be merged -- one injects an event store, interview engines and a job
+manager the other has no equivalent for.
+
+What *was* duplicated is the wiring contract for the handlers they share, and
+that is what lives here. Both interview handlers are advisory producers: each
+takes a fan-out registry, and the PM one also takes the workspace whose
+artifacts a lane is pointed at. Those two arguments must arrive together --
+a producer holding a registry and no workspace computes the right prior-round
+ids and then discards them, which reads exactly like a session with no history.
+In #2146 the server passed the workspace to the artifact store and nothing to
+the producer, twenty lines apart in one function, and the feature was dead in
+production while every lane-level test stayed green.
+
+One function both roots call is what keeps that from recurring by omission:
+there is no longer a second place to remember. Where a root genuinely has less
+to give -- no event store, no engine, no workspace -- it passes less, and the
+handlers' own defaults absorb it. That is the difference between the roots that
+is real, kept, and separated from the contract that is not.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
+from ouroboros.mcp.tools.fanout import FanoutRegistry
+from ouroboros.mcp.tools.pm_handler import PMInterviewHandler
+
+
+def create_interview_handlers(
+    *,
+    fanout_registry: FanoutRegistry | None = None,
+    workspace: Path | str | None = None,
+    llm_backend: str | None = None,
+    agent_runtime_backend: str | None = None,
+    opencode_mode: str | None = None,
+    interview_engine: Any | None = None,
+    event_store: Any | None = None,
+    state_dir: Path | None = None,
+    suppress_tool_use_prompt_cues: bool = False,
+) -> tuple[InterviewHandler, PMInterviewHandler]:
+    """Return the interview and PM-interview handlers, wired the same way.
+
+    ``workspace`` is the resolved project the fan-out artifact store is built
+    from, and it reaches the PM producer so a lane can be told where this
+    session's earlier answers were published. A root that configures no store
+    passes ``None`` and the producer tells its children nothing, which is the
+    honest state rather than a degraded one: there is nothing stored to point
+    at, and a child sent looking would spend a tool call learning that.
+
+    Returned as a pair rather than registered here, because which tools a root
+    exposes and in what order is the root's business; what belongs to this
+    module is only how the two are wired.
+    """
+    interview = InterviewHandler(
+        interview_engine=interview_engine,
+        event_store=event_store,
+        llm_backend=llm_backend,
+        agent_runtime_backend=agent_runtime_backend,
+        opencode_mode=opencode_mode,
+        fanout_registry=fanout_registry,
+        suppress_tool_use_prompt_cues=suppress_tool_use_prompt_cues,
+    )
+    pm_interview = PMInterviewHandler(
+        data_dir=state_dir,
+        event_store=event_store,
+        llm_backend=llm_backend,
+        agent_runtime_backend=agent_runtime_backend,
+        opencode_mode=opencode_mode,
+        fanout_registry=fanout_registry,
+        project_dir=Path(workspace) if workspace is not None else None,
+    )
+    return interview, pm_interview
+
+
+__all__ = ["create_interview_handlers"]

--- a/src/ouroboros/mcp/tools/pm_handler.py
+++ b/src/ouroboros/mcp/tools/pm_handler.py
@@ -369,6 +369,7 @@ class PMInterviewHandler:
     agent_runtime_backend: str | None = field(default=None, repr=False)
     opencode_mode: str | None = field(default=None, repr=False)
     fanout_registry: FanoutRegistry | None = field(default=None, repr=False)
+    project_dir: Path | None = field(default=None, repr=False)
 
     def _attach_advisory(self, meta: dict[str, Any], session_id: str, question: str) -> None:
         """Attach the evidence lanes to one PM turn that shows ``question``.
@@ -382,6 +383,11 @@ class PMInterviewHandler:
         because two of the four question turns run on a session loaded from disk
         and have no engine state to read it from. Reading one source on all four
         is what keeps the roster from depending on how the turn was reached.
+
+        ``project_dir`` travels the same way and for the same reason: every one
+        of the four turns can have earlier rounds behind it, so a turn that
+        reached the question by resume must be able to say where their answers
+        are just as the turn that asked it directly can.
         """
         pm_meta = _load_pm_meta(session_id, data_dir=self.data_dir)
         attach_question_advisory(
@@ -396,6 +402,7 @@ class PMInterviewHandler:
             runtime_backend=self.agent_runtime_backend,
             opencode_mode=self.opencode_mode,
             fanout_registry=self.fanout_registry,
+            project_dir=self.project_dir,
         )
 
     @property

--- a/src/ouroboros/mcp/tools/question_advisory.py
+++ b/src/ouroboros/mcp/tools/question_advisory.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 import hashlib
 import json
+from pathlib import Path
 from typing import Any
 
 import structlog
@@ -38,7 +39,11 @@ from ouroboros.mcp.tools.advisory_prompts import (
     _data_context_lane_brief,
     _data_context_lane_task,
 )
-from ouroboros.mcp.tools.fanout import FanoutRegistry, stamp_question_advisory_fanout
+from ouroboros.mcp.tools.fanout import (
+    FANOUT_KIND_QUESTION_ADVISORY,
+    FanoutRegistry,
+    stamp_question_advisory_fanout,
+)
 from ouroboros.mcp.tools.subagent import (
     _INTERVIEW_ADVISORY_MAX_JSON_CHARS,
     _INTERVIEW_ADVISORY_MAX_QUESTION_CHARS,
@@ -285,6 +290,48 @@ def _lane_agent(raw_lane: Mapping[str, Any], persona: str, capability: str) -> s
     return "researcher" if capability in {"inspect_code", "web_research"} else "general"
 
 
+def _prior_findings_section(request: Mapping[str, Any]) -> str:
+    """Return the block telling a child where this session's earlier answers are.
+
+    Rendered by presence, like ``ambiguity_score`` above it: a session with no
+    earlier round carries neither field and its child is handed no line about a
+    place with nothing in it.
+
+    **The child is told where to look, not what was found.** Inlining the
+    findings themselves would grow the prompt with every round and would make
+    this server choose, without reading the question, which of them matter. The
+    child has read the question, so it chooses — and pays for reading only what
+    it chose. That is also what keeps the parent's context flat: the search
+    happens inside a subagent that is discarded when the round ends.
+
+    What it must not become is a second set of rules. A lane is help beside a
+    question the user still answers themselves, so there is nothing here about
+    proving a stored answer sufficient, reporting what a reuse left unsettled,
+    or marking an answer as reused. Those would be bookkeeping about
+    incompleteness, and incompleteness is not what this fan-out is guarding
+    against — the guards that matter are the contract's, and they hold whatever
+    the child read: a claim still carries a real path, a roster ``repo_id``, and
+    this question's identity, and still cannot spell itself pre-confirmed.
+    """
+    root = str(request.get("prior_findings_root") or "")
+    raw_ids = request.get("prior_fanout_ids")
+    ids = [str(item) for item in raw_ids] if isinstance(raw_ids, (list, tuple)) else []
+    if not root or not ids:
+        return ""
+    return f"""## Prior Findings
+Earlier rounds of this same session already ran these lanes, and each completed
+run stored its answers as JSON under:
+
+- root: {root}
+- this session's fan-out ids: {", ".join(ids)}
+
+Those files hold answers in the same shape you must return, keyed by `lane_id`
+under `result.aggregated_outputs`, so a finding in one can be reported directly.
+Look there before you read code or take a measurement, and investigate for
+yourself whatever you still need. Grep for a fan-out id or a `lane_id` to find
+the file worth opening rather than reading them all."""
+
+
 def build_question_advisory_subagents(request: Mapping[str, Any]) -> list[SubagentPayload]:
     """Build one advisory subagent payload per lane the catalog declares.
 
@@ -333,6 +380,11 @@ def build_question_advisory_subagents(request: Mapping[str, Any]) -> list[Subage
         if label in request:
             session_lines.append(f"- {label}: {request[label]}")
     session_block = "\n".join(session_lines)
+    # One block for every lane of this turn: where to look is a property of the
+    # session, not of the lane, and a per-lane copy would be one text to keep in
+    # step for no difference in what it says.
+    prior_findings = _prior_findings_section(request)
+    prior_findings_section = f"\n{prior_findings}\n" if prior_findings else ""
 
     payloads: list[SubagentPayload] = []
     seen: set[str] = set()
@@ -381,7 +433,7 @@ def build_question_advisory_subagents(request: Mapping[str, Any]) -> list[Subage
 {lane_task}
 
 {extra}
-
+{prior_findings_section}
 ## Synthesis Contract
 ```json
 {synthesis_contract_json}
@@ -427,6 +479,8 @@ def build_question_advisory_request(
     code_investigation_request: Mapping[str, Any] | None = None,
     repository_roster: list[dict[str, str]] | None = None,
     last_question: str | None = None,
+    prior_findings_root: str | None = None,
+    prior_fanout_ids: tuple[str, ...] | list[str] | None = None,
 ) -> dict[str, Any]:
     """Build the per-question advisory request for one tool's question turn.
 
@@ -436,6 +490,13 @@ def build_question_advisory_request(
     tool-shaped inputs, and each is attached only when its caller supplies one —
     the interview has a code-fact request and no roster; PM has a roster and no
     code-fact request, because a code fact cannot become a PRD answer.
+
+    ``prior_findings_root`` and ``prior_fanout_ids`` are the third such input and
+    travel together: a root with no ids is a directory with nothing in it for
+    this session, and ids with no root are addresses with nowhere to resolve
+    them. Both are values this server wrote — a path and a list of ids — so
+    carrying them costs the request nothing that grows with what the children
+    found, and puts no child-authored text on the producer side at all.
     """
     mcp_tool_capability = ouroboros_tool_capability_metadata(tool_name)
     advisory = mcp_tool_capability["orchestration"]["question_advisory_fanout"]
@@ -465,7 +526,45 @@ def build_question_advisory_request(
         request["code_investigation_request"] = dict(code_investigation_request)
     if repository_roster is not None:
         request["repository_roster"] = repository_roster
+    # Attached only as a pair, and only when the pair points at something. The
+    # first question of a session has no earlier round, and a child told to look
+    # somewhere empty spends a tool call learning that.
+    if prior_findings_root and prior_fanout_ids:
+        request["prior_findings_root"] = prior_findings_root
+        request["prior_fanout_ids"] = list(prior_fanout_ids)
     return request
+
+
+def _prior_findings_root(project_dir: Path | str | None) -> str | None:
+    """Return where this project's fan-out artifacts live, or ``None``.
+
+    Derived from the project rather than passed in ready-made, so this and the
+    store that writes there cannot disagree about the address:
+    ``ContentAddressedArtifactStore.for_project`` builds the same path from the
+    same input.
+    """
+    if project_dir is None:
+        return None
+    try:
+        return str(Path(project_dir).expanduser().resolve() / ".ouroboros" / "artifacts")
+    except OSError:
+        return None
+
+
+def _prior_fanout_ids(registry: FanoutRegistry | None, session_id: str) -> tuple[str, ...]:
+    """Return this session's earlier question-advisory ids, newest first.
+
+    Advisory, in the sense the whole lane is: a registry that cannot answer
+    leaves the child with one fewer place to look, which is a smaller loss than
+    the turn it would cost to raise here. The contract is unchanged either way —
+    nothing downstream reads this list.
+    """
+    if registry is None or not session_id:
+        return ()
+    try:
+        return registry.session_fanout_ids(session_id, kind=FANOUT_KIND_QUESTION_ADVISORY)
+    except OSError:
+        return ()
 
 
 def attach_question_advisory(
@@ -484,6 +583,7 @@ def attach_question_advisory(
     runtime_backend: str | None = None,
     opencode_mode: str | None = None,
     fanout_registry: FanoutRegistry | None = None,
+    project_dir: Path | str | None = None,
 ) -> None:
     """Attach the advisory fan-out to a turn that shows a question to the user.
 
@@ -495,6 +595,11 @@ def attach_question_advisory(
     A build failure leaves the turn otherwise intact. The question is what the
     user needs; losing the lanes costs them evidence, while raising here would
     cost them the question.
+
+    ``project_dir`` is what makes this session's earlier findings reachable: the
+    artifacts a submission publishes live under it, and without it a child is
+    told about ids it has nowhere to resolve. A caller that does not have one
+    still gets its lanes, and they investigate the way they always did.
     """
     if not question:
         return
@@ -508,6 +613,8 @@ def attach_question_advisory(
         code_investigation_request=code_investigation_request,
         repository_roster=repository_roster,
         last_question=last_question,
+        prior_findings_root=_prior_findings_root(project_dir),
+        prior_fanout_ids=_prior_fanout_ids(fanout_registry, session_id),
     )
     try:
         payloads = build_question_advisory_subagents(request)

--- a/src/ouroboros/orchestrator/capabilities/pm_schemas.py
+++ b/src/ouroboros/orchestrator/capabilities/pm_schemas.py
@@ -233,9 +233,9 @@ def _pm_examined_repository_schema(*, max_claims: int) -> dict[str, Any]:
         "required": ["repo_id", "policy_claims"],
         "properties": {
             "repo_id": _pm_repo_id_property(
-                "Roster identifier of a repository this lane read. An identifier "
-                "outside the roster, or one repeated in another entry, is "
-                "rejected at re-entry."
+                "Roster identifier of a repository this answer stands on. An "
+                "identifier outside the roster, or one repeated in another "
+                "entry, is rejected at re-entry."
             ),
             "policy_claims": {
                 "type": "array",
@@ -311,6 +311,17 @@ def _pm_code_context_answer_contract() -> dict[str, Any]:
     silently reading as "searched everywhere and found nothing". A repository
     the lane never opened simply has no entry, which is what makes stopping
     early -- the behaviour the lane brief asks for -- reportable honestly.
+
+    **The reading it reports is the session's, not the turn's.** A lane may
+    answer from what an earlier question of the same session already found, so
+    an entry means "this answer stands on this repository" rather than "I opened
+    it in this turn". The session was already the time envelope here -- it is
+    why ``data_context`` carries no ``observed_at`` -- and nothing in the shape
+    changes: the entry still names a roster repository, the claim still carries
+    a real path in it, and neither is spellable for a repository nobody read.
+    What deliberately has no field is which turn did the reading. That would be
+    bookkeeping about the lane's own completeness, and completeness is not what
+    this contract holds; it holds that the answer cannot lie about its sources.
     """
     identity_property = {
         "type": "string",
@@ -333,9 +344,12 @@ def _pm_code_context_answer_contract() -> dict[str, Any]:
             "maxItems": _PM_EXAMINED_MAX_REPOSITORIES,
             "items": _pm_examined_repository_schema(max_claims=max_claims),
             "description": (
-                "Repositories this lane read, one entry each, carrying what it "
-                "found there. A repository it did not open has no entry; an "
-                "entry with no claims was read and had nothing."
+                "Repositories this answer stands on, one entry each, carrying "
+                "what was found there. Reading may have happened on an earlier "
+                "question of this same session -- the session is the time "
+                "envelope, as it already is for a measurement's age. A "
+                "repository nobody read has no entry; an entry with no claims "
+                "was read and had nothing."
             ),
         }
         if max_claims:

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -4499,14 +4499,14 @@ class TestCreateOuroborosServerOpenCodeMode:
             "ouroboros_execute_seed": "ouroboros.mcp.tools.definitions.ExecuteSeedHandler",
             "ouroboros_start_execute_seed": "ouroboros.mcp.tools.definitions.StartExecuteSeedHandler",
             "ouroboros_generate_seed": "ouroboros.mcp.tools.definitions.GenerateSeedHandler",
-            "ouroboros_interview": "ouroboros.mcp.tools.definitions.InterviewHandler",
+            "ouroboros_interview": "ouroboros.mcp.tools.interview_composition.InterviewHandler",
             "ouroboros_evaluate": "ouroboros.mcp.tools.definitions.EvaluateHandler",
             "ouroboros_lateral_think": "ouroboros.mcp.tools.definitions.LateralThinkHandler",
             "ouroboros_evolve_step": "ouroboros.mcp.tools.definitions.EvolveStepHandler",
             "ouroboros_start_evolve_step": "ouroboros.mcp.tools.definitions.StartEvolveStepHandler",
             "ouroboros_ralph": "ouroboros.mcp.tools.definitions.RalphHandler",
             "ouroboros_start_ralph": "ouroboros.mcp.tools.definitions.StartRalphHandler",
-            "ouroboros_pm_interview": "ouroboros.mcp.tools.pm_handler.PMInterviewHandler",
+            "ouroboros_pm_interview": "ouroboros.mcp.tools.interview_composition.PMInterviewHandler",
             "ouroboros_qa": "ouroboros.mcp.tools.qa.QAHandler",
         }
 

--- a/tests/unit/mcp/test_fanout_composition_wiring.py
+++ b/tests/unit/mcp/test_fanout_composition_wiring.py
@@ -1,0 +1,106 @@
+"""Both composition roots must agree about where fan-out artifacts live.
+
+Ouroboros builds its handlers in two places, and the split is not accidental:
+``create_ouroboros_server`` wires the MCP server a client connects to, with an
+event store, interview engines and a job manager behind it, while
+``get_ouroboros_tools`` wires the lighter set an in-process runtime dispatches
+to without a server at all. Neither list is a copy of the other -- they inject
+different services, and merging them would mean one path dragging in what the
+other has no equivalent for.
+
+What *is* duplicated is the wiring contract for the handlers they share, and
+that is what these tests hold. A fan-out has two sides: the submit handler
+publishes each completed run into a project-local artifact store, and the
+advisory producer tells a child where those artifacts landed. The two sides are
+wired from separate arguments in both roots, so a root can wire one and not the
+other -- which is exactly what shipped in #2146, where the server passed its
+workspace to the store and nothing to the producer. Every lane-level test kept
+passing, because each of them builds its own request and so never travels the
+composition that omitted one.
+
+The invariant is a conditional rather than "both roots pass the same thing": a
+root that cannot store fan-out results has nothing to point a child at, and
+telling it to carry a workspace anyway would be a rule with no defect behind
+it. What must not exist is the half -- storage with no address.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ouroboros.mcp.server.adapter import create_ouroboros_server
+from ouroboros.mcp.tools.definitions import get_ouroboros_tools
+from ouroboros.mcp.tools.fanout_handler import SubmitFanoutResultsHandler
+from ouroboros.mcp.tools.pm_handler import PMInterviewHandler
+
+
+def _artifact_root(handlers: Any) -> Path | None:
+    """Return the root the submit side would publish into, if it can publish."""
+    submit = next(
+        (handler for handler in handlers if isinstance(handler, SubmitFanoutResultsHandler)),
+        None,
+    )
+    if submit is None or submit.disposable_memory is None:
+        return None
+    return Path(submit.disposable_memory.artifact_store.root)
+
+
+def _advisory_root(handlers: Any) -> Path | None:
+    """Return the root the advisory producer would send a child to."""
+    producer = next(
+        (handler for handler in handlers if isinstance(handler, PMInterviewHandler)),
+        None,
+    )
+    assert producer is not None, "no PM advisory producer registered"
+    if producer.project_dir is None:
+        return None
+    return Path(producer.project_dir).expanduser().resolve() / ".ouroboros" / "artifacts"
+
+
+def test_the_server_points_the_producer_at_the_store_it_writes_to(tmp_path: Path) -> None:
+    """The composition that ships, compared side against side by value.
+
+    Equality is the assertion, not "both are set". Two roots agreeing that a
+    path exists is not the same as agreeing on which one, and a producer sent
+    to a neighbouring directory reads exactly like a session with no history.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server = create_ouroboros_server(
+        project_dir=workspace,
+        state_dir=tmp_path / "state",
+        durable_jobs=False,
+    )
+    handlers = list(server._tool_handlers.values())
+
+    stored_at = _artifact_root(handlers)
+    assert stored_at is not None, "the server can always publish; this root cannot be absent"
+    assert _advisory_root(handlers) == stored_at
+
+
+def test_the_runtime_tool_set_points_the_producer_at_the_store_it_writes_to(
+    tmp_path: Path,
+) -> None:
+    """The other root, held to the same conditional, with a workspace given."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    handlers = list(get_ouroboros_tools(project_dir=workspace))
+
+    stored_at = _artifact_root(handlers)
+    assert stored_at is not None, "a workspace was given, so publication is configured"
+    assert _advisory_root(handlers) == stored_at
+
+
+def test_a_root_that_cannot_store_results_is_not_asked_to_carry_an_address() -> None:
+    """No workspace means no store, and no store means nothing to point at.
+
+    Held so the invariant above cannot later be "tightened" into demanding a
+    workspace everywhere. A runtime tool set built for inspection has no
+    artifacts, and a child sent to look for them would spend a tool call
+    learning that.
+    """
+    handlers = list(get_ouroboros_tools())
+
+    assert _artifact_root(handlers) is None
+    assert _advisory_root(handlers) is None

--- a/tests/unit/mcp/tools/test_fanout_core.py
+++ b/tests/unit/mcp/tools/test_fanout_core.py
@@ -242,6 +242,52 @@ def test_registry_load_unknown_returns_none(tmp_path: Any) -> None:
     assert FanoutRegistry(tmp_path).load("nope") is None
 
 
+def test_registry_lists_one_sessions_ids_of_one_kind(tmp_path: Any) -> None:
+    """The lookup a producer uses to tell a child where this session has been.
+
+    Both filters are load-bearing and neither substitutes for the other: one
+    directory holds every session, and one session can run a persona panel
+    beside its advisory lanes. An id that passed only the session filter would
+    send a child to read a panel's output as though it were a lane's.
+    """
+    registry = FanoutRegistry(tmp_path)
+
+    def _register(kind: str, session_id: str) -> str:
+        fanout_id = registry.register(
+            kind=kind,
+            session_id=session_id,
+            correlation_key="context.lane_id",
+            expected_keys=["code_context"],
+            synthesizer_input={"request": {}},
+        )
+        assert fanout_id is not None
+        return fanout_id
+
+    mine_first = _register(FANOUT_KIND_QUESTION_ADVISORY, "s1")
+    mine_second = _register(FANOUT_KIND_QUESTION_ADVISORY, "s1")
+    other_session = _register(FANOUT_KIND_QUESTION_ADVISORY, "s2")
+    other_kind = _register(FANOUT_KIND_LATERAL_PERSONA_PANEL, "s1")
+
+    listed = registry.session_fanout_ids("s1", kind=FANOUT_KIND_QUESTION_ADVISORY)
+    assert set(listed) == {mine_first, mine_second}
+    assert other_session not in listed
+    assert other_kind not in listed
+
+
+def test_registry_lists_nothing_for_a_session_that_has_not_run(tmp_path: Any) -> None:
+    """A directory that does not exist yet is an empty history, not a failure.
+
+    The producer calls this while building a question turn, so anything raised
+    here would cost the user their question to save a child one shortcut.
+    """
+    assert (
+        FanoutRegistry(tmp_path / "absent").session_fanout_ids(
+            "s1", kind=FANOUT_KIND_QUESTION_ADVISORY
+        )
+        == ()
+    )
+
+
 # --------------------------------------------------------------------------- #
 # submit_fanout_results routing
 # --------------------------------------------------------------------------- #

--- a/tests/unit/mcp/tools/test_pm_question_advisory.py
+++ b/tests/unit/mcp/tools/test_pm_question_advisory.py
@@ -1382,3 +1382,50 @@ def test_the_producer_hands_over_addresses_and_never_what_a_child_found(
     assert first["question_advisory_fanout_id"] in prompt
     assert claim not in prompt
     assert claim not in json.dumps(later["question_advisory_request"])
+
+
+def test_the_shipped_server_hands_pm_the_workspace_its_artifacts_live_under(
+    tmp_path: Path,
+) -> None:
+    """Two turns through the composed server, not through the helper directly.
+
+    The lane-level tests above all build their own request, so every one of them
+    passes while the composition that actually ships passes no workspace at all
+    — and a feature nothing constructs is dead in production while its unit
+    tests stay green. This drives the handler the server registered: turn one
+    registers a fan-out, turn two must be told where turn one's answers went.
+
+    The path is asserted against the artifact store's own, resolved from the
+    same workspace, because two compositions agreeing that a path exists is not
+    the same as them agreeing on which one.
+    """
+    from ouroboros.mcp.server.adapter import create_ouroboros_server
+    from ouroboros.persistence.artifact_store import ContentAddressedArtifactStore
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server = create_ouroboros_server(
+        project_dir=workspace,
+        state_dir=tmp_path / "state",
+        durable_jobs=False,
+    )
+    handler = next(
+        candidate
+        for candidate in server._tool_handlers.values()
+        if isinstance(candidate, PMInterviewHandler)
+    )
+
+    first: dict[str, Any] = {}
+    handler._attach_advisory(first, "pm-server", QUESTION)
+    later: dict[str, Any] = {}
+    handler._attach_advisory(later, "pm-server", "Second question?")
+
+    prompts = {
+        payload.context["lane_id"]: payload.to_dict()["prompt"]
+        for payload in build_question_advisory_subagents(later["question_advisory_request"])
+    }
+    assert prompts, "the composed handler attached no lanes"
+    expected_root = str(ContentAddressedArtifactStore.for_project(workspace).root)
+    for prompt in prompts.values():
+        assert expected_root in prompt
+        assert first["question_advisory_fanout_id"] in prompt

--- a/tests/unit/mcp/tools/test_pm_question_advisory.py
+++ b/tests/unit/mcp/tools/test_pm_question_advisory.py
@@ -143,6 +143,7 @@ def _attach(
     *,
     session_id: str = "pm-1",
     question: str = QUESTION,
+    project_dir: Path | None = None,
 ) -> dict[str, Any]:
     meta: dict[str, Any] = {}
     attach_question_advisory(
@@ -152,6 +153,7 @@ def _attach(
         question=question,
         repository_roster=roster,
         fanout_registry=registry,
+        project_dir=project_dir,
     )
     return meta
 
@@ -1254,3 +1256,129 @@ def test_no_constant_names_a_synthetic_round_any_more() -> None:
     import ouroboros.orchestrator.capabilities.pm_schemas as pm_schemas
 
     assert [name for name in dir(pm_schemas) if "EVIDENCE_ROUND" in name] == []
+
+
+# ── Decision 16: a lane may answer from what this session already found ───
+
+
+def _lane_prompts(meta: dict[str, Any]) -> dict[str, str]:
+    """Return the emitted prompt for every lane of one question turn."""
+    return {
+        payload.context["lane_id"]: payload.to_dict()["prompt"]
+        for payload in build_question_advisory_subagents(meta["question_advisory_request"])
+    }
+
+
+def test_a_later_round_is_told_where_this_sessions_earlier_answers_are(
+    registry: FanoutRegistry,
+    roster: list[dict[str, str]],
+    tmp_path: Path,
+) -> None:
+    """Both lanes get the addresses, because both can be answered from them.
+
+    The pair is what reaches the child: a root with no ids names a directory
+    holding other sessions' work, and ids with no root are addresses with
+    nowhere to resolve them.
+    """
+    first = _attach(registry, roster, project_dir=tmp_path)
+    later = _attach(registry, roster, question="Second question?", project_dir=tmp_path)
+
+    prompts = _lane_prompts(later)
+    assert set(prompts) == {"code_context", "data_context"}
+    for prompt in prompts.values():
+        assert "## Prior Findings" in prompt
+        assert str(tmp_path.resolve() / ".ouroboros" / "artifacts") in prompt
+        assert first["question_advisory_fanout_id"] in prompt
+
+
+def test_the_first_question_of_a_session_is_told_nothing_about_prior_findings(
+    registry: FanoutRegistry,
+    roster: list[dict[str, str]],
+    tmp_path: Path,
+) -> None:
+    """An empty place is worse than no place: looking there costs a tool call.
+
+    The turn's own fan-out is registered after its payloads are built, so a
+    child is never sent to fetch the answer it is being asked to write.
+    """
+    first = _attach(registry, roster, project_dir=tmp_path)
+    for prompt in _lane_prompts(first).values():
+        assert "## Prior Findings" not in prompt
+        assert first["question_advisory_fanout_id"] not in prompt
+
+
+def test_a_lane_with_no_project_to_resolve_against_is_told_nothing(
+    registry: FanoutRegistry,
+    roster: list[dict[str, str]],
+) -> None:
+    """Without a project the ids have no store behind them, so they stay unsent.
+
+    The lanes still run. Losing the shortcut costs a child the places it could
+    have looked; it does not cost the user their question.
+    """
+    _attach(registry, roster)
+    later = _attach(registry, roster, question="Second question?")
+    for prompt in _lane_prompts(later).values():
+        assert "## Prior Findings" not in prompt
+
+
+def test_another_sessions_findings_are_never_offered(
+    registry: FanoutRegistry,
+    roster: list[dict[str, str]],
+    tmp_path: Path,
+) -> None:
+    """One registry serves every session, so the filter is the whole boundary.
+
+    Sessions share a directory and a roster can differ between them, so an id
+    from a neighbouring session would send a child to read a system it was
+    never asked about.
+    """
+    theirs = _attach(registry, roster, session_id="pm-other", project_dir=tmp_path)
+    mine = _attach(registry, roster, session_id="pm-mine", project_dir=tmp_path)
+    later = _attach(
+        registry,
+        roster,
+        session_id="pm-mine",
+        question="Second question?",
+        project_dir=tmp_path,
+    )
+
+    prompt = _lane_prompts(later)["code_context"]
+    assert mine["question_advisory_fanout_id"] in prompt
+    assert theirs["question_advisory_fanout_id"] not in prompt
+
+
+def test_the_producer_hands_over_addresses_and_never_what_a_child_found(
+    registry: FanoutRegistry,
+    roster: list[dict[str, str]],
+    tmp_path: Path,
+) -> None:
+    """The prompt cannot grow with what earlier rounds found, only with ids.
+
+    This is the whole reason the lookup is the child's rather than the server's.
+    Inlining findings would make every round pay for every earlier round, and
+    would make this server pick which of them matter without having read the
+    question. It also keeps the producer side free of child-authored text, which
+    is the obligation RFC #1754 deferred along with durable result state.
+    """
+    claim = "a sentence only the child could have written"
+    first = _attach(registry, roster, project_dir=tmp_path)
+    _submit(
+        registry,
+        first,
+        _found_policy(
+            roster,
+            examined=[
+                {
+                    "repo_id": roster[0]["repo_id"],
+                    "policy_claims": [{"path": "src/billing.py", "policy_claim": claim}],
+                }
+            ],
+        ),
+    )
+
+    later = _attach(registry, roster, question="Second question?", project_dir=tmp_path)
+    prompt = _lane_prompts(later)["code_context"]
+    assert first["question_advisory_fanout_id"] in prompt
+    assert claim not in prompt
+    assert claim not in json.dumps(later["question_advisory_request"])


### PR DESCRIPTION
## Summary

A PM question turn fans out two advisory lanes, and today each one starts from
zero: it greps the roster repositories or runs a measurement, every round, for
every question. Within a single session that repeats work the session already
did — round 5's question is often already answered by a finding round 2 stored.

This tells a lane where its session's earlier answers are, so it can report one
directly instead of re-deriving it. What the parent session receives is
unchanged: the same contracted answer, with no way to tell whether the child
read code, ran a query, or read an earlier round's file. That indifference is
the point — the lane's job is defined by what it returns, not by what it
touched.

## Background

The submissions were never volatile. `ouroboros_submit_fanout_results` publishes
each completed fan-out as a content-addressed artifact under
`<project>/.ouroboros/artifacts/`, and those bodies carry the lane answers whole
— paths, claims, metrics, values. They were simply unreachable: nothing linked a
session to them, so every round re-derived findings that were sitting on disk.

The link turned out to already exist on both sides. A registry record holds
`session_id` and is named by its `fanout_id`; the artifact a submission publishes
holds that same `fanout_id`. Walking that join needs no new index and no second
copy of anything.

## Decisions

**The lookup belongs to the child, not to the server.** The alternative was to
inline earlier findings into the payload. That grows the prompt with every round
whether or not anything is relevant, and it makes the server choose which
findings matter without having read the question. The child has read the
question, so the child chooses — and pays for reading only what it chose. The
parent's context is untouched either way, because the search happens inside a
subagent that is discarded when the round ends.

**Addresses travel; findings do not.** The producer sends a root path and a list
of fan-out ids. Both are values this server wrote, so the request cannot grow
with what children found, and no child-authored text lands on the producer side
— which is the sanitization obligation RFC #1754 deferred alongside durable
result state. That obligation stays deferred rather than being quietly incurred.
A test pins it: a claim submitted in round 1 does not appear in round 2's
prompt.

**Both lanes, not just the code lane.** A measurement looked like the risky one
to reuse until the contract's own position was checked: `data_context` carries
no `observed_at` because "ageing is accepted unconditionally, and the interview
session is the measurement's time envelope". An interview runs for an hour, not
a week. Splitting eligibility per lane would have added a rule the schema had
already decided against.

**No new rules about incompleteness.** An earlier draft had the lane state what
a stored answer settled and what it left open, then investigate the gap. That is
bookkeeping about the lane's own completeness, and completeness is not what this
fan-out guards. What it guards is that an answer cannot lie about its sources,
and every one of those guards holds unchanged here: a claim still carries a real
path and a roster `repo_id`, still gets stamped with this question's identity,
still cannot spell itself pre-confirmed, and the finding still reaches the user
for confirmation before it is recorded. Deliberately not added: a sufficiency
proof, a gap report, a "reused" marker.

**Failure is advisory.** An unreadable registry, a missing directory, or no
project at all costs the child one place it could have looked. It never costs
the user their question: the lanes still run and investigate the way they
always did.

## Contract change

One semantic clarification, no shape change: `examined` entries now mean "the
repositories this answer stands on", where the reading may have happened on an
earlier question of the same session. The session was already the time envelope
here, so this states the scope that was already in force rather than widening
it. What deliberately gains no field is *which* turn did the reading.

## Scope

Wired for `ouroboros_pm_interview` only. The mechanism is generic and renders by
presence, so the interview joins by passing `project_dir` — but it is a
different question shape with six lanes, and that is worth its own look.

## Test plan

- [x] `uv run pytest tests/unit tests/conformance -q` passes
- [x] `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/` clean
- [x] `uv run mypy src/ouroboros/mcp/tools/` clean

New coverage:

- a later round is told where this session's earlier answers are, on both lanes
- the first question of a session is told nothing (an empty place costs a tool
  call), and no turn is sent to fetch the answer it is being asked to write
- another session's ids are never offered, and neither is another kind's
- the producer hands over addresses and never what a child found
- a lane with no project to resolve against is told nothing and still runs
