### PR TITLE
feat(cli): surface zcode CLI model-config readiness in setup and health

### DIFF
--- a/docs/runtime-guides/zcode.md
+++ b/docs/runtime-guides/zcode.md
@@ -16,6 +16,7 @@ installed ZCode coding agent. The runtime supports either the macOS app-bundle
 | --- | --- |
 | ZCode desktop app or `zcode` executable | Provides the coding-agent runtime |
 | A configured Z.ai provider/model | Zcode reads provider and model selection from its own config |
+| `~/.zcode/cli/config.json` with an effective `model.main` | The headless CLI exits with `Model config is missing` without it; see [Model provider configuration](#model-provider-configuration) |
 | Compatible Node.js for a standalone `.cjs` path | Official app bundles use their bundled Electron/Node runtime; standalone scripts use the system Node |
 | Ouroboros base package | No provider-specific Python extra is required |
 
@@ -25,6 +26,10 @@ installed ZCode coding agent. The runtime supports either the macOS app-bundle
 ouroboros setup --runtime zcode
 ouroboros run workflow seed.yaml --runtime zcode
 ```
+
+Setup warns, and `ouroboros status health` reports a warning, when
+`~/.zcode/cli/config.json` has no effective `model.main` — the CLI would
+otherwise fail only after Ouroboros has already spawned it.
 
 If setup cannot find ZCode automatically, configure one of:
 
@@ -58,6 +63,52 @@ paths use the system Node.js. Other paths are treated as executable wrappers or
 binaries and are invoked directly. `NODE_OPTIONS` is removed from both Node
 launch shapes so a project or parent process cannot preload JavaScript into the
 vendor CLI.
+
+## Model provider configuration
+
+Besides the CLI path, the Zcode CLI resolves its model provider from
+`~/.zcode/cli/config.json` on every run — including the headless
+`--prompt --json` invocations Ouroboros spawns. Without an effective
+`model.main` the CLI exits immediately with:
+
+```text
+Error: Model config is missing. Create /Users/<you>/.zcode/cli/config.json
+with an explicit model provider before running ZCode.
+```
+
+`model.main` must be the `"provider-id/model-id"` **string**; an object entry
+is silently dropped by the CLI's config parser, which then reports the same
+missing-config error. The referenced provider id needs an entry in the same
+file's `provider` registry carrying `kind`, `options.baseURL`, and
+`options.apiKey`:
+
+```json
+{
+  "model": { "main": "builtin:zai-coding-plan/GLM-5.3" },
+  "provider": {
+    "builtin:zai-coding-plan": {
+      "name": "Z.ai - Coding Plan",
+      "kind": "anthropic",
+      "options": {
+        "baseURL": "https://api.z.ai/api/anthropic",
+        "apiKey": "<your key>",
+        "apiKeyRequired": true
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+The desktop app's `~/.zcode/v2/config.json` uses the same `provider` registry
+shape, so copying the active provider entry from there is the quickest way to
+satisfy the CLI. OAuth credentials in `~/.zcode/v2/credentials.json` are shared
+between the desktop app and the CLI, but the model reference itself is not:
+the desktop app's model selection does not create `~/.zcode/cli/config.json`.
+
+`ouroboros setup --runtime zcode` warns when this file has no effective
+`model.main`, and the `ouroboros status health` rows for the zcode runtime and
+LLM backend surface the same probe.
 
 ## Runtime and LLM backend
 
@@ -152,6 +203,12 @@ output timeout for their expected task duration.
 
 **Zcode is not detected.** Set `OUROBOROS_ZCODE_CLI_PATH`, configure
 `orchestrator.zcode_cli_path`, or put a `zcode` executable on `PATH`.
+
+**Headless runs exit with `Model config is missing`.** The Zcode CLI has no
+`model.main` it can resolve in `~/.zcode/cli/config.json`. See
+[Model provider configuration](#model-provider-configuration); the two usual
+causes are a missing file and an object-form `model.main`, which the CLI
+silently drops — the reference must be the `"provider-id/model-id"` string.
 
 **A standalone script reports a missing Node built-in such as `node:sqlite`.**
 Use the intact ZCode app-bundle path so Ouroboros can select the bundled

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -3830,6 +3830,37 @@ def _setup_grok(grok_path: str) -> None:
 def _setup_zcode(zcode_path: str) -> None:
     """Configure Ouroboros for the Zcode CLI runtime."""
     _setup_runtime_only_backend("zcode", zcode_path, "zcode_cli_path")
+    _warn_zcode_model_config()
+
+
+def _warn_zcode_model_config() -> None:
+    """Warn when the Zcode CLI itself has no usable model provider config.
+
+    Ouroboros setup only records the CLI path; the Zcode CLI separately
+    resolves its model from ``~/.zcode/cli/config.json`` on every headless
+    run and exits with ``Model config is missing`` when that file has no
+    effective ``model.main`` reference. Without this probe the failure only
+    appears mid-execution, after Ouroboros has already spawned the CLI.
+    """
+
+    from ouroboros.config.zcode_model_config import inspect_zcode_model_config
+
+    status = inspect_zcode_model_config()
+    if status.ok:
+        return
+
+    print_warning(f"Zcode model provider config not ready: {status.detail}")
+    print_info(
+        "Headless Zcode runs will exit with 'Model config is missing' until "
+        f"{status.config_path} defines model.main."
+    )
+    print_info(
+        'Example: {"model": {"main": "builtin:zai-coding-plan/GLM-5.3"}, '
+        '"provider": {"builtin:zai-coding-plan": {"kind": "anthropic", '
+        '"options": {"baseURL": "https://api.z.ai/api/anthropic", "apiKey": "..."}}}} '
+        "(model.main must be the provider/model string). "
+        "See docs/runtime-guides/zcode.md"
+    )
 
 
 def _setup_pi(pi_path: str) -> None:

--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -34,7 +34,7 @@ from ouroboros.cli.formatters.tables import (
     create_table,
     print_table,
 )
-from ouroboros.config.loader import load_config
+from ouroboros.config.loader import get_zcode_cli_path, load_config
 from ouroboros.config.models import resolve_event_store_path
 from ouroboros.config.zcode_model_config import inspect_zcode_model_config
 from ouroboros.events.base import BaseEvent
@@ -693,6 +693,10 @@ def _print_health_details(checks: list[dict[str, str]]) -> None:
 def _candidate_cli_paths(backend: str, data: dict) -> list[str]:
     """Return CLI path candidates using the same precedence as runtime launchers."""
     candidates: list[str] = []
+    if backend == "zcode":
+        zcode_path = get_zcode_cli_path()
+        if zcode_path:
+            candidates.append(zcode_path)
     env_key = _CLI_PATH_ENV_BY_BACKEND.get(backend)
     if env_key is not None:
         env_path = os.environ.get(env_key, "").strip()
@@ -742,7 +746,12 @@ def _check_runtime_backend(data: dict) -> dict[str, str]:
             continue
         expanded = Path(candidate).expanduser()
         if expanded.is_absolute() or len(expanded.parts) > 1:
-            if expanded.exists() and expanded.is_file() and os.access(expanded, os.X_OK):
+            script = backend == "zcode" and expanded.suffix.lower() in {".cjs", ".js", ".mjs"}
+            if (
+                expanded.exists()
+                and expanded.is_file()
+                and (os.access(expanded, os.R_OK) if script else os.access(expanded, os.X_OK))
+            ):
                 return _runtime_backend_health_row(backend, f"{backend}: {expanded}")
             continue
         resolved = shutil.which(candidate)

--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -36,6 +36,7 @@ from ouroboros.cli.formatters.tables import (
 )
 from ouroboros.config.loader import load_config
 from ouroboros.config.models import resolve_event_store_path
+from ouroboros.config.zcode_model_config import inspect_zcode_model_config
 from ouroboros.events.base import BaseEvent
 from ouroboros.mcp.tools.project_status_handler import ProjectStatusHandler
 from ouroboros.mcp.tools.projection_handlers import ProjectionQueryHandler
@@ -742,14 +743,35 @@ def _check_runtime_backend(data: dict) -> dict[str, str]:
         expanded = Path(candidate).expanduser()
         if expanded.is_absolute() or len(expanded.parts) > 1:
             if expanded.exists() and expanded.is_file() and os.access(expanded, os.X_OK):
-                return _health_row("Runtime backend", "ok", f"{backend}: {expanded}")
+                return _runtime_backend_health_row(backend, f"{backend}: {expanded}")
             continue
         resolved = shutil.which(candidate)
         if resolved:
-            return _health_row("Runtime backend", "ok", f"{backend}: {resolved}")
+            return _runtime_backend_health_row(backend, f"{backend}: {resolved}")
 
     expected = candidates[0] if candidates else (capability.cli_name if capability else backend)
     return _health_row("Runtime backend", "error", f"{backend} CLI not found: {expected}")
+
+
+def _runtime_backend_health_row(backend: str, detail: str) -> dict[str, str]:
+    """Augment the zcode runtime row with the CLI's own model readiness.
+
+    Finding the zcode executable is necessary but not sufficient: every
+    headless invocation also needs ``model.main`` in ``~/.zcode/cli/config.json``
+    or the vendor CLI exits with ``Model config is missing`` after Ouroboros
+    has already launched it.
+    """
+
+    if backend != "zcode":
+        return _health_row("Runtime backend", "ok", detail)
+    zcode_model = inspect_zcode_model_config()
+    if not zcode_model.ok:
+        return _health_row(
+            "Runtime backend",
+            "warning",
+            f"{detail}; model config: {zcode_model.detail}",
+        )
+    return _health_row("Runtime backend", "ok", detail)
 
 
 def _credential_provider_for_backend(backend: str) -> str | None:
@@ -812,6 +834,19 @@ def _check_credentials(data: dict, config_path: Path) -> dict[str, str]:
 
     provider = _credential_provider_for_backend(canonical_backend)
     if provider is None:
+        if canonical_backend == "zcode":
+            zcode_model = inspect_zcode_model_config()
+            if not zcode_model.ok:
+                return _health_row(
+                    "Credentials",
+                    "warning",
+                    f"zcode model config: {zcode_model.detail}",
+                )
+            return _health_row(
+                "Credentials",
+                "ok",
+                f"zcode uses local CLI authentication; {zcode_model.detail}",
+            )
         return _health_row(
             "Credentials", "ok", f"{canonical_backend} uses local CLI authentication"
         )

--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -742,7 +742,6 @@ def _check_runtime_backend(data: dict) -> dict[str, str]:
     if backend == "claude" and not candidates:
         return _health_row("Runtime backend", "ok", "claude: SDK default")
 
-    readiness_error: str | None = None
     for candidate in candidates:
         if not candidate:
             continue
@@ -758,8 +757,7 @@ def _check_runtime_backend(data: dict) -> dict[str, str]:
                     try:
                         resolve_zcode_command_prefix(expanded)
                     except RuntimeError as exc:
-                        readiness_error = str(exc)
-                        continue
+                        return _health_row("Runtime backend", "error", str(exc))
                 return _runtime_backend_health_row(backend, f"{backend}: {expanded}")
             continue
         resolved = shutil.which(candidate)
@@ -768,13 +766,10 @@ def _check_runtime_backend(data: dict) -> dict[str, str]:
                 try:
                     resolve_zcode_command_prefix(resolved)
                 except RuntimeError as exc:
-                    readiness_error = str(exc)
-                    continue
+                    return _health_row("Runtime backend", "error", str(exc))
             return _runtime_backend_health_row(backend, f"{backend}: {resolved}")
 
     expected = candidates[0] if candidates else (capability.cli_name if capability else backend)
-    if readiness_error is not None:
-        return _health_row("Runtime backend", "error", readiness_error)
     return _health_row("Runtime backend", "error", f"{backend} CLI not found: {expected}")
 
 

--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -41,6 +41,7 @@ from ouroboros.events.base import BaseEvent
 from ouroboros.mcp.tools.project_status_handler import ProjectStatusHandler
 from ouroboros.mcp.tools.projection_handlers import ProjectionQueryHandler
 from ouroboros.persistence.event_store import EventStore, sqlite_database_url
+from ouroboros.zcode_cli_launcher import resolve_zcode_command_prefix
 
 app = typer.Typer(
     name="status",
@@ -741,6 +742,7 @@ def _check_runtime_backend(data: dict) -> dict[str, str]:
     if backend == "claude" and not candidates:
         return _health_row("Runtime backend", "ok", "claude: SDK default")
 
+    readiness_error: str | None = None
     for candidate in candidates:
         if not candidate:
             continue
@@ -752,13 +754,27 @@ def _check_runtime_backend(data: dict) -> dict[str, str]:
                 and expanded.is_file()
                 and (os.access(expanded, os.R_OK) if script else os.access(expanded, os.X_OK))
             ):
+                if backend == "zcode":
+                    try:
+                        resolve_zcode_command_prefix(expanded)
+                    except RuntimeError as exc:
+                        readiness_error = str(exc)
+                        continue
                 return _runtime_backend_health_row(backend, f"{backend}: {expanded}")
             continue
         resolved = shutil.which(candidate)
         if resolved:
+            if backend == "zcode":
+                try:
+                    resolve_zcode_command_prefix(resolved)
+                except RuntimeError as exc:
+                    readiness_error = str(exc)
+                    continue
             return _runtime_backend_health_row(backend, f"{backend}: {resolved}")
 
     expected = candidates[0] if candidates else (capability.cli_name if capability else backend)
+    if readiness_error is not None:
+        return _health_row("Runtime backend", "error", readiness_error)
     return _health_row("Runtime backend", "error", f"{backend} CLI not found: {expected}")
 
 

--- a/src/ouroboros/config/zcode_model_config.py
+++ b/src/ouroboros/config/zcode_model_config.py
@@ -141,11 +141,25 @@ def inspect_zcode_model_config(
         )
 
     options = entry.get("options")
-    has_base_url = isinstance(options, dict) and bool(options.get("baseURL"))
-    if not entry.get("kind") and not has_base_url:
+    kind = entry.get("kind")
+    base_url = options.get("baseURL") if isinstance(options, dict) else None
+    api_key = options.get("apiKey") if isinstance(options, dict) else None
+    if not isinstance(kind, str) or not kind.strip():
         return ZcodeModelConfigStatus(
             ok=False,
-            detail=f"provider {provider_id!r} entry has neither kind nor options.baseURL",
+            detail=f"provider {provider_id!r} entry has no non-empty kind",
+            config_path=path,
+        )
+    if not isinstance(base_url, str) or not base_url.strip():
+        return ZcodeModelConfigStatus(
+            ok=False,
+            detail=f"provider {provider_id!r} entry has no non-empty options.baseURL",
+            config_path=path,
+        )
+    if not isinstance(api_key, str) or not api_key.strip():
+        return ZcodeModelConfigStatus(
+            ok=False,
+            detail=f"provider {provider_id!r} entry has no non-empty options.apiKey",
             config_path=path,
         )
 

--- a/src/ouroboros/config/zcode_model_config.py
+++ b/src/ouroboros/config/zcode_model_config.py
@@ -1,0 +1,156 @@
+"""Readiness probe for the Zcode CLI's model provider configuration.
+
+The Zcode CLI resolves its model provider from ``~/.zcode/cli/config.json``
+before every run, including the headless ``--prompt --json`` invocations
+Ouroboros spawns. When the file is missing or carries no usable
+``model.main`` reference, the CLI exits immediately with
+``Model config is missing.`` — after Ouroboros has already assembled the
+prompt and session, so the failure only surfaces mid-execution.
+
+Two config shapes select the main model (measured from Zcode CLI 0.15.x and
+0.16.x):
+
+* ``{"model": "provider-id/model-id", "provider": {...}}``
+* ``{"model": {"main": "provider-id/model-id"}, "provider": {...}}``
+
+``model.main`` must be the ``"provider-id/model-id"`` *string*. An object
+entry is silently dropped by the CLI's config parser, which then reports the
+same ``Model config is missing`` error. The provider id referenced by
+``model.main`` must have an entry under the same file's ``provider``
+registry; that entry carries the ``kind``, ``options.baseURL`` and
+``options.apiKey`` values the CLI needs. The desktop app's
+``~/.zcode/v2/config.json`` uses the same registry shape and is the usual
+copy source for a CLI-side setup.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ZcodeModelConfigStatus:
+    """Outcome of probing ``~/.zcode/cli/config.json`` for a main model."""
+
+    ok: bool
+    detail: str
+    config_path: Path
+
+
+def default_zcode_cli_config_path() -> Path:
+    """Return the Zcode CLI config path the CLI itself names in its errors."""
+
+    home = os.environ.get("HOME")
+    base = Path(home).expanduser() if home else Path.home()
+    return base / ".zcode" / "cli" / "config.json"
+
+
+def _split_model_ref(ref: str) -> tuple[str, str] | None:
+    if "/" not in ref:
+        return None
+    provider_id, _, model_id = ref.partition("/")
+    provider_id = provider_id.strip()
+    model_id = model_id.strip()
+    if not provider_id or not model_id:
+        return None
+    return provider_id, model_id
+
+
+def inspect_zcode_model_config(
+    config_path: Path | None = None,
+) -> ZcodeModelConfigStatus:
+    """Check that the Zcode CLI has a resolvable main model provider.
+
+    The probe mirrors the CLI's own acceptance rules: a string
+    ``"provider-id/model-id"`` reference under ``model`` or ``model.main``,
+    plus a matching entry in the file's ``provider`` registry carrying
+    ``kind`` or ``options.baseURL``. Anything else reproduces the CLI's
+    ``Model config is missing`` failure, so the returned status explains the
+    exact gap instead of letting setup and health checks report success.
+    """
+
+    path = config_path or default_zcode_cli_config_path()
+    if not path.is_file():
+        return ZcodeModelConfigStatus(
+            ok=False,
+            detail=f"{path} not found; the headless Zcode CLI exits with "
+            "'Model config is missing' until it defines model.main",
+            config_path=path,
+        )
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, ValueError) as exc:
+        return ZcodeModelConfigStatus(
+            ok=False,
+            detail=f"{path} is not readable JSON: {exc}",
+            config_path=path,
+        )
+
+    if not isinstance(data, dict):
+        return ZcodeModelConfigStatus(
+            ok=False,
+            detail=f"{path.name} top-level JSON value is not an object",
+            config_path=path,
+        )
+
+    model = data.get("model")
+    main_ref: str | None = None
+    if isinstance(model, str):
+        main_ref = model
+    elif isinstance(model, dict):
+        main = model.get("main")
+        if isinstance(main, dict):
+            return ZcodeModelConfigStatus(
+                ok=False,
+                detail="model.main is an object; the Zcode CLI only accepts the "
+                '"provider-id/model-id" string form and silently drops object entries',
+                config_path=path,
+            )
+        if isinstance(main, str):
+            main_ref = main
+
+    if not main_ref:
+        return ZcodeModelConfigStatus(
+            ok=False,
+            detail=f'{path.name} has no model or model.main "provider-id/model-id" reference',
+            config_path=path,
+        )
+
+    parsed = _split_model_ref(main_ref)
+    if parsed is None:
+        return ZcodeModelConfigStatus(
+            ok=False,
+            detail=f"model reference {main_ref!r} is not in 'provider-id/model-id' form",
+            config_path=path,
+        )
+    provider_id, model_id = parsed
+
+    registry = data.get("provider")
+    entry = registry.get(provider_id) if isinstance(registry, dict) else None
+    if not isinstance(entry, dict):
+        return ZcodeModelConfigStatus(
+            ok=False,
+            detail=f"provider {provider_id!r} referenced by model.main has no entry "
+            f"in {path.name}'s provider registry (kind, options.baseURL, options.apiKey)",
+            config_path=path,
+        )
+
+    options = entry.get("options")
+    has_base_url = isinstance(options, dict) and bool(options.get("baseURL"))
+    if not entry.get("kind") and not has_base_url:
+        return ZcodeModelConfigStatus(
+            ok=False,
+            detail=f"provider {provider_id!r} entry has neither kind nor options.baseURL",
+            config_path=path,
+        )
+
+    return ZcodeModelConfigStatus(
+        ok=True,
+        detail=f"model.main -> {provider_id}/{model_id} (provider entry present)",
+        config_path=path,
+    )

--- a/src/ouroboros/config/zcode_model_config.py
+++ b/src/ouroboros/config/zcode_model_config.py
@@ -67,9 +67,10 @@ def inspect_zcode_model_config(
     The probe mirrors the CLI's own acceptance rules: a string
     ``"provider-id/model-id"`` reference under ``model`` or ``model.main``,
     plus a matching entry in the file's ``provider`` registry carrying
-    ``kind`` or ``options.baseURL``. Anything else reproduces the CLI's
-    ``Model config is missing`` failure, so the returned status explains the
-    exact gap instead of letting setup and health checks report success.
+    non-empty ``kind``, ``options.baseURL``, and ``options.apiKey``. Anything
+    else reproduces the CLI's ``Model config is missing`` failure, so the
+    returned status explains the exact gap instead of letting setup and health
+    checks report success.
     """
 
     path = config_path or default_zcode_cli_config_path()

--- a/src/ouroboros/orchestrator/zcode_cli_runtime.py
+++ b/src/ouroboros/orchestrator/zcode_cli_runtime.py
@@ -48,7 +48,7 @@ from ouroboros.orchestrator.codex_cli_runtime import (
 )
 from ouroboros.runtime.child_env import build_child_env
 from ouroboros.zcode_cli_launcher import (
-    build_zcode_command_prefix,
+    resolve_zcode_command_prefix,
     resolve_zcode_electron_node_path,
 )
 
@@ -356,7 +356,7 @@ class ZcodeCLIRuntime(CodexCliRuntime):
         if cli_path is None:
             msg = "zcode CLI path could not be resolved (set OUROBOROS_ZCODE_CLI_PATH or orchestrator.zcode_cli_path)"
             raise RuntimeError(msg)
-        prefix = build_zcode_command_prefix(cli_path, self._electron_node_path)
+        prefix = resolve_zcode_command_prefix(cli_path)
         command = prefix + [
             "--json",
             "--prompt",

--- a/src/ouroboros/providers/zcode_cli_adapter.py
+++ b/src/ouroboros/providers/zcode_cli_adapter.py
@@ -47,7 +47,7 @@ from ouroboros.providers.response_format import (
 )
 from ouroboros.runtime.child_env import build_child_env
 from ouroboros.zcode_cli_launcher import (
-    build_zcode_command_prefix,
+    resolve_zcode_command_prefix,
     resolve_zcode_electron_node_path,
 )
 
@@ -241,7 +241,7 @@ class ZcodeCliLLMAdapter(CodexCliLLMAdapter):
                 "(set OUROBOROS_ZCODE_CLI_PATH or orchestrator.zcode_cli_path)"
             )
             raise RuntimeError(msg)
-        prefix = build_zcode_command_prefix(cli_path, self._electron_node_path)
+        prefix = resolve_zcode_command_prefix(cli_path)
         command = prefix + [
             "--json",
             "--prompt",

--- a/src/ouroboros/zcode_cli_launcher.py
+++ b/src/ouroboros/zcode_cli_launcher.py
@@ -6,6 +6,7 @@ import json
 import os
 from pathlib import Path
 import plistlib
+import shutil
 
 ZCODE_SCRIPT_SUFFIXES = (".cjs", ".js", ".mjs")
 ZCODE_NODE_BUNDLE_METADATA = ".node-bundle-meta.json"
@@ -118,3 +119,27 @@ def build_zcode_command_prefix(cli_path: str | Path, electron_node_path: str | N
     if cli_path_str.lower().endswith(ZCODE_SCRIPT_SUFFIXES):
         return ["node", cli_path_str]
     return [cli_path_str]
+
+
+def resolve_zcode_command_prefix(cli_path: str | Path) -> list[str]:
+    """Validate launcher prerequisites and return the runtime command prefix.
+
+    This is intentionally side-effect free: it inspects the selected launch
+    shape without starting ZCode.  App-bundle scripts must have valid bundle
+    metadata and an executable bundled Electron runtime, while standalone
+    scripts require a system Node executable. Direct launchers retain the
+    runtime's existing direct-execution behavior.
+    """
+    cli_path_str = str(cli_path)
+    path = Path(cli_path_str).expanduser()
+    electron_node_path = resolve_zcode_electron_node_path(path)
+    if electron_node_path is not None:
+        return build_zcode_command_prefix(path, electron_node_path)
+
+    if path.suffix.lower() in ZCODE_SCRIPT_SUFFIXES:
+        if shutil.which("node") is None:
+            msg = f"ZCode standalone script requires Node on PATH: {path}"
+            raise RuntimeError(msg)
+        return build_zcode_command_prefix(path, None)
+
+    return build_zcode_command_prefix(path, None)

--- a/tests/unit/cli/test_status_health_zcode.py
+++ b/tests/unit/cli/test_status_health_zcode.py
@@ -1,0 +1,95 @@
+"""Unit tests for the zcode model-config wiring in ``status health``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ouroboros.cli.commands import status as status_module
+from ouroboros.config.zcode_model_config import ZcodeModelConfigStatus
+
+
+def _probe_result(ok: bool, detail: str) -> ZcodeModelConfigStatus:
+    return ZcodeModelConfigStatus(
+        ok=ok, detail=detail, config_path=Path("/fake/.zcode/cli/config.json")
+    )
+
+
+def test_zcode_credentials_ok_includes_model_config_detail(monkeypatch):
+    monkeypatch.delenv("OUROBOROS_LLM_BACKEND", raising=False)
+    monkeypatch.delenv("OUROBOROS_RUNTIME", raising=False)
+    monkeypatch.setattr(
+        status_module,
+        "inspect_zcode_model_config",
+        lambda: _probe_result(True, "model.main -> p/m (provider entry present)"),
+    )
+
+    row = status_module._check_credentials({"llm": {"backend": "zcode"}}, Path("/fake/config.yaml"))
+
+    assert row["status"] == "ok"
+    assert "model.main -> p/m" in row["detail"]
+
+
+def test_zcode_credentials_warning_when_model_config_missing(monkeypatch):
+    monkeypatch.delenv("OUROBOROS_LLM_BACKEND", raising=False)
+    monkeypatch.delenv("OUROBOROS_RUNTIME", raising=False)
+    monkeypatch.setattr(
+        status_module,
+        "inspect_zcode_model_config",
+        lambda: _probe_result(False, "config.json not found"),
+    )
+
+    row = status_module._check_credentials({"llm": {"backend": "zcode"}}, Path("/fake/config.yaml"))
+
+    assert row["status"] == "warning"
+    assert "config.json not found" in row["detail"]
+
+
+def test_non_zcode_local_auth_backend_stays_ok_without_probe(monkeypatch):
+    monkeypatch.delenv("OUROBOROS_LLM_BACKEND", raising=False)
+    monkeypatch.delenv("OUROBOROS_RUNTIME", raising=False)
+
+    def _fail_probe():
+        raise AssertionError("probe must not run for non-zcode backends")
+
+    monkeypatch.setattr(status_module, "inspect_zcode_model_config", _fail_probe)
+
+    row = status_module._check_credentials({"llm": {"backend": "gjc"}}, Path("/fake/config.yaml"))
+
+    assert row["status"] == "ok"
+
+
+def test_runtime_backend_row_warns_for_zcode_without_model_config(monkeypatch):
+    monkeypatch.setattr(
+        status_module,
+        "inspect_zcode_model_config",
+        lambda: _probe_result(False, "config.json not found"),
+    )
+
+    row = status_module._runtime_backend_health_row("zcode", "zcode: /bin/zcode.cjs")
+
+    assert row["status"] == "warning"
+    assert "model config: config.json not found" in row["detail"]
+
+
+def test_runtime_backend_row_ok_for_zcode_with_model_config(monkeypatch):
+    monkeypatch.setattr(
+        status_module,
+        "inspect_zcode_model_config",
+        lambda: _probe_result(True, "model.main -> p/m"),
+    )
+
+    row = status_module._runtime_backend_health_row("zcode", "zcode: /bin/zcode.cjs")
+
+    assert row["status"] == "ok"
+
+
+def test_runtime_backend_row_unchanged_for_other_backends(monkeypatch):
+    def _fail_probe():
+        raise AssertionError("probe must not run for non-zcode backends")
+
+    monkeypatch.setattr(status_module, "inspect_zcode_model_config", _fail_probe)
+
+    row = status_module._runtime_backend_health_row("codex", "codex: /bin/codex")
+
+    assert row["status"] == "ok"
+    assert row["detail"] == "codex: /bin/codex"

--- a/tests/unit/cli/test_status_health_zcode.py
+++ b/tests/unit/cli/test_status_health_zcode.py
@@ -93,3 +93,31 @@ def test_runtime_backend_row_unchanged_for_other_backends(monkeypatch):
 
     assert row["status"] == "ok"
     assert row["detail"] == "codex: /bin/codex"
+
+
+def test_zcode_candidate_uses_runtime_environment_path(monkeypatch, tmp_path):
+    script = tmp_path / "custom-zcode.cjs"
+    script.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+    monkeypatch.setenv("OUROBOROS_ZCODE_CLI_PATH", str(script))
+
+    candidates = status_module._candidate_cli_paths("zcode", {})
+
+    assert candidates[0] == str(script)
+
+
+def test_zcode_health_accepts_readable_script_path(monkeypatch, tmp_path):
+    script = tmp_path / "custom-zcode.cjs"
+    script.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+    monkeypatch.setenv("OUROBOROS_ZCODE_CLI_PATH", str(script))
+    monkeypatch.setattr(
+        status_module,
+        "inspect_zcode_model_config",
+        lambda: _probe_result(True, "model.main -> p/m"),
+    )
+
+    row = status_module._check_runtime_backend(
+        {"orchestrator": {"runtime_backend": "zcode"}, "llm": {"backend": "zcode"}}
+    )
+
+    assert row["status"] == "ok"
+    assert str(script) in row["detail"]

--- a/tests/unit/cli/test_status_health_zcode.py
+++ b/tests/unit/cli/test_status_health_zcode.py
@@ -151,3 +151,28 @@ def test_zcode_health_rejects_standalone_script_without_node(monkeypatch, tmp_pa
 
     assert row["status"] == "error"
     assert "requires Node on PATH" in row["detail"]
+
+
+def test_zcode_health_does_not_fallback_after_selected_override_is_unready(monkeypatch, tmp_path):
+    override = tmp_path / "override-zcode.cjs"
+    override.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+    configured = tmp_path / "configured-zcode"
+    configured.write_text("#!/bin/sh\n", encoding="utf-8")
+    configured.chmod(0o755)
+    monkeypatch.setenv("OUROBOROS_ZCODE_CLI_PATH", str(override))
+    monkeypatch.setattr("ouroboros.zcode_cli_launcher.shutil.which", lambda _name: None)
+
+    row = status_module._check_runtime_backend(
+        {
+            "orchestrator": {
+                "runtime_backend": "zcode",
+                "zcode_cli_path": str(configured),
+            },
+            "llm": {"backend": "zcode"},
+        }
+    )
+
+    assert row["status"] == "error"
+    assert "requires Node on PATH" in row["detail"]
+    assert str(override) in row["detail"]
+    assert str(configured) not in row["detail"]

--- a/tests/unit/cli/test_status_health_zcode.py
+++ b/tests/unit/cli/test_status_health_zcode.py
@@ -121,3 +121,33 @@ def test_zcode_health_accepts_readable_script_path(monkeypatch, tmp_path):
 
     assert row["status"] == "ok"
     assert str(script) in row["detail"]
+
+
+def test_zcode_health_rejects_malformed_app_bundle(monkeypatch, tmp_path):
+    contents = tmp_path / "ZCode.app" / "Contents"
+    script = contents / "Resources" / "glm" / "zcode.cjs"
+    script.parent.mkdir(parents=True)
+    script.write_text("// zcode", encoding="utf-8")
+    script.with_name(".node-bundle-meta.json").write_text("{", encoding="utf-8")
+    monkeypatch.setenv("OUROBOROS_ZCODE_CLI_PATH", str(script))
+
+    row = status_module._check_runtime_backend(
+        {"orchestrator": {"runtime_backend": "zcode"}, "llm": {"backend": "zcode"}}
+    )
+
+    assert row["status"] == "error"
+    assert "invalid JSON" in row["detail"]
+
+
+def test_zcode_health_rejects_standalone_script_without_node(monkeypatch, tmp_path):
+    script = tmp_path / "custom-zcode.cjs"
+    script.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+    monkeypatch.setenv("OUROBOROS_ZCODE_CLI_PATH", str(script))
+    monkeypatch.setattr("ouroboros.zcode_cli_launcher.shutil.which", lambda _name: None)
+
+    row = status_module._check_runtime_backend(
+        {"orchestrator": {"runtime_backend": "zcode"}, "llm": {"backend": "zcode"}}
+    )
+
+    assert row["status"] == "error"
+    assert "requires Node on PATH" in row["detail"]

--- a/tests/unit/config/test_zcode_model_config.py
+++ b/tests/unit/config/test_zcode_model_config.py
@@ -1,0 +1,152 @@
+"""Unit tests for the Zcode CLI model-config readiness probe."""
+
+from __future__ import annotations
+
+import json
+
+from ouroboros.config.zcode_model_config import inspect_zcode_model_config
+
+
+def _write_config(tmp_path, payload) -> None:
+    (tmp_path / "config.json").write_text(
+        json.dumps(payload) if not isinstance(payload, str) else payload,
+        encoding="utf-8",
+    )
+
+
+_PROVIDER_ENTRY = {
+    "name": "Z.ai - Coding Plan",
+    "kind": "anthropic",
+    "options": {
+        "baseURL": "https://api.z.ai/api/anthropic",
+        "apiKey": "key",
+        "apiKeyRequired": True,
+    },
+    "enabled": True,
+}
+
+
+def test_missing_file_reports_missing_config(tmp_path):
+    status = inspect_zcode_model_config(tmp_path / "config.json")
+
+    assert not status.ok
+    assert "not found" in status.detail
+    assert "Model config is missing" in status.detail
+
+
+def test_invalid_json_reports_parse_error(tmp_path):
+    (tmp_path / "config.json").write_text("{not json", encoding="utf-8")
+
+    status = inspect_zcode_model_config(tmp_path / "config.json")
+
+    assert not status.ok
+    assert "not readable JSON" in status.detail
+
+
+def test_top_level_non_object_is_rejected(tmp_path):
+    _write_config(tmp_path, ["model"])
+
+    status = inspect_zcode_model_config(tmp_path / "config.json")
+
+    assert not status.ok
+    assert "not an object" in status.detail
+
+
+def test_no_model_reference_is_rejected(tmp_path):
+    _write_config(tmp_path, {"provider": {"builtin:zai-coding-plan": _PROVIDER_ENTRY}})
+
+    status = inspect_zcode_model_config(tmp_path / "config.json")
+
+    assert not status.ok
+    assert "no model or model.main" in status.detail
+
+
+def test_object_form_model_main_is_rejected(tmp_path):
+    # The Zcode CLI silently drops object-form model.main entries and then
+    # fails with the same "Model config is missing" error; call that out
+    # explicitly instead of reporting a generic gap.
+    _write_config(
+        tmp_path,
+        {
+            "model": {
+                "main": {
+                    "provider": "builtin:zai-coding-plan",
+                    "model": "GLM-5.3",
+                    "kind": "anthropic",
+                }
+            },
+            "provider": {"builtin:zai-coding-plan": _PROVIDER_ENTRY},
+        },
+    )
+
+    status = inspect_zcode_model_config(tmp_path / "config.json")
+
+    assert not status.ok
+    assert "object" in status.detail
+    assert "string form" in status.detail
+
+
+def test_model_ref_without_slash_is_rejected(tmp_path):
+    _write_config(tmp_path, {"model": "builtin:zai-coding-plan"})
+
+    status = inspect_zcode_model_config(tmp_path / "config.json")
+
+    assert not status.ok
+    assert "'provider-id/model-id' form" in status.detail
+
+
+def test_provider_missing_from_registry_is_rejected(tmp_path):
+    _write_config(
+        tmp_path,
+        {"model": {"main": "builtin:zai-coding-plan/GLM-5.3"}, "provider": {}},
+    )
+
+    status = inspect_zcode_model_config(tmp_path / "config.json")
+
+    assert not status.ok
+    assert "no entry" in status.detail
+
+
+def test_provider_entry_without_kind_or_base_url_is_rejected(tmp_path):
+    _write_config(
+        tmp_path,
+        {
+            "model": {"main": "builtin:zai-coding-plan/GLM-5.3"},
+            "provider": {"builtin:zai-coding-plan": {"name": "Z.ai"}},
+        },
+    )
+
+    status = inspect_zcode_model_config(tmp_path / "config.json")
+
+    assert not status.ok
+    assert "neither kind nor options.baseURL" in status.detail
+
+
+def test_string_model_with_provider_entry_passes(tmp_path):
+    _write_config(
+        tmp_path,
+        {
+            "model": "builtin:zai-coding-plan/GLM-5.3",
+            "provider": {"builtin:zai-coding-plan": _PROVIDER_ENTRY},
+        },
+    )
+
+    status = inspect_zcode_model_config(tmp_path / "config.json")
+
+    assert status.ok
+    assert "builtin:zai-coding-plan/GLM-5.3" in status.detail
+
+
+def test_model_main_string_with_provider_entry_passes(tmp_path):
+    _write_config(
+        tmp_path,
+        {
+            "model": {"main": "builtin:zai-coding-plan/GLM-5.3"},
+            "provider": {"builtin:zai-coding-plan": _PROVIDER_ENTRY},
+        },
+    )
+
+    status = inspect_zcode_model_config(tmp_path / "config.json")
+
+    assert status.ok
+    assert "provider entry present" in status.detail

--- a/tests/unit/config/test_zcode_model_config.py
+++ b/tests/unit/config/test_zcode_model_config.py
@@ -119,7 +119,28 @@ def test_provider_entry_without_kind_or_base_url_is_rejected(tmp_path):
     status = inspect_zcode_model_config(tmp_path / "config.json")
 
     assert not status.ok
-    assert "neither kind nor options.baseURL" in status.detail
+    assert "no non-empty kind" in status.detail
+
+
+def test_provider_entry_requires_kind_base_url_and_api_key(tmp_path):
+    for entry in (
+        {"options": {"baseURL": "https://example.test", "apiKey": "key"}},
+        {"kind": "anthropic", "options": {"apiKey": "key"}},
+        {"kind": "anthropic", "options": {"baseURL": "https://example.test"}},
+        {
+            "kind": "anthropic",
+            "options": {"baseURL": "https://example.test", "apiKey": ""},
+        },
+    ):
+        _write_config(
+            tmp_path,
+            {
+                "model": {"main": "p/m"},
+                "provider": {"p": entry},
+            },
+        )
+        status = inspect_zcode_model_config(tmp_path / "config.json")
+        assert not status.ok
 
 
 def test_string_model_with_provider_entry_passes(tmp_path):

--- a/tests/unit/test_zcode_cli_launcher.py
+++ b/tests/unit/test_zcode_cli_launcher.py
@@ -11,6 +11,7 @@ import pytest
 
 from ouroboros.zcode_cli_launcher import (
     build_zcode_command_prefix,
+    resolve_zcode_command_prefix,
     resolve_zcode_electron_node_path,
 )
 
@@ -57,6 +58,26 @@ def test_standalone_script_uses_system_node_without_metadata(tmp_path: Path) -> 
 
     assert resolve_zcode_electron_node_path(cli_path) is None
     assert build_zcode_command_prefix(cli_path, None) == ["node", str(cli_path)]
+
+
+def test_standalone_script_readiness_requires_system_node(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli_path = tmp_path / "zcode.cjs"
+    cli_path.write_text("// standalone zcode", encoding="utf-8")
+    monkeypatch.setattr("ouroboros.zcode_cli_launcher.shutil.which", lambda _name: None)
+
+    with pytest.raises(RuntimeError, match="requires Node on PATH"):
+        resolve_zcode_command_prefix(cli_path)
+
+
+def test_app_bundle_command_readiness_validates_bundle_metadata(tmp_path: Path) -> None:
+    cli_path, _ = _fake_electron_node_bundle(tmp_path)
+    cli_path.with_name(".node-bundle-meta.json").write_text("{", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="invalid JSON"):
+        resolve_zcode_command_prefix(cli_path)
 
 
 def test_path_executable_runs_directly() -> None:


### PR DESCRIPTION
Fixes #2148

## Problem

On a machine with the ZCode desktop app installed, `ouroboros setup --runtime zcode` succeeds and `ouroboros status health` reports every check green:

```
│ Runtime backend │   ok    │ zcode: /Applications/ZCode.app/.../zcode.cjs │
│ Credentials     │   ok    │ zcode uses local CLI authentication          │
```

...but the first workflow step fails mid-execution, after Ouroboros has already assembled the prompt and spawned the CLI:

```text
Error: Model config is missing. Create /Users/<you>/.zcode/cli/config.json
with an explicit model provider before running ZCode.
```

The Zcode CLI resolves its model from `~/.zcode/cli/config.json` on every headless run. The desktop app's model selection (in `~/.zcode/v2/config.json`) does not create that file, and OAuth credentials being shared (`~/.zcode/v2/credentials.json`) makes the health row's "local CLI authentication" claim plausible while the effective model reference is still missing.

Two schema gotchas make this easy to hit and hard to debug (measured from Zcode CLI 0.15.x and 0.16.x):

1. `model.main` must be the `"provider-id/model-id"` **string**. An object entry is silently dropped by the CLI's config parser, which then reports the same "Model config is missing" error — an apparently complete config keeps failing.
2. The provider referenced by `model.main` must have an entry in the same file's `provider` registry (`kind`, `options.baseURL`, `options.apiKey`); the CLI does not hardcode coding-plan endpoints.

## Change

- **`ouroboros.config.zcode_model_config`** — new probe mirroring the CLI's acceptance rules: resolves the default config path, requires a string `model`/`model.main` reference in `provider-id/model-id` form, and a matching `provider` registry entry with `kind` or `options.baseURL`. Returns a frozen status with a detail string that names the exact gap (including the object-form case).
- **`ouroboros setup --runtime zcode`** — after writing the config, prints a warning with the failing detail and a copy-paste example config when the probe fails.
- **`ouroboros status health`** — the zcode runtime-backend row downgrades to `warning` with the probe detail, and the zcode LLM-backend credentials row runs the probe instead of unconditionally reporting `ok`.
- **`docs/runtime-guides/zcode.md`** — prerequisites row, new "Model provider configuration" section (string-ref schema, registry example, copy-from-desktop note), and a troubleshooting entry for the exact CLI error.

## Testing

- `tests/unit/config/test_zcode_model_config.py` — 10 cases covering missing file, invalid JSON, non-object root, missing reference, object-form `model.main`, unparseable ref, missing provider entry, entry without `kind`/`baseURL`, and both passing shapes.
- `tests/unit/cli/test_status_health_zcode.py` — 6 cases for the credentials row and runtime-backend row wiring, including non-zcode backends never running the probe.
- `uv run pytest tests/unit/cli tests/unit/config -q`: 2549 passed; the 22 failures are pre-existing on clean `main` (codex MCP-registration and mcp-doctor tests fail identically without this branch).
- Verified the rendered setup warning end to end against a fake $HOME.