### PR TITLE
fix(advisory): say the findings body is a list, because it is

### DIFF
--- a/src/ouroboros/mcp/tools/question_advisory.py
+++ b/src/ouroboros/mcp/tools/question_advisory.py
@@ -307,14 +307,10 @@ def _recent_findings_section(request: Mapping[str, Any]) -> str:
     outside this session's roster is rejected at submission. The child is told
     so here, where it is deciding what to read.
 
-    **The shape is stated exactly, because it was not.** This said the answers
-    were "keyed by ``lane_id``", which reads as a mapping; they are a list of
-    entries carrying a ``lane_id``. Two subagents made the same wrong move on
-    it -- ``"code_context" in aggregated_outputs`` against a list is ``False``
-    -- and one of them concluded the files held nothing and went back to
-    searching the repositories. Nothing failed loudly: the paths were right, the
-    files opened, and the lane simply reported finding nothing to reuse, which
-    is indistinguishable from there being nothing.
+    **The shape is stated, not summarised.** "Keyed by ``lane_id``" read as a
+    mapping, so a lane tested ``"code_context" in aggregated_outputs`` against a
+    list, found nothing and re-investigated -- silently, since a lane with
+    nothing to reuse looks like a project with nothing to reuse.
 
     What this must not become is a second set of rules. There is nothing here
     about proving a stored finding sufficient, reporting what a reuse left

--- a/src/ouroboros/mcp/tools/question_advisory.py
+++ b/src/ouroboros/mcp/tools/question_advisory.py
@@ -307,6 +307,15 @@ def _recent_findings_section(request: Mapping[str, Any]) -> str:
     outside this session's roster is rejected at submission. The child is told
     so here, where it is deciding what to read.
 
+    **The shape is stated exactly, because it was not.** This said the answers
+    were "keyed by ``lane_id``", which reads as a mapping; they are a list of
+    entries carrying a ``lane_id``. Two subagents made the same wrong move on
+    it -- ``"code_context" in aggregated_outputs`` against a list is ``False``
+    -- and one of them concluded the files held nothing and went back to
+    searching the repositories. Nothing failed loudly: the paths were right, the
+    files opened, and the lane simply reported finding nothing to reuse, which
+    is indistinguishable from there being nothing.
+
     What this must not become is a second set of rules. There is nothing here
     about proving a stored finding sufficient, reporting what a reuse left
     unsettled, or marking an answer as reused. Those would be bookkeeping about
@@ -333,9 +342,10 @@ plainly:
 {listing}
 ```
 
-Each file holds answers keyed by `lane_id` under `result.aggregated_outputs`.
-Read the `code_context` and `data_context` entries: those report what the system
-does and measures, which is what you are being asked for. Any other entry is
+In each file, `result.aggregated_outputs` is a **list** of entries shaped
+`{{"lane_id": ..., "output": ...}}` — not a mapping. Select the entries whose
+`lane_id` is `code_context` or `data_context`: those report what the system does
+and measures, which is what you are being asked for. Any other entry is
 reasoning about a different question — not evidence, and not yours to reuse.
 
 Read what looks relevant before you inspect code or take a measurement, use what

--- a/tests/unit/mcp/tools/test_recent_findings.py
+++ b/tests/unit/mcp/tools/test_recent_findings.py
@@ -214,7 +214,11 @@ def test_the_prompt_names_which_entries_may_be_read(
 
     prompt = _lane_prompts(_attach(roster, store))["code_context"]
 
-    assert "`code_context` and `data_context`" in prompt
+    # The two eligible lane ids and the reason the others are not evidence —
+    # asserted as the pair rather than as one sentence, so rewording the
+    # instruction does not break the test while dropping a lane would.
+    assert "`code_context`" in prompt
+    assert "`data_context`" in prompt
     assert "reasoning about a different question" in prompt
 
 
@@ -453,3 +457,33 @@ def test_a_path_survives_characters_that_markdown_would_eat(
     assert ordinary in section
     # Nothing after the block's own title may read as a heading.
     assert not any(line.startswith("## ") for line in section.splitlines()[1:])
+
+
+def test_the_block_describes_the_shape_a_published_body_actually_has(
+    roster: list[dict[str, str]], store: ContentAddressedArtifactStore
+) -> None:
+    """The prompt's description is checked against a real publication, not itself.
+
+    It said the answers were "keyed by `lane_id`", which reads as a mapping.
+    They are a list of entries carrying a `lane_id`, so `"code_context" in
+    aggregated_outputs` is `False` — two subagents made exactly that move, and
+    one concluded the files held nothing and went back to searching the
+    repositories. Nothing failed loudly: the paths were right and the files
+    opened, so a lane reporting no reusable findings looked identical to there
+    being none.
+
+    Asserting the sentence alone would pin one wording against another. What
+    makes this hold is reading a body the store actually published and checking
+    that the access the block describes is the access that works.
+    """
+    published = _publish(store, lanes=("code_context", "data_context"))
+
+    outputs = json.loads(Path(published).read_text())["result"]["aggregated_outputs"]
+    assert isinstance(outputs, list), "the block promises a list"
+    assert "code_context" not in outputs, "mapping access must not appear to work"
+    selected = [entry for entry in outputs if entry["lane_id"] == "code_context"]
+    assert len(selected) == 1 and "output" in selected[0]
+
+    section = _lane_prompts(_attach(roster, store))["code_context"]
+    assert "is a **list** of entries" in section
+    assert "not a mapping" in section


### PR DESCRIPTION
Follow-up to #2154 (RFC #2153). One sentence in the recent-findings prompt block, plus the test that would have caught it.

## What was wrong

The block told a lane:

> Each file holds answers **keyed by** `lane_id` under `result.aggregated_outputs`.

They are not keyed by anything. `aggregated_outputs` is a **list** of `{"lane_id": ..., "output": ...}` entries, so the access that sentence invites — `"code_context" in aggregated_outputs` — is `False` against a list.

## How it showed up

Observed twice in one session running the merged feature, in two different subagents:

- the interview's `code_context` lane made that exact check, printed nothing, then inspected the structure and recovered;
- a PM `code_context` lane made the same check and reported *"The artifacts had no `code_context`/`data_context` entries"*, then went back to searching the repositories.

Nothing failed loudly. The store had the findings, the paths in the prompt were correct, the files opened. A lane that reports nothing to reuse looks exactly like a project with nothing to reuse — which is the failure mode this feature has had to be protected from at every step, and it arrived through a description rather than through code.

The shape is identical for both tools, so nothing here is PM- or interview-specific: PM publishes two lanes and the interview six, in the same envelope.

## The fix

The block now states the container and the entry shape and says outright that it is not a mapping. The instruction it carries is unchanged — take the `code_context` and `data_context` entries, treat the rest as reasoning about a different question.

## The test

It reads a body the store actually published and asserts that the access the block describes is the access that works: `aggregated_outputs` is a list, `"code_context" in outputs` is False, and selecting by `lane_id` finds the entry. Then it checks the block says so.

Asserting the sentence alone would have passed for as long as the sentence was wrong — pinning one wording against another proves nothing about the data. One existing test pinned the old conjunction (`` `code_context` and `data_context` ``); it now asserts both lane ids separately, so rewording cannot break it while dropping a lane still does.

## Test plan

- [x] `tests/unit/mcp` + `bigbang` + `orchestrator` + `conformance` — 8428 passed, 2 skipped
- [x] `uv run ruff check src/ tests/` and `ruff format --check`
- [x] `uv run mypy src/ouroboros/mcp/`
- [x] `python3 scripts/check-module-size.py --baseline-ref origin/main`
- [x] Reverting the sentence fails the new test; the old wording is what it catches
