### PR TITLE
refactor(fanout): let a record's filename say which session owns it

### DIFF
--- a/src/ouroboros/mcp/tools/fanout.py
+++ b/src/ouroboros/mcp/tools/fanout.py
@@ -73,6 +73,23 @@ _DEFAULT_FANOUT_DIR = Path.home() / ".ouroboros" / "data" / "fanout"
 #: ``/tmp/forged.json``, and a check placed after that join is already too late.
 _FANOUT_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,128}")
 
+#: A session id may be written into a record's filename, so it is constrained
+#: exactly as ``_FANOUT_ID_RE`` constrains the id: both end up joined to the
+#: registry directory, and a separator, a parent segment or an absolute form
+#: must be unspellable rather than detected after the join.
+_SESSION_SEGMENT_RE = re.compile(r"[A-Za-z0-9_-]{1,128}")
+
+#: Between the session and the id. Doubled so the boundary survives both sides
+#: containing single underscores, which they do -- ``interview_20260809_055623``
+#: and ``fanout_<hex>``. The id is the tail, so a name is read from the right
+#: whatever the session happens to contain.
+_SESSION_SEPARATOR = "__"
+
+#: How many of a session's ids one lookup returns. A cap rather than the whole
+#: history: the list is read by whatever asked for it, and an hour-long session
+#: should not hand its caller a longer one.
+_SESSION_FANOUT_ID_LIMIT = 12
+
 # Fan-out re-entry kinds — each routes to one revived synthesizer.
 FANOUT_KIND_LATERAL_PERSONA_PANEL = "lateral_persona_panel"
 FANOUT_KIND_CODE_INVESTIGATION = "code_investigation"
@@ -216,7 +233,7 @@ class FanoutRegistry:
             return
         self._dir = directory
 
-    def _path(self, fanout_id: str) -> Path | None:
+    def _path(self, fanout_id: str, session_id: str = "") -> Path | None:
         """Return the record path for ``fanout_id``, or ``None`` if it is not one.
 
         The registry directory is the whole of where a record may live, so an id
@@ -224,9 +241,23 @@ class FanoutRegistry:
         rather than raising keeps the existing read contract: an unredeemable id
         is reported as an unknown fan-out, which is what a caller holding a
         forged one should learn.
+
+        A spellable ``session_id`` is written into the name. One directory holds
+        every session this machine has run, and the session is otherwise only
+        inside the file, so "which of these are mine" could be answered only by
+        opening all of them. The name is where that answer belongs: it makes the
+        question a directory listing rather than a read of the whole history.
+
+        The session segment is held to the same alphabet as the id and for the
+        same reason -- both are joined to a directory, so a separator or a
+        parent segment must have no spelling rather than being detected after
+        the join. A session that cannot be spelled falls back to the flat name,
+        which is also the shape every record written before this had.
         """
         if not _FANOUT_ID_RE.fullmatch(fanout_id):
             return None
+        if session_id and _SESSION_SEGMENT_RE.fullmatch(session_id):
+            return self._dir / f"{session_id}{_SESSION_SEPARATOR}{fanout_id}.json"
         return self._dir / f"{fanout_id}.json"
 
     def register(
@@ -261,7 +292,7 @@ class FanoutRegistry:
         # where it was written -- raised rather than returned as ``None``, which
         # says "this write did not happen" about a caller that asked for the
         # impossible.
-        record_path = self._path(resolved_id)
+        record_path = self._path(resolved_id, session_id)
         if record_path is None:
             raise ValueError(
                 "fanout_id must be 1-128 characters of [A-Za-z0-9_-]; "
@@ -307,11 +338,96 @@ class FanoutRegistry:
         self._issued = True
         return resolved_id
 
+    def _prefixed_path(self, fanout_id: str) -> Path | None:
+        """Return the session-prefixed record path for ``fanout_id``, if one exists.
+
+        The id is the tail of the name, so it is matched from the right and the
+        session in front may contain anything its own alphabet allows. An id
+        matching more than once cannot happen -- ids are unique and the suffix
+        pins the whole tail -- but if the directory ever holds two, neither is
+        chosen: picking by listing order would decide a redemption by filesystem
+        accident.
+        """
+        try:
+            matches = list(self._dir.glob(f"*{_SESSION_SEPARATOR}{fanout_id}.json"))
+        except OSError:
+            return None
+        return matches[0] if len(matches) == 1 else None
+
+    def session_fanout_ids(
+        self,
+        session_id: str,
+        *,
+        kind: str,
+        limit: int = _SESSION_FANOUT_ID_LIMIT,
+    ) -> tuple[str, ...]:
+        """Return this session's fan-out ids of one kind, most recent first.
+
+        A directory listing, not a scan. The session is in the name, so the
+        files that are not this session's are never opened -- which is what
+        keeps the cost of asking independent of how much history the machine
+        has kept. Only the matches are read, and only to check ``kind``, since
+        one session can run a persona panel beside its advisory lanes and an id
+        that passed the session filter alone would send a caller to read one as
+        though it were the other.
+
+        **Records written before the session was in the name are not found.**
+        Their filename cannot answer the question and reading every flat file to
+        ask would restore the cost this exists to remove. A session that
+        predates the layout is a finished one, and the degradation for a session
+        straddling the change is that its earlier rounds are not offered --
+        fewer results, never another session's.
+
+        Advisory in the sense the caller is: nothing here decides whether a
+        fan-out completes, so an unreadable directory returns nothing rather
+        than raising into a turn that only wanted a shortcut.
+        """
+        if not session_id or not _SESSION_SEGMENT_RE.fullmatch(session_id):
+            return ()
+        try:
+            entries = list(self._dir.glob(f"{session_id}{_SESSION_SEPARATOR}*.json"))
+        except OSError:
+            return ()
+        stamped: list[tuple[float, str]] = []
+        for path in entries:
+            try:
+                stamped.append((path.stat().st_mtime, path.stem))
+            except OSError:
+                continue
+        # ``stem`` breaks a same-timestamp tie, so two records written in one
+        # clock tick order the same way on every call rather than by whatever
+        # order the directory happened to be read in.
+        stamped.sort(key=lambda item: (-item[0], item[1]))
+        found: list[str] = []
+        for _, stem in stamped:
+            if len(found) >= limit:
+                break
+            _, _, fanout_id = stem.partition(_SESSION_SEPARATOR)
+            record = self.load(fanout_id)
+            if record is None or record.kind != kind:
+                continue
+            if record.session_id != session_id:
+                continue
+            found.append(record.fanout_id)
+        return tuple(found)
+
     def load(self, fanout_id: str) -> FanoutRecord | None:
-        """Load a persisted fan-out record, or ``None`` if unknown/corrupt."""
+        """Load a persisted fan-out record, or ``None`` if unknown/corrupt.
+
+        Resolved by id alone, because that is all a submission carries. The flat
+        name is tried first and a session-prefixed one is found by listing,
+        which is what lets records written on either side of this layout be read
+        by the same call -- no migration, and no id that stops being redeemable
+        because the name it was written under changed.
+        """
         path = self._path(fanout_id)
         if path is None:
             return None
+        if not path.exists():
+            prefixed = self._prefixed_path(fanout_id)
+            if prefixed is None:
+                return None
+            path = prefixed
         try:
             content = path.read_text(encoding="utf-8")
         except OSError:

--- a/tests/unit/core/test_owner_only.py
+++ b/tests/unit/core/test_owner_only.py
@@ -558,7 +558,9 @@ def test_fanout_registry_register_is_owner_only(tmp_path: Path) -> None:
         expected_keys=["code_facts"],
         synthesizer_input={"request": {"question": "which module owns auth?"}},
     )
-    saved = tmp_path / "fanout" / f"{fanout_id}.json"
+    # Found by listing: a record's filename carries the session that owns it,
+    # so rebuilding the name from the id would be a second copy of the layout.
+    (saved,) = (tmp_path / "fanout").glob(f"*{fanout_id}.json")
 
     assert _mode(saved) == 0o600
     assert registry.load(fanout_id) is not None
@@ -576,7 +578,9 @@ def test_fanout_registry_narrows_a_record_left_at_0644(tmp_path: Path) -> None:
         expected_keys=["code_facts"],
         synthesizer_input={},
     )
-    saved = tmp_path / "fanout" / f"{fanout_id}.json"
+    # Found by listing: a record's filename carries the session that owns it,
+    # so rebuilding the name from the id would be a second copy of the layout.
+    (saved,) = (tmp_path / "fanout").glob(f"*{fanout_id}.json")
     saved.chmod(0o644)
 
     registry.register(

--- a/tests/unit/mcp/tools/test_data_context_lane.py
+++ b/tests/unit/mcp/tools/test_data_context_lane.py
@@ -15,6 +15,7 @@ required lane that can always answer.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 from jsonschema import Draft202012Validator
@@ -41,6 +42,17 @@ from ouroboros.orchestrator.capabilities.interview_schemas import (
 )
 
 QUESTION = "How many enterprise accounts asked for SSO last quarter?"
+
+
+def _record_path(directory: Any, fanout_id: str) -> Path:
+    """Return the on-disk record for ``fanout_id``, found by listing.
+
+    A record's filename carries the session that owns it, so a test that
+    rebuilds the name from the id is a second place the layout is written down
+    -- and the one that goes stale first.
+    """
+    (path,) = directory.glob(f"*{fanout_id}.json")
+    return path
 
 
 def _advisory_payloads() -> list[dict[str, Any]]:
@@ -852,7 +864,7 @@ def test_the_record_never_holds_what_a_child_said(tmp_path: Any) -> None:
     outcome = _submit(registry, fanout_id, results)
     assert outcome["status"] == "complete"
 
-    on_disk = (tmp_path / f"{fanout_id}.json").read_text(encoding="utf-8")
+    on_disk = _record_path(tmp_path, fanout_id).read_text(encoding="utf-8")
     assert secret not in on_disk
     assert "advice" not in on_disk
     record = registry.load(fanout_id)
@@ -1179,7 +1191,7 @@ def test_the_record_carries_no_contract_to_lose(tmp_path: Any) -> None:
     registry = FanoutRegistry(tmp_path)
     fanout_id, _lane_ids, _identity = _registered_advisory(registry)
 
-    persisted = json.loads((tmp_path / f"{fanout_id}.json").read_text(encoding="utf-8"))
+    persisted = json.loads(_record_path(tmp_path, fanout_id).read_text(encoding="utf-8"))
 
     assert "answer_contracts" not in persisted
     assert not hasattr(registry.load(fanout_id), "answer_contracts")
@@ -1195,7 +1207,7 @@ def test_no_record_state_can_switch_a_lane_contract_off(tmp_path: Any) -> None:
     """
     registry = FanoutRegistry(tmp_path)
     fanout_id, lane_ids, identity = _registered_advisory(registry)
-    path = tmp_path / f"{fanout_id}.json"
+    path = _record_path(tmp_path, fanout_id)
     persisted = json.loads(path.read_text(encoding="utf-8"))
     persisted["answer_contracts"] = {}
     path.write_text(json.dumps(persisted, ensure_ascii=False), encoding="utf-8")

--- a/tests/unit/mcp/tools/test_fanout_core.py
+++ b/tests/unit/mcp/tools/test_fanout_core.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -995,8 +996,12 @@ async def test_submit_tool_rejects_forged_ids_and_still_redeems_issued_ones(
     assert produced.is_ok, produced
     issued_id = produced.unwrap().meta["fanout_id"]
 
+    # Located by listing rather than by spelling the name: a record's filename
+    # carries the session that owns it, and a test that rebuilds the name is a
+    # second place the layout is written down.
+    (record_path,) = (state_dir / "fanout").glob(f"*{issued_id}.json")
     outside = tmp_path / "forged.json"
-    outside.write_text((state_dir / "fanout" / f"{issued_id}.json").read_text(), encoding="utf-8")
+    outside.write_text(record_path.read_text(), encoding="utf-8")
 
     submit, disposable = _bounded_submit(registry, tmp_path)
     results = [{"key": persona, "content": f"{persona}-out"} for persona in personas]
@@ -1213,3 +1218,136 @@ def test_distinct_correlation_keys_still_complete(tmp_path: Any) -> None:
     )
 
     assert out["status"] == "complete"
+
+
+# --------------------------------------------------------------------------- #
+# Session-addressed record names (#2150)
+# --------------------------------------------------------------------------- #
+
+
+def _register(registry: FanoutRegistry, session_id: str, kind: str) -> str:
+    fanout_id = registry.register(
+        kind=kind,
+        session_id=session_id,
+        correlation_key="context.lane_id",
+        expected_keys=["code_context"],
+        synthesizer_input={"request": {}},
+    )
+    assert fanout_id is not None
+    return fanout_id
+
+
+def test_a_records_name_says_which_session_owns_it(tmp_path: Any) -> None:
+    """The filename is the index. Without it the session is only inside the file.
+
+    One directory holds every session the machine has run — 192 records across
+    155 sessions when this was written — so a lookup that reads to find out
+    costs the whole history to learn what a listing could have said.
+    """
+    registry = FanoutRegistry(tmp_path)
+    fanout_id = _register(registry, "sess-1", FANOUT_KIND_QUESTION_ADVISORY)
+
+    (written,) = tmp_path.glob("*.json")
+    assert written.name == f"sess-1__{fanout_id}.json"
+
+
+def test_a_session_lookup_opens_only_that_sessions_records(tmp_path: Any) -> None:
+    """The cost of asking must not grow with what other sessions left behind."""
+    registry = FanoutRegistry(tmp_path)
+    mine = [_register(registry, "mine", FANOUT_KIND_QUESTION_ADVISORY) for _ in range(3)]
+    for index in range(40):
+        _register(registry, f"other-{index}", FANOUT_KIND_QUESTION_ADVISORY)
+
+    opened: list[str] = []
+    original = FanoutRegistry.load
+
+    def _counting_load(self: FanoutRegistry, fanout_id: str) -> Any:
+        opened.append(fanout_id)
+        return original(self, fanout_id)
+
+    FanoutRegistry.load = _counting_load  # type: ignore[method-assign]
+    try:
+        listed = registry.session_fanout_ids("mine", kind=FANOUT_KIND_QUESTION_ADVISORY)
+    finally:
+        FanoutRegistry.load = original  # type: ignore[method-assign]
+
+    assert set(listed) == set(mine)
+    assert set(opened) == set(mine), "a record outside the session was opened"
+
+
+def test_a_session_lookup_separates_kinds(tmp_path: Any) -> None:
+    """One session can run a persona panel beside its advisory lanes.
+
+    Both filters are load-bearing: an id that passed the session filter alone
+    would send a caller to read a panel's output as though it were a lane's.
+    """
+    registry = FanoutRegistry(tmp_path)
+    advisory = _register(registry, "sess-1", FANOUT_KIND_QUESTION_ADVISORY)
+    panel = _register(registry, "sess-1", FANOUT_KIND_LATERAL_PERSONA_PANEL)
+
+    listed = registry.session_fanout_ids("sess-1", kind=FANOUT_KIND_QUESTION_ADVISORY)
+    assert listed == (advisory,)
+    assert panel not in listed
+
+
+def test_a_record_written_before_the_session_was_in_its_name_still_loads(
+    tmp_path: Any,
+) -> None:
+    """No migration, and no id that stops being redeemable because a name changed.
+
+    A submission carries an id and nothing else, so the read path has to find a
+    record under either shape. The 192 records already on disk when this landed
+    are the reason it is a fallback rather than a rewrite.
+    """
+    registry = FanoutRegistry(tmp_path)
+    legacy = FanoutRecord(
+        fanout_id="fanout_legacy",
+        kind=FANOUT_KIND_QUESTION_ADVISORY,
+        session_id="sess-old",
+        correlation_key="context.lane_id",
+        expected_keys=("code_context",),
+        synthesizer_input={"request": {}},
+    )
+    (tmp_path / "fanout_legacy.json").write_text(json.dumps(legacy.to_dict()), encoding="utf-8")
+
+    loaded = registry.load("fanout_legacy")
+    assert loaded is not None
+    assert loaded.session_id == "sess-old"
+
+    # It is not offered by a session lookup, and that is the honest trade: its
+    # name cannot answer the question, and reading every flat file to ask would
+    # restore the cost the name exists to remove.
+    assert registry.session_fanout_ids("sess-old", kind=FANOUT_KIND_QUESTION_ADVISORY) == ()
+
+
+def test_a_session_that_cannot_be_spelled_falls_back_to_the_flat_name(
+    tmp_path: Any,
+) -> None:
+    """A separator or a parent segment has no spelling, so nothing escapes here.
+
+    The record is still written and still redeemable — the session simply does
+    not reach the filename, which is the pre-existing shape rather than a
+    failure. Refusing to register would cost a turn its re-entry over a name.
+    """
+    registry = FanoutRegistry(tmp_path)
+    fanout_id = _register(registry, "../escape", FANOUT_KIND_QUESTION_ADVISORY)
+
+    (written,) = tmp_path.glob("*.json")
+    assert written.name == f"{fanout_id}.json"
+    assert written.parent == tmp_path
+    loaded = registry.load(fanout_id)
+    assert loaded is not None and loaded.session_id == "../escape"
+    assert registry.session_fanout_ids("../escape", kind=FANOUT_KIND_QUESTION_ADVISORY) == ()
+
+
+def test_a_session_lookup_returns_the_newest_first_and_caps_them(tmp_path: Any) -> None:
+    """The caller reads this list, so a long session must not hand it a long one."""
+    registry = FanoutRegistry(tmp_path)
+    ids = [_register(registry, "sess-1", FANOUT_KIND_QUESTION_ADVISORY) for _ in range(20)]
+    for index, fanout_id in enumerate(ids):
+        (written,) = tmp_path.glob(f"*{fanout_id}.json")
+        os.utime(written, (1_700_000_000 + index, 1_700_000_000 + index))
+
+    listed = registry.session_fanout_ids("sess-1", kind=FANOUT_KIND_QUESTION_ADVISORY)
+    assert len(listed) == 12
+    assert list(listed) == list(reversed(ids[-12:]))


### PR DESCRIPTION
Closes #2150.

## Summary

Asking "which fan-outs belong to this session?" meant opening every record in the registry directory, because the only field that answers it lived inside the file. This puts the session in the filename, so the question is a directory listing instead.

## Background

Two things made the read cost more than it looks:

- **The directory is global while the artifacts it indexes are not.** Records go to `~/.ouroboros/data/fanout/` (`FanoutRegistry()` in `definitions.py`, `state_dir_path / "fanout"` in `adapter.py`, where the state dir defaults to `get_config_dir() / "data"`). The bodies they point at are per-project, under `<project>/.ouroboros/artifacts/`. So the server knows the workspace, writes bodies there, and still keeps the index of them in one directory shared by every project on the machine.
- **A record carries no project.** Its fields are `fanout_id`, `kind`, `session_id`, `correlation_key`, `expected_keys`, `required_keys`, `synthesizer_input`, `question_identity`. Knowing the workspace narrows nothing.

Measured while writing this: **192 records across 155 distinct sessions**, median one record per session, oldest from 24 July — records have no retention policy, unlike artifacts' 90-day prune, so the directory only grows. A lookup that reads to find out therefore costs the whole history to learn what a listing could have said.

## What changed

`fanout_<id>.json` → `<session_id>__fanout_<id>.json`, and `session_fanout_ids(session_id, kind=...)` globs that prefix. Records outside the session are never opened; the matches are read only to check `kind`, since one session can run a persona panel beside its advisory lanes and an id that passed the session filter alone would send a caller to read one as though it were the other.

Three decisions worth stating:

**The session segment is held to the id's alphabet.** `_FANOUT_ID_RE` exists so a separator, a parent segment or an absolute form has no spelling — a value joined to a directory must be constrained before the join, not inspected after it. The session is now joined the same way, so it gets the same constraint. A session that cannot be spelled falls back to the flat name and still registers: refusing would cost a turn its re-entry over a filename.

**`load` finds either shape.** A submission carries an id and nothing else, so the read path tries the flat name and then locates a prefixed one by listing. That is what makes this need no migration — the 192 records already on disk stay redeemable, and no id stops working because the name it was written under changed.

**A session lookup does not find pre-layout records.** Their filename cannot answer the question, and reading every flat file to ask would restore exactly the cost this removes. A session that predates the layout is a finished one; the degradation for a session straddling the change is that its earlier rounds are not offered — fewer results, never another session's.

## Ordering

#2150 was filed as blocked on #2146, which is the first caller that asks this question. The order is inverted deliberately: the store capability lands first and the feature consumes it, which keeps the layout change reviewable on its own and lets #2146 drop its own scan in favour of this one.

## Tests

Four tests that hard-coded the flat name now locate records by listing — that is not incidental churn, it is the same defect in test form: a name rebuilt from an id is a second place the layout is written down, and the one that goes stale first.

New coverage:

- a record's name says which session owns it
- a session lookup opens only that session's records — proven by counting `load` calls with 3 of the session's records among 40 others
- kind and session are both load-bearing filters
- a record written before the session was in its name still loads, and is not offered by a session lookup
- a session that cannot be spelled falls back to the flat name, stays redeemable, and lands nowhere but the registry directory
- newest first, capped

## Test plan

- [x] `uv run pytest tests/unit tests/conformance -q`
- [x] `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/`
- [x] `uv run mypy src/ouroboros/mcp/`
- [x] `python3 scripts/check-module-size.py --baseline-ref origin/main`
