### PR TITLE
feat(install): install the dsh plugin when DeepSeek Harness is present

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -939,6 +939,8 @@ HAS_KIRO=false
 HAS_COPILOT=false
 HAS_PI=false
 HAS_GJC=false
+HAS_DSH=false
+DSH_PLUGIN_SPEC="github:Q00/ouroboros#main&path:integrations/dsh-plugin"
 if command -v codex &>/dev/null; then
   _ok "Codex found: $(which codex)"
   HAS_CODEX=true
@@ -978,6 +980,10 @@ fi
 if command -v gjc &>/dev/null; then
   _ok "GJC found: $(which gjc)"
   HAS_GJC=true
+fi
+if command -v dsh &>/dev/null; then
+  _ok "DeepSeek Harness found: $(which dsh)"
+  HAS_DSH=true
 fi
 
 RUNTIME_COUNT=0
@@ -1439,6 +1445,41 @@ if [ -t 0 ] && [ -z "${OUROBOROS_INSTALL_SKIP_CONFIG_GUI:-}" ]; then
       _info '  in a terminal:    ouroboros config'
       ;;
   esac
+fi
+
+# 6. DeepSeek Harness integration. Unlike the other hosts, dsh keeps its plugins
+# per profile, and `dsh plugin` requires --profile, so there is no single global
+# install to run. Cover the profile a dsh user actually boots (`web`, which
+# `dsh web` scaffolds) and refresh any other profile that already carries the
+# bundle, which is how an existing install picks up a new release.
+if [ "$HAS_DSH" = true ]; then
+  _blank
+  _say "${BLUE}◆${RESET} ${BOLD}DeepSeek Harness plugin${RESET}"
+
+  DSH_PROFILE_ROOT="${DSH_HOME:-$HOME/.dsh}/profiles"
+  DSH_TARGET_PROFILES="web"
+  if [ -d "$DSH_PROFILE_ROOT" ]; then
+    for _dsh_profile_dir in "$DSH_PROFILE_ROOT"/*/; do
+      [ -d "$_dsh_profile_dir" ] || continue
+      _dsh_profile=$(basename "$_dsh_profile_dir")
+      [ "$_dsh_profile" = "web" ] && continue
+      # Only profiles that already opted in. Adding Ouroboros tools to an
+      # unrelated profile because the installer ran is not an upgrade.
+      if grep -q "dsh-ouroboros" "$_dsh_profile_dir/package.json" 2>/dev/null; then
+        DSH_TARGET_PROFILES="$DSH_TARGET_PROFILES $_dsh_profile"
+      fi
+    done
+  fi
+
+  for _dsh_profile in $DSH_TARGET_PROFILES; do
+    if dsh plugin --profile "$_dsh_profile" add "$DSH_PLUGIN_SPEC" >/dev/null 2>&1; then
+      _ok "dsh profile '$_dsh_profile': Ouroboros tools installed"
+    else
+      _warn "dsh profile '$_dsh_profile': install skipped"
+      _info "Manual install: dsh plugin --profile $_dsh_profile add \"$DSH_PLUGIN_SPEC\""
+    fi
+  done
+  _info "Type 'ooo interview <goal>' in a dsh chat to use them."
 fi
 
 _blank

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1457,21 +1457,40 @@ if [ "$HAS_DSH" = true ]; then
   _say "${BLUE}◆${RESET} ${BOLD}DeepSeek Harness plugin${RESET}"
 
   DSH_PROFILE_ROOT="${DSH_HOME:-$HOME/.dsh}/profiles"
-  DSH_TARGET_PROFILES="web"
-  if [ -d "$DSH_PROFILE_ROOT" ]; then
+  DSH_TARGET_PROFILES=("web")
+  _dsh_json_python="${PYTHON:-}"
+  if [ -z "$_dsh_json_python" ]; then
+    _dsh_json_python=$(command -v python3 2>/dev/null || true)
+  fi
+  if [ -z "$_dsh_json_python" ]; then
+    _dsh_ouroboros_cmd=$(command -v ouroboros 2>/dev/null || true)
+    if [ -n "$_dsh_ouroboros_cmd" ] && [ -r "$_dsh_ouroboros_cmd" ]; then
+      _dsh_shebang=$(head -n 1 "$_dsh_ouroboros_cmd" 2>/dev/null || true)
+      case "$_dsh_shebang" in
+        '#!'/*)
+          _dsh_json_python=${_dsh_shebang#'#!'}
+          case "$_dsh_json_python" in
+            *' '*) _dsh_json_python="" ;;
+          esac
+          [ -x "$_dsh_json_python" ] || _dsh_json_python=""
+          ;;
+      esac
+    fi
+  fi
+  if [ -n "$_dsh_json_python" ] && [ -d "$DSH_PROFILE_ROOT" ]; then
     for _dsh_profile_dir in "$DSH_PROFILE_ROOT"/*/; do
       [ -d "$_dsh_profile_dir" ] || continue
       _dsh_profile=$(basename "$_dsh_profile_dir")
       [ "$_dsh_profile" = "web" ] && continue
       # Only profiles that already opted in. Adding Ouroboros tools to an
       # unrelated profile because the installer ran is not an upgrade.
-      if grep -q "dsh-ouroboros" "$_dsh_profile_dir/package.json" 2>/dev/null; then
-        DSH_TARGET_PROFILES="$DSH_TARGET_PROFILES $_dsh_profile"
+      if "$_dsh_json_python" -c 'import json, sys; data = json.load(open(sys.argv[1], encoding="utf-8")); dependencies = data.get("dependencies", {}) if isinstance(data, dict) else {}; sys.exit(0 if isinstance(dependencies, dict) and "dsh-ouroboros" in dependencies else 1)' "$_dsh_profile_dir/package.json" 2>/dev/null; then
+        DSH_TARGET_PROFILES+=("$_dsh_profile")
       fi
     done
   fi
 
-  for _dsh_profile in $DSH_TARGET_PROFILES; do
+  for _dsh_profile in "${DSH_TARGET_PROFILES[@]}"; do
     if dsh plugin --profile "$_dsh_profile" add "$DSH_PLUGIN_SPEC" >/dev/null 2>&1; then
       _ok "dsh profile '$_dsh_profile': Ouroboros tools installed"
     else

--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -2432,3 +2432,66 @@ def test_install_all_extras_match_pyproject_pins(tmp_path: Path) -> None:
     assert "--with mcp==" not in calls
     assert "--with claude-agent-sdk==0.2.128" in calls
     assert "--with anthropic==0.120.2" in calls
+
+
+_DSH_STUB = f"""#!/bin/sh
+printf 'dsh %s\\n' "$*" >> {CALLS_LOG_REF}
+exit 0
+"""
+
+
+def _dsh_calls(tmp_path: Path) -> list[str]:
+    calls = (tmp_path / "calls.log").read_text(encoding="utf-8").splitlines()
+    return [line for line in calls if line.startswith("dsh ")]
+
+
+def test_installer_without_dsh_touches_no_profile(tmp_path: Path) -> None:
+    """The bundle install is conditional on the host actually being installed."""
+    result = _run_installer(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert not _dsh_calls(tmp_path)
+    assert "DeepSeek Harness plugin" not in result.stdout
+
+
+def test_installer_covers_the_profile_a_dsh_user_boots(tmp_path: Path) -> None:
+    """`dsh web` scaffolds `web`, so that is the profile worth covering blind."""
+    result = _run_installer(tmp_path, fake_commands={"dsh": _DSH_STUB})
+
+    assert result.returncode == 0, result.stderr
+    assert _dsh_calls(tmp_path) == [
+        "dsh plugin --profile web add github:Q00/ouroboros#main&path:integrations/dsh-plugin"
+    ]
+
+
+def test_installer_refreshes_profiles_that_already_opted_in(tmp_path: Path) -> None:
+    """An existing install picks up a release; an unrelated profile is left alone."""
+    profiles = tmp_path / "home" / ".dsh" / "profiles"
+    (profiles / "tui").mkdir(parents=True)
+    (profiles / "tui" / "package.json").write_text(
+        '{"dependencies": {"dsh-ouroboros": "github:Q00/ouroboros"}}', encoding="utf-8"
+    )
+    (profiles / "unrelated").mkdir(parents=True)
+    (profiles / "unrelated" / "package.json").write_text(
+        '{"dependencies": {"something-else": "1.0.0"}}', encoding="utf-8"
+    )
+
+    result = _run_installer(tmp_path, fake_commands={"dsh": _DSH_STUB})
+
+    assert result.returncode == 0, result.stderr
+    profiles_called = sorted(
+        line.split("--profile ")[1].split()[0] for line in _dsh_calls(tmp_path)
+    )
+    assert profiles_called == ["tui", "web"]
+
+
+def test_installer_survives_a_failing_dsh(tmp_path: Path) -> None:
+    """A broken host cannot fail an install that already put Ouroboros on disk."""
+    result = _run_installer(
+        tmp_path,
+        fake_commands={"dsh": "#!/bin/sh\nexit 1\n"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "install skipped" in result.stdout
+    assert "Manual install: dsh plugin --profile web add" in result.stdout

--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -2473,16 +2473,61 @@ def test_installer_refreshes_profiles_that_already_opted_in(tmp_path: Path) -> N
     )
     (profiles / "unrelated").mkdir(parents=True)
     (profiles / "unrelated" / "package.json").write_text(
-        '{"dependencies": {"something-else": "1.0.0"}}', encoding="utf-8"
+        json.dumps(
+            {
+                "dependencies": {"not-dsh-ouroboros": "1.0.0"},
+                "description": "mentions dsh-ouroboros without installing it",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (profiles / "malformed").mkdir(parents=True)
+    (profiles / "malformed" / "package.json").write_text(
+        '{"dependencies": {"dsh-ouroboros":', encoding="utf-8"
     )
 
-    result = _run_installer(tmp_path, fake_commands={"dsh": _DSH_STUB})
+    result = _run_installer(
+        tmp_path,
+        fake_commands={
+            "dsh": _DSH_STUB,
+            "python3": f'#!/bin/sh\nexec {shlex.quote(sys.executable)} "$@"\n',
+        },
+    )
 
     assert result.returncode == 0, result.stderr
     profiles_called = sorted(
         line.split("--profile ")[1].split()[0] for line in _dsh_calls(tmp_path)
     )
     assert profiles_called == ["tui", "web"]
+
+
+def test_installer_preserves_an_opted_in_profile_name_as_one_argument(tmp_path: Path) -> None:
+    """Profile discovery must not split or expand user-owned directory names."""
+    profile = tmp_path / "home" / ".dsh" / "profiles" / "team alpha"
+    profile.mkdir(parents=True)
+    (profile / "package.json").write_text(
+        '{"dependencies": {"dsh-ouroboros": "github:Q00/ouroboros"}}', encoding="utf-8"
+    )
+    dsh_stub = f"""#!/bin/sh
+printf 'dsh-profile:%s\\n' "$3" >> {CALLS_LOG_REF}
+exit 0
+"""
+
+    result = _run_installer(
+        tmp_path,
+        fake_commands={
+            "dsh": dsh_stub,
+            "python3": f'#!/bin/sh\nexec {shlex.quote(sys.executable)} "$@"\n',
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    profiles_called = [
+        line.removeprefix("dsh-profile:")
+        for line in (tmp_path / "calls.log").read_text(encoding="utf-8").splitlines()
+        if line.startswith("dsh-profile:")
+    ]
+    assert profiles_called == ["web", "team alpha"]
 
 
 def test_installer_survives_a_failing_dsh(tmp_path: Path) -> None:


### PR DESCRIPTION
Part of #2163 (second half). Independent of #2164; different files.

## Why

`install.sh` sets up every host it detects. A dsh user was the only one who then had to read a README and paste a command to get any Ouroboros tools.

## What it does

dsh keeps plugins per profile and `dsh plugin` requires `--profile`, so there is no global install to run. The installer therefore picks its targets:

- **`web`** — the profile `dsh web` scaffolds, and the one a dsh user actually boots. Installing into it also creates it if absent, which is the same thing `dsh web` would do.
- **Any other profile whose `package.json` already carries `dsh-ouroboros`** — this is how an existing install picks up a release.
- **Nothing else.** Adding Ouroboros tools to someone's unrelated profile because an installer ran is not an upgrade.

Failure is non-fatal and prints the manual command. Ouroboros is already on disk by that point, and a host that cannot install a plugin must not fail an install that just succeeded.

## Verification

Against the real `dsh` CLI (0.1.0-rc.6) in a throwaway `DSH_HOME`, not only against a stub:

```
OK: web
deps:    {'dsh-ouroboros': 'github:Q00/ouroboros#main&path:integrations/dsh-plugin'}
bundles: ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app', 'dsh-ouroboros']
```

`tests/unit/scripts/test_install_runtime_selection.py`: 97 passed, including four new cases — no dsh means no profile is touched, `web` is covered blind, an opted-in profile is refreshed while an unrelated one is not, and a failing `dsh` leaves the install green with the manual command printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AA3ADfHwxVa5drYxFAjC8C