### PR TITLE
docs: add source tour mapping three mechanisms to file:line coordinates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -67,6 +67,7 @@ replayable execution contract on your choice of runtime backend.
 
 - [Contributing Guide](../CONTRIBUTING.md) - How to set up, code, test, and submit PRs
 - [Architecture for Contributors](./contributing/architecture-overview.md) - How modules connect
+- [Source Tour](./contributing/source-tour.md) - Three core mechanisms mapped to file:line coordinates, for teardown writers and reviewers
 - [Agent OS Kernel Terminology](./contributing/agent-os-kernel-terminology.md) - Locked vocabulary for `AgentRuntimeContext`, `ControlPlane`, `ControlContract`, `Directive`, `ControlBus`, and `IOJournal`
 - [ControlContract](./contributing/control-contract.md) - Control-plane schema, terminality, replay, and idempotency invariants
 - [Testing Guide](./contributing/testing-guide.md) - Writing and running tests

--- a/docs/contributing/source-tour.md
+++ b/docs/contributing/source-tour.md
@@ -1,0 +1,72 @@
+# Source tour: three Ouroboros mechanisms and the lines that limit them
+
+Product claims should be greppable. This page maps the three mechanisms our
+docs talk about most to the exact lines that implement them, including the
+limits. If you are writing a teardown, start here: these are the files we
+would want you to judge us by.
+
+## Stop 1: The success contract omits the answer key
+
+`src/ouroboros/orchestrator/contract_redaction.py`
+
+- `contract_redaction.py:10`: `hidden_contract_variants` enumerates the five
+  encodings that get masked.
+- `contract_redaction.py:42`: the substitution is literal `str.replace`.
+  That means a reshaped copy of a hidden value is not caught. We track that
+  gap in a public issue rather than claiming otherwise.
+- `retry_hints.py:76`: `build_assertion_safe_retry_hint`: retry hints are
+  assembled deterministically, no model call.
+- `retry_hints.py:102`: the retry prompt carries a tail of command output;
+  redaction on it is the same literal substitution.
+
+The claim's exact scope: when an acceptance criterion defines a verify
+command or an expected-output assertion, those values are omitted from the
+worker's contract block, with no flag to put them back. The scope is the
+contract block: the docs say so, and
+[`docs/hidden-checklist-convergence/requirements.md:17`](../hidden-checklist-convergence/requirements.md)
+states the boundary explicitly.
+
+## Stop 2: The ambiguity gate is a number, not a vibe
+
+`src/ouroboros/bigbang/ambiguity.py`
+
+- `ambiguity.py:37`: `AMBIGUITY_THRESHOLD = 0.2` gates seed generation.
+- `ambiguity.py:48-50`: the score is weighted: goal clarity 0.40, constraint
+  clarity 0.30, success-criteria clarity 0.30.
+- `ambiguity.py:42-45`: per-axis floors (0.75 / 0.65 / 0.70, plus a fourth
+  0.60 floor for brownfield context) mean one strong axis cannot carry two
+  weak ones.
+- `seed_generator.py:1770`: the domain gate; `force` is the one portable
+  bypass, and it is explicit (`authoring_handlers.py:1464` passes it straight
+  through).
+- `interview_driver.py:125`: the unattended auto mode has its own readiness
+  constant (`BACKEND_READY_AMBIGUITY_THRESHOLD`, also 0.20, defined
+  independently).
+
+The gate does not judge whether your idea is good. A request can score well
+and still describe a bad idea clearly. It only guarantees that a vague spec
+cannot exist without someone explicitly choosing it.
+
+## Stop 3: Reviewer independence is a labeled state
+
+`src/ouroboros/evaluation/reviewer_independence.py`
+
+- `reviewer_independence.py:50`: evaluation runs carry one of four
+  independence labels (`INDEPENDENT` is one of them, not the default
+  assumption).
+- `reviewer_independence.py:148`: `filter_voter_models` removes voters that
+  share a vendor with the executor.
+- `reviewer_independence.py:46` and `:168`: minimum viable jury is 2; if
+  same-vendor removal would go below that, the original roster is rolled
+  back rather than pretending a one-voter jury is a jury.
+- `reviewer_independence.py:167`: voters of unknown vendor are not removed,
+  because same-vendor cannot be proven. The conservative direction is to
+  keep and label.
+- `consensus.py:388`: the resulting state is recorded in the consensus
+  output, so you can see what kind of jury judged a run.
+
+## How to use this page
+
+Choose one symbol above and verify its coordinate against current `main`. If
+it moved, report the symbol and the old and new line numbers. That gives us
+a documentation bug we can reproduce and fix without guessing.


### PR DESCRIPTION
## Summary
- Adds `docs/contributing/source-tour.md`: three mechanisms (success-contract redaction, ambiguity gate, reviewer independence) mapped to exact `file:line` coordinates, each with its stated limit, aimed at teardown writers and reviewers who want to verify claims against source instead of prose.
- Links the new page from `docs/README.md` under Contributing, next to Architecture for Contributors.
- All 20 cited coordinates verified against current `main` at time of writing.

## Test plan
- [x] Every `path:line` coordinate manually diffed against current `main` (grep token match)
- [x] No em dash in the new page (docs style: none used)
- [x] Link added to `docs/README.md` resolves to the new file

Co-authored-by: Ouroboros Growth Marketer session