### PR TITLE
fix(mcp): serve with an installed CLI when the SDK runtime is only inherited

### DIFF
--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -1244,6 +1244,11 @@ def serve(
         ouroboros mcp serve --runtime codex --llm-backend codex
 
     """
+    # Reject recursive server launches before shell hydration or any persistent
+    # cache/environment mutation. The parent runtime already owns the MCP edge.
+    if os.environ.get("_OUROBOROS_NESTED"):
+        _stderr_console.print("[dim]Nested ouroboros MCP server detected — exiting cleanly[/dim]")
+        raise typer.Exit(0)
     # Detached MCP hosts often inherit a minimal environment. Hydrate before
     # resolving selector provenance so login-shell/cache OUROBOROS_* choices
     # remain authoritative rather than being mistaken for the shipped default.
@@ -1280,14 +1285,6 @@ def serve(
         )
         selected_runtime = standin_backend
 
-    # Guard: prevent recursive MCP server spawning.
-    # When ouroboros spawns a runtime (Codex/Claude/OpenCode), the child process
-    # inherits this env var. If that runtime's MCP config tries to spawn another
-    # ouroboros server, the nested instance exits cleanly instead of creating a
-    # process tree explosion.
-    if os.environ.get("_OUROBOROS_NESTED"):
-        _stderr_console.print("[dim]Nested ouroboros MCP server detected — exiting cleanly[/dim]")
-        raise typer.Exit(0)
     os.environ["_OUROBOROS_NESTED"] = "1"
 
     # Transport is re-validated inside _run_mcp_server; normalize here first so

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -11,6 +11,7 @@ from enum import Enum
 import json
 import os
 from pathlib import Path
+import shutil
 import signal
 import subprocess
 import sys
@@ -33,6 +34,7 @@ from ouroboros.orchestrator.heartbeat import (
     process_start_time,
 )
 from ouroboros.package_profiles import (
+    CLAUDE_CLI_RUNTIME_BACKEND,
     SDK_RUNTIME_IN_MCP_SERVER_MESSAGE,
     UNSUPPORTED_CLAUDE_SDK_MCP_MESSAGE,
     has_unsupported_claude_sdk_mcp_mix,
@@ -513,6 +515,43 @@ def _effective_mcp_server_runtime(runtime: AgentRuntimeBackend | None) -> str:
     if normalized is None:  # Defensive: the configured/default resolver always returns text.
         normalized = "claude"
     return resolve_runtime_backend_name(normalized)
+
+
+# Executable stand-ins for the in-process ``claude`` SDK runtime, in preference
+# order. ``claude-cli`` is first because it is the same engine out of process,
+# so a user who inherited the SDK default gets the runtime they meant.
+# Each row is (CLI on PATH, canonical backend, the spelling a user would type).
+# The public spelling is carried rather than derived: ``public_runtime_backend``
+# maps public names onto canonical ones, and telling a user to pass the internal
+# ``claude_mcp`` would name a value the ``--runtime`` option rejects.
+_SDK_RUNTIME_STANDINS: tuple[tuple[str, str, str], ...] = (
+    ("claude", CLAUDE_CLI_RUNTIME_BACKEND, AgentRuntimeBackend.CLAUDE_CLI.value),
+    ("codex", "codex", AgentRuntimeBackend.CODEX.value),
+    ("opencode", "opencode", AgentRuntimeBackend.OPENCODE.value),
+)
+
+
+def _sdk_runtime_standin(runtime: AgentRuntimeBackend | None) -> tuple[str, str] | None:
+    """Return an executable runtime to use in place of an inherited SDK default.
+
+    The SDK-backed ``claude`` runtime cannot run inside this process, so a host
+    that reaches serve with it gets no tools at all. When nobody asked for that
+    runtime here — it arrived from config or from the shipped default — an
+    installed CLI is a better answer than a dead server, and the substitution is
+    announced rather than silent.
+
+    An explicit ``--runtime claude`` or ``OUROBOROS_AGENT_RUNTIME=claude`` is
+    left to fail: overriding what the caller just said would be worse than the
+    error.
+    """
+    if runtime is not None:
+        return None
+    if os.environ.get("OUROBOROS_AGENT_RUNTIME", "").strip():
+        return None
+    for command, backend, public_name in _SDK_RUNTIME_STANDINS:
+        if shutil.which(command):
+            return backend, public_name
+    return None
 
 
 def _require_mcp_dependency() -> None:
@@ -1220,8 +1259,23 @@ def serve(
         _stderr_console.print(Text(UNSUPPORTED_CLAUDE_SDK_MCP_MESSAGE, style="red"))
         raise typer.Exit(1)
     if selected_runtime == "claude":
-        _stderr_console.print(Text(SDK_RUNTIME_IN_MCP_SERVER_MESSAGE, style="red"))
-        raise typer.Exit(1)
+        standin = _sdk_runtime_standin(runtime)
+        if standin is None:
+            _stderr_console.print(Text(SDK_RUNTIME_IN_MCP_SERVER_MESSAGE, style="red"))
+            raise typer.Exit(1)
+        # Say which runtime is actually serving. A host that swallows stderr
+        # would otherwise show a working tool list backed by a runtime the user
+        # never picked.
+        standin_backend, standin_name = standin
+        _stderr_console.print(
+            Text(
+                "Inherited the 'claude' SDK runtime, which cannot run inside the MCP "
+                f"server; serving with '{standin_name}' instead. Pass --runtime or set "
+                "OUROBOROS_AGENT_RUNTIME to choose.",
+                style="yellow",
+            )
+        )
+        selected_runtime = standin_backend
 
     # Guard: prevent recursive MCP server spawning.
     # When ouroboros spawns a runtime (Codex/Claude/OpenCode), the child process

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -27,7 +27,12 @@ from ouroboros import telemetry as usage_telemetry
 from ouroboros.backends import resolve_runtime_backend_name
 from ouroboros.cli.commands.mcp_doctor import register_doctor_command
 from ouroboros.cli.formatters.panels import print_info, print_success
-from ouroboros.config import get_agent_runtime_backend
+from ouroboros.config import (
+    get_agent_runtime_backend,
+    get_cli_path,
+    get_codex_cli_path,
+    get_opencode_cli_path,
+)
 from ouroboros.orchestrator.heartbeat import (
     current_process_identity,
     is_process_identity_alive,
@@ -518,38 +523,33 @@ def _effective_mcp_server_runtime(runtime: AgentRuntimeBackend | None) -> str:
 
 
 # Executable stand-ins for the in-process ``claude`` SDK runtime, in preference
-# order. ``claude-cli`` is first because it is the same engine out of process,
-# so a user who inherited the SDK default gets the runtime they meant.
-# Each row is (CLI on PATH, canonical backend, the spelling a user would type).
-# The public spelling is carried rather than derived: ``public_runtime_backend``
-# maps public names onto canonical ones, and telling a user to pass the internal
-# ``claude_mcp`` would name a value the ``--runtime`` option rejects.
-_SDK_RUNTIME_STANDINS: tuple[tuple[str, str, str], ...] = (
-    ("claude", CLAUDE_CLI_RUNTIME_BACKEND, AgentRuntimeBackend.CLAUDE_CLI.value),
-    ("codex", "codex", AgentRuntimeBackend.CODEX.value),
-    ("opencode", "opencode", AgentRuntimeBackend.OPENCODE.value),
+# order. Each row carries the canonical backend, public spelling, configured
+# path resolver, and bare command used by the runtime factory.
+_SDK_RUNTIME_STANDINS = (
+    (CLAUDE_CLI_RUNTIME_BACKEND, AgentRuntimeBackend.CLAUDE_CLI.value, get_cli_path, "claude"),
+    ("codex", AgentRuntimeBackend.CODEX.value, get_codex_cli_path, "codex"),
+    ("opencode", AgentRuntimeBackend.OPENCODE.value, get_opencode_cli_path, "opencode"),
 )
 
 
 def _sdk_runtime_standin(runtime: AgentRuntimeBackend | None) -> tuple[str, str] | None:
     """Return an executable runtime to use in place of an inherited SDK default.
 
-    The SDK-backed ``claude`` runtime cannot run inside this process, so a host
-    that reaches serve with it gets no tools at all. When nobody asked for that
-    runtime here — it arrived from config or from the shipped default — an
-    installed CLI is a better answer than a dead server, and the substitution is
-    announced rather than silent.
-
-    An explicit ``--runtime claude`` or ``OUROBOROS_AGENT_RUNTIME=claude`` is
-    left to fail: overriding what the caller just said would be worse than the
-    error.
+    Explicit CLI or environment selections remain authoritative. For inherited
+    config/default selection, hydrate the detached host's login-shell PATH and
+    reuse the backend-specific executable path resolvers used by runtime
+    construction instead of maintaining a narrower availability definition.
     """
     if runtime is not None:
         return None
-    if os.environ.get("OUROBOROS_AGENT_RUNTIME", "").strip():
+    if any(
+        os.environ.get(key, "").strip() for key in ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_RUNTIME")
+    ):
         return None
-    for command, backend, public_name in _SDK_RUNTIME_STANDINS:
-        if shutil.which(command):
+    _ensure_shell_env()
+    for backend, public_name, configured_path, command in _SDK_RUNTIME_STANDINS:
+        executable = configured_path() or command
+        if shutil.which(executable):
             return backend, public_name
     return None
 
@@ -1270,8 +1270,8 @@ def serve(
         _stderr_console.print(
             Text(
                 "Inherited the 'claude' SDK runtime, which cannot run inside the MCP "
-                f"server; serving with '{standin_name}' instead. Pass --runtime or set "
-                "OUROBOROS_AGENT_RUNTIME to choose.",
+                f"server; serving with '{standin_name}' instead. Pass --runtime, set "
+                "OUROBOROS_AGENT_RUNTIME, or set OUROBOROS_RUNTIME to choose.",
                 style="yellow",
             )
         )

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -546,7 +546,6 @@ def _sdk_runtime_standin(runtime: AgentRuntimeBackend | None) -> tuple[str, str]
         os.environ.get(key, "").strip() for key in ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_RUNTIME")
     ):
         return None
-    _ensure_shell_env()
     for backend, public_name, configured_path, command in _SDK_RUNTIME_STANDINS:
         executable = configured_path() or command
         if shutil.which(executable):
@@ -1245,6 +1244,10 @@ def serve(
         ouroboros mcp serve --runtime codex --llm-backend codex
 
     """
+    # Detached MCP hosts often inherit a minimal environment. Hydrate before
+    # resolving selector provenance so login-shell/cache OUROBOROS_* choices
+    # remain authoritative rather than being mistaken for the shipped default.
+    _ensure_shell_env()
     # Resolve the exact backend the composition root would use before touching
     # nested-process state, shell state, persistence, or runtime adapters. A
     # missing option inherits config and ultimately defaults to the SDK-backed

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -532,6 +532,17 @@ _SDK_RUNTIME_STANDINS = (
 )
 
 
+def _runtime_profile_controls_stage_backends() -> bool:
+    """Return whether stage routing can override the top-level fallback."""
+    try:
+        from ouroboros.config.loader import load_config
+
+        profile = load_config().orchestrator.runtime_profile
+    except Exception:
+        return False
+    return profile is not None and bool(profile.default or profile.stages)
+
+
 def _sdk_runtime_standin(runtime: AgentRuntimeBackend | None) -> tuple[str, str] | None:
     """Return an executable runtime to use in place of an inherited SDK default.
 
@@ -545,6 +556,8 @@ def _sdk_runtime_standin(runtime: AgentRuntimeBackend | None) -> tuple[str, str]
     if any(
         os.environ.get(key, "").strip() for key in ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_RUNTIME")
     ):
+        return None
+    if _runtime_profile_controls_stage_backends():
         return None
     for backend, public_name, configured_path, command in _SDK_RUNTIME_STANDINS:
         executable = configured_path() or command

--- a/tests/unit/cli/test_mcp_nested_guard.py
+++ b/tests/unit/cli/test_mcp_nested_guard.py
@@ -311,6 +311,7 @@ def _clear_runtime_selection(monkeypatch) -> None:
     monkeypatch.delenv("OUROBOROS_AGENT_RUNTIME", raising=False)
     monkeypatch.delenv("OUROBOROS_RUNTIME", raising=False)
     monkeypatch.delenv("_OUROBOROS_NESTED", raising=False)
+    monkeypatch.setattr("ouroboros.cli.commands.mcp._ensure_shell_env", lambda: None)
     # An inherited SDK default now looks for an installed CLI to serve with, so
     # what is on the developer's PATH would otherwise decide these outcomes.
     _installed_clis(monkeypatch)
@@ -484,6 +485,78 @@ def test_env_selected_sdk_runtime_still_fails(monkeypatch, tmp_path) -> None:
         result = runner.invoke(app, ["serve"])
 
     _assert_rejected_before_start(result, run_mcp_server, tmp_path)
+
+
+def test_legacy_env_selected_sdk_runtime_still_fails(monkeypatch, tmp_path) -> None:
+    """OUROBOROS_RUNTIME is an explicit selector too and must not be replaced."""
+    _clear_runtime_selection(monkeypatch)
+    _installed_clis(monkeypatch, "claude", "codex")
+    monkeypatch.setenv("OUROBOROS_RUNTIME", "claude")
+    run_mcp_server = AsyncMock()
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("ouroboros.cli.commands.mcp._run_mcp_server", new=run_mcp_server),
+    ):
+        result = runner.invoke(app, ["serve"])
+
+    _assert_rejected_before_start(result, run_mcp_server, tmp_path)
+
+
+def test_inherited_sdk_uses_configured_claude_cli_path(monkeypatch, tmp_path) -> None:
+    _clear_runtime_selection(monkeypatch)
+    configured_cli = tmp_path / "tools" / "claude-custom"
+    configured_cli.parent.mkdir()
+    configured_cli.write_text("", encoding="utf-8")
+    config_dir = tmp_path / ".ouroboros"
+    config_dir.mkdir()
+    (config_dir / "config.yaml").write_text(
+        "orchestrator:\n"
+        "  runtime_backend: claude\n"
+        f"  cli_path: {configured_cli}\n"
+        "llm:\n  backend: claude\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "ouroboros.cli.commands.mcp.shutil.which",
+        lambda command: str(configured_cli) if command == str(configured_cli) else None,
+    )
+    run_mcp_server = AsyncMock()
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("ouroboros.cli.commands.mcp._run_mcp_server", new=run_mcp_server),
+    ):
+        result = runner.invoke(app, ["serve"])
+
+    assert result.exit_code == 0
+    assert run_mcp_server.await_args.args[4] == "claude_mcp"
+
+
+def test_inherited_sdk_uses_login_shell_recovered_path(monkeypatch, tmp_path) -> None:
+    _clear_runtime_selection(monkeypatch)
+    hydrated = False
+
+    def hydrate() -> None:
+        nonlocal hydrated
+        hydrated = True
+
+    monkeypatch.setattr("ouroboros.cli.commands.mcp._ensure_shell_env", hydrate)
+    monkeypatch.setattr(
+        "ouroboros.cli.commands.mcp.shutil.which",
+        lambda command: f"/login/bin/{command}" if hydrated and command == "claude" else None,
+    )
+    run_mcp_server = AsyncMock()
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("ouroboros.cli.commands.mcp._run_mcp_server", new=run_mcp_server),
+    ):
+        result = runner.invoke(app, ["serve"])
+
+    assert result.exit_code == 0
+    assert hydrated is True
+    assert run_mcp_server.await_args.args[4] == "claude_mcp"
 
 
 def test_no_installed_cli_keeps_the_original_refusal(monkeypatch, tmp_path) -> None:

--- a/tests/unit/cli/test_mcp_nested_guard.py
+++ b/tests/unit/cli/test_mcp_nested_guard.py
@@ -49,6 +49,17 @@ def test_nested_guard_exits_cleanly(monkeypatch):
     assert result.exit_code == 0
 
 
+def test_nested_guard_skips_shell_hydration(monkeypatch) -> None:
+    monkeypatch.setenv("_OUROBOROS_NESTED", "1")
+    hydrate = Mock(side_effect=AssertionError("nested serve must not hydrate"))
+    monkeypatch.setattr("ouroboros.cli.commands.mcp._ensure_shell_env", hydrate)
+
+    result = runner.invoke(app, ["serve", "--runtime", "claude-cli"])
+
+    assert result.exit_code == 0
+    hydrate.assert_not_called()
+
+
 def test_serve_sets_nested_env_var(monkeypatch):
     """serve() should set _OUROBOROS_NESTED=1 for child processes.
 

--- a/tests/unit/cli/test_mcp_nested_guard.py
+++ b/tests/unit/cli/test_mcp_nested_guard.py
@@ -610,6 +610,30 @@ def test_shell_hydrated_explicit_sdk_selector_still_fails(monkeypatch, tmp_path)
     _assert_rejected_before_start(result, run_mcp_server, tmp_path)
 
 
+def test_inherited_sdk_refuses_when_stage_profile_controls_backend(monkeypatch, tmp_path) -> None:
+    _clear_runtime_selection(monkeypatch)
+    _installed_clis(monkeypatch, "claude", "codex")
+    config_dir = tmp_path / ".ouroboros"
+    config_dir.mkdir()
+    (config_dir / "config.yaml").write_text(
+        "orchestrator:\n"
+        "  runtime_backend: claude\n"
+        "  runtime_profile:\n"
+        "    default: claude\n"
+        "llm:\n  backend: claude\n",
+        encoding="utf-8",
+    )
+    run_mcp_server = AsyncMock()
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("ouroboros.cli.commands.mcp._run_mcp_server", new=run_mcp_server),
+    ):
+        result = runner.invoke(app, ["serve"])
+
+    _assert_rejected_before_start(result, run_mcp_server, tmp_path)
+
+
 def test_no_installed_cli_keeps_the_original_refusal(monkeypatch, tmp_path) -> None:
     """With nothing to serve with, the actionable error is still the answer."""
     _clear_runtime_selection(monkeypatch)

--- a/tests/unit/cli/test_mcp_nested_guard.py
+++ b/tests/unit/cli/test_mcp_nested_guard.py
@@ -311,6 +311,17 @@ def _clear_runtime_selection(monkeypatch) -> None:
     monkeypatch.delenv("OUROBOROS_AGENT_RUNTIME", raising=False)
     monkeypatch.delenv("OUROBOROS_RUNTIME", raising=False)
     monkeypatch.delenv("_OUROBOROS_NESTED", raising=False)
+    # An inherited SDK default now looks for an installed CLI to serve with, so
+    # what is on the developer's PATH would otherwise decide these outcomes.
+    _installed_clis(monkeypatch)
+
+
+def _installed_clis(monkeypatch, *available: str) -> None:
+    """Pin which runtime CLIs the stand-in search can find."""
+    monkeypatch.setattr(
+        "ouroboros.cli.commands.mcp.shutil.which",
+        lambda command: f"/usr/local/bin/{command}" if command in available else None,
+    )
 
 
 def _assert_rejected_before_start(result, run_mcp_server: AsyncMock, home) -> None:
@@ -395,3 +406,96 @@ def test_bare_serve_allows_configured_cli_worker(monkeypatch, tmp_path) -> None:
         allowed_origins=(),
         workspace_roots=(),
     )
+
+
+def test_inherited_sdk_default_serves_with_an_installed_cli(monkeypatch, tmp_path) -> None:
+    """A dead server is worse than a runtime nobody typed.
+
+    The SDK-backed ``claude`` runtime cannot run in this process, so inheriting
+    it from config used to mean an MCP host booted with zero Ouroboros tools and
+    three lines of stderr. With a CLI installed, serve that instead and say so.
+    """
+    _clear_runtime_selection(monkeypatch)
+    _installed_clis(monkeypatch, "claude", "codex")
+    config_dir = tmp_path / ".ouroboros"
+    config_dir.mkdir()
+    (config_dir / "config.yaml").write_text(
+        "orchestrator:\n  runtime_backend: claude\nllm:\n  backend: claude\n",
+        encoding="utf-8",
+    )
+    run_mcp_server = AsyncMock()
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("ouroboros.cli.commands.mcp._run_mcp_server", new=run_mcp_server),
+    ):
+        result = runner.invoke(app, ["serve"])
+
+    assert result.exit_code == 0
+    assert run_mcp_server.await_args.args[4] == "claude_mcp"
+    # The substitution has to be visible, or the tool list silently belongs to a
+    # runtime the user never picked.
+    assert "claude-cli" in result.output
+    assert "--runtime" in result.output
+
+
+def test_stand_in_prefers_the_same_engine_out_of_process(monkeypatch, tmp_path) -> None:
+    """Without the Claude CLI, the next installed runtime still beats failing."""
+    _clear_runtime_selection(monkeypatch)
+    _installed_clis(monkeypatch, "codex", "opencode")
+    run_mcp_server = AsyncMock()
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("ouroboros.cli.commands.mcp._run_mcp_server", new=run_mcp_server),
+    ):
+        result = runner.invoke(app, ["serve"])
+
+    assert result.exit_code == 0
+    assert run_mcp_server.await_args.args[4] == "codex"
+
+
+def test_explicit_sdk_runtime_still_fails(monkeypatch, tmp_path) -> None:
+    """Substituting for a runtime the caller just named would be worse."""
+    _clear_runtime_selection(monkeypatch)
+    _installed_clis(monkeypatch, "claude", "codex")
+    run_mcp_server = AsyncMock()
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("ouroboros.cli.commands.mcp._run_mcp_server", new=run_mcp_server),
+    ):
+        result = runner.invoke(app, ["serve", "--runtime", "claude"])
+
+    _assert_rejected_before_start(result, run_mcp_server, tmp_path)
+
+
+def test_env_selected_sdk_runtime_still_fails(monkeypatch, tmp_path) -> None:
+    """The environment is an explicit choice too, so it is not overridden."""
+    _clear_runtime_selection(monkeypatch)
+    _installed_clis(monkeypatch, "claude", "codex")
+    monkeypatch.setenv("OUROBOROS_AGENT_RUNTIME", "claude")
+    run_mcp_server = AsyncMock()
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("ouroboros.cli.commands.mcp._run_mcp_server", new=run_mcp_server),
+    ):
+        result = runner.invoke(app, ["serve"])
+
+    _assert_rejected_before_start(result, run_mcp_server, tmp_path)
+
+
+def test_no_installed_cli_keeps_the_original_refusal(monkeypatch, tmp_path) -> None:
+    """With nothing to serve with, the actionable error is still the answer."""
+    _clear_runtime_selection(monkeypatch)
+    _installed_clis(monkeypatch)
+    run_mcp_server = AsyncMock()
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("ouroboros.cli.commands.mcp._run_mcp_server", new=run_mcp_server),
+    ):
+        result = runner.invoke(app, ["serve"])
+
+    _assert_rejected_before_start(result, run_mcp_server, tmp_path)

--- a/tests/unit/cli/test_mcp_nested_guard.py
+++ b/tests/unit/cli/test_mcp_nested_guard.py
@@ -559,6 +559,46 @@ def test_inherited_sdk_uses_login_shell_recovered_path(monkeypatch, tmp_path) ->
     assert run_mcp_server.await_args.args[4] == "claude_mcp"
 
 
+def test_shell_hydrated_non_sdk_selector_is_authoritative(monkeypatch, tmp_path) -> None:
+    _clear_runtime_selection(monkeypatch)
+
+    def hydrate() -> None:
+        monkeypatch.setenv("OUROBOROS_AGENT_RUNTIME", "codex")
+
+    monkeypatch.setattr("ouroboros.cli.commands.mcp._ensure_shell_env", hydrate)
+    _installed_clis(monkeypatch, "claude", "codex")
+    run_mcp_server = AsyncMock()
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("ouroboros.cli.commands.mcp._run_mcp_server", new=run_mcp_server),
+    ):
+        result = runner.invoke(app, ["serve"])
+
+    assert result.exit_code == 0
+    assert run_mcp_server.await_args.args[4] == "codex"
+    assert "serving with 'claude-cli'" not in result.output
+
+
+def test_shell_hydrated_explicit_sdk_selector_still_fails(monkeypatch, tmp_path) -> None:
+    _clear_runtime_selection(monkeypatch)
+
+    def hydrate() -> None:
+        monkeypatch.setenv("OUROBOROS_RUNTIME", "claude")
+
+    monkeypatch.setattr("ouroboros.cli.commands.mcp._ensure_shell_env", hydrate)
+    _installed_clis(monkeypatch, "claude", "codex")
+    run_mcp_server = AsyncMock()
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("ouroboros.cli.commands.mcp._run_mcp_server", new=run_mcp_server),
+    ):
+        result = runner.invoke(app, ["serve"])
+
+    _assert_rejected_before_start(result, run_mcp_server, tmp_path)
+
+
 def test_no_installed_cli_keeps_the_original_refusal(monkeypatch, tmp_path) -> None:
     """With nothing to serve with, the actionable error is still the answer."""
     _clear_runtime_selection(monkeypatch)


### PR DESCRIPTION
Part of #2163 (first half).

## The failure

Installing the dsh plugin on a machine whose config says `runtime_backend: claude` gives the user this, three times, and zero Ouroboros tools:

```
The MCP server cannot host the 'claude' SDK runtime in this process. Pass an
executable runtime, for example 'ouroboros mcp serve --runtime claude-cli', ...
```

The guard's premise is right: the in-process Claude SDK runtime cannot run inside the MCP server. Its conclusion is what hurts. The user never chose that runtime for this process; it came from config or from the shipped default. And because the plugin sets `failOnStartupError: false`, dsh boots normally and the tools are simply absent, so the error reads as noise rather than as the reason nothing works.

## The change

`serve` now looks for an executable stand-in before refusing:

| Situation | Before | After |
|---|---|---|
| Inherited `claude`, a CLI is installed | exit 1, no tools | serves with that CLI, announced on stderr |
| Inherited `claude`, nothing installed | exit 1 | exit 1, same message |
| `--runtime claude` | exit 1 | exit 1 |
| `OUROBOROS_AGENT_RUNTIME=claude` | exit 1 | exit 1 |

Preference order is `claude-cli`, then `codex`, then `opencode`. `claude-cli` is first because it is the same engine out of process, so a user who inherited the SDK default gets the runtime they meant.

Two decisions worth naming:

- **An explicit selection still fails.** Substituting for a runtime the caller just typed would be worse than the error, and the error already names the fix.
- **The substitution is announced, with the public spelling.** A silent swap would leave a working tool list backed by a runtime nobody picked. The notice says `claude-cli`, not the internal `claude_mcp`, because the latter is a value `--runtime` rejects.

## Verification

Not inferred from the guard. In a real MCP 2 environment, with `runtime_backend: claude` in config and no environment override:

```
$ uvx --isolated --from '<repo>[mcp]' ouroboros mcp serve
Inherited the 'claude' SDK runtime, which cannot run inside the MCP server;
serving with 'claude-cli' instead. Pass --runtime or set OUROBOROS_AGENT_RUNTIME to choose.
Registered 36 tools
```

and `initialize` answered on stdout. The same config previously exited 1.

`tests/unit/cli/test_mcp_nested_guard.py`: 21 passed, covering the stand-in, the ordering, both explicit-selection refusals, and the nothing-installed refusal.

**Two existing tests were reading the developer's own PATH.** `test_bare_serve_rejects_missing_config_sdk_default_before_mutation` and `test_bare_serve_rejects_configured_sdk_before_mutation` passed on a machine without `claude`/`codex` and would have failed on one with them. Both now pin the CLI probe, so the outcome is the same in CI and on a laptop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AA3ADfHwxVa5drYxFAjC8C