### PR TITLE
fix(install): preserve DSH profile names in recovery output

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1480,7 +1480,8 @@ if [ "$HAS_DSH" = true ]; then
   if [ -n "$_dsh_json_python" ] && [ -d "$DSH_PROFILE_ROOT" ]; then
     for _dsh_profile_dir in "$DSH_PROFILE_ROOT"/*/; do
       [ -d "$_dsh_profile_dir" ] || continue
-      _dsh_profile=$(basename "$_dsh_profile_dir")
+      _dsh_profile=${_dsh_profile_dir#"$DSH_PROFILE_ROOT"/}
+      _dsh_profile=${_dsh_profile%/}
       [ "$_dsh_profile" = "web" ] && continue
       # Only profiles that already opted in. Adding Ouroboros tools to an
       # unrelated profile because the installer ran is not an upgrade.
@@ -1491,11 +1492,12 @@ if [ "$HAS_DSH" = true ]; then
   fi
 
   for _dsh_profile in "${DSH_TARGET_PROFILES[@]}"; do
+    LC_ALL=C printf -v _dsh_profile_q '%q' "$_dsh_profile"
     if dsh plugin --profile "$_dsh_profile" add "$DSH_PLUGIN_SPEC" >/dev/null 2>&1; then
-      _ok "dsh profile '$_dsh_profile': Ouroboros tools installed"
+      _ok "dsh profile $_dsh_profile_q: Ouroboros tools installed"
     else
-      _warn "dsh profile '$_dsh_profile': install skipped"
-      _info "Manual install: dsh plugin --profile $_dsh_profile add \"$DSH_PLUGIN_SPEC\""
+      _warn "dsh profile $_dsh_profile_q: install skipped"
+      _info "Manual install: dsh plugin --profile $_dsh_profile_q add \"$DSH_PLUGIN_SPEC\""
     fi
   done
   _info "Type 'ooo interview <goal>' in a dsh chat to use them."

--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -2530,6 +2530,97 @@ exit 0
     assert profiles_called == ["web", "team alpha"]
 
 
+@pytest.mark.parametrize(
+    "profile_name",
+    [
+        "team alpha",
+        "team's alpha",
+        "team$alpha*",
+        "team$(printf PWNED)",
+        "team`printf PWNED`",
+        "team;printf PWNED",
+        "team\nalpha",
+        "team\n",
+        "team\ralpha",
+        "team\x1b[31mred",
+        "team\u202etxt",
+        "team\u200btxt",
+        "팀 alpha",
+    ],
+)
+def test_installer_quotes_profile_in_manual_recovery_command(
+    tmp_path: Path, profile_name: str
+) -> None:
+    """The printed fallback command must preserve a profile name as one shell argument."""
+    profile = tmp_path / "home" / ".dsh" / "profiles" / profile_name
+    profile.mkdir(parents=True)
+    (profile / "package.json").write_text(
+        '{"dependencies": {"dsh-ouroboros": "github:Q00/ouroboros"}}', encoding="utf-8"
+    )
+
+    result = _run_installer(
+        tmp_path,
+        fake_commands={
+            "dsh": "#!/bin/sh\nexit 1\n",
+            "python3": f'#!/bin/sh\nexec {shlex.quote(sys.executable)} "$@"\n',
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    manual_commands = [
+        line.split("Manual install: ", 1)[1]
+        for line in result.stdout.splitlines()
+        if "Manual install: " in line
+    ]
+    quoted_profile = subprocess.run(
+        ["bash", "-c", "printf '%q' \"$1\"", "_", profile_name],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "LC_ALL": "C"},
+    ).stdout
+    assert manual_commands == [
+        'dsh plugin --profile web add "github:Q00/ouroboros#main&path:integrations/dsh-plugin"',
+        f'dsh plugin --profile {quoted_profile} add "github:Q00/ouroboros#main&path:integrations/dsh-plugin"',
+    ]
+    expected_warning = f"dsh profile {quoted_profile}: install skipped"
+    assert sum(line.endswith(expected_warning) for line in result.stdout.splitlines()) == 1
+    assert profile_name not in result.stdout
+
+
+@pytest.mark.parametrize(
+    "profile_name",
+    ["team\n", "team\x1b[31mred", "team\u202etxt", "team\u200btxt", "팀 alpha"],
+)
+def test_installer_quotes_profile_in_success_log(tmp_path: Path, profile_name: str) -> None:
+    """Successful installs must not emit raw profile control characters."""
+    profile = tmp_path / "home" / ".dsh" / "profiles" / profile_name
+    profile.mkdir(parents=True)
+    (profile / "package.json").write_text(
+        '{"dependencies": {"dsh-ouroboros": "github:Q00/ouroboros"}}', encoding="utf-8"
+    )
+
+    result = _run_installer(
+        tmp_path,
+        fake_commands={
+            "dsh": "#!/bin/sh\nexit 0\n",
+            "python3": f'#!/bin/sh\nexec {shlex.quote(sys.executable)} "$@"\n',
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    quoted_profile = subprocess.run(
+        ["bash", "-c", "printf '%q' \"$1\"", "_", profile_name],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "LC_ALL": "C"},
+    ).stdout
+    expected_status = f"dsh profile {quoted_profile}: Ouroboros tools installed"
+    assert sum(line.endswith(expected_status) for line in result.stdout.splitlines()) == 1
+    assert profile_name not in result.stdout
+
+
 def test_installer_survives_a_failing_dsh(tmp_path: Path) -> None:
     """A broken host cannot fail an install that already put Ouroboros on disk."""
     result = _run_installer(


### PR DESCRIPTION
## Summary

Follow-up to #2165. Preserve exact DSH profile directory names during discovery and render profile names safely in installer status and manual recovery output.

- replace `basename` command substitution with Bash parameter expansion so trailing newlines are preserved
- use `printf -v ... %q` for success, failure, and copyable recovery output
- keep the actual `dsh --profile` argument byte-preserving and single-argument
- remove generated-command evaluation from regression tests

## Verification

- focused hostile-name cases: spaces, quotes, globs, command substitution syntax, separators, embedded/trailing newline, CR, and ANSI escape
- installer module: 107 passed, 3 host-baseline failures deselected after reproducing them on clean main
- DSH plugin bundle: 7 passed
- Ruff check and format check: passed
- Bash 3.2 syntax and direct portability probes: passed
- three independent reviews on frozen diff `7c32da491da90fc23dc6fcf9bbf1fa1e629d49662c95a88bd8d61d14d16531ca`: PASS / PASS / PASS

Refs #2163