### PR TITLE
fix(cli): ask the question the ambiguity score implies

### DIFF
--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -730,6 +730,10 @@ class InterviewEngine:
     _MIN_SYSTEM_PROMPT_CHARS = 1200
     _MAX_INITIAL_CONTEXT_SYSTEM_CHARS = 1800
     _MAX_INITIAL_CONTEXT_TOTAL_CHARS = MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS
+    # Opening span of the base agent prompt that survives trimming ahead of the
+    # perspective panel: the role boundaries, context boundaries, and response
+    # format that keep the generator asking questions instead of answering them.
+    _BASE_PROMPT_ROLE_FLOOR_CHARS = 500
     _INITIAL_CONTEXT_SUMMARY_QUESTION = INITIAL_CONTEXT_SUMMARY_QUESTION
     suppress_tool_use_prompt_cues: bool = False
     # When True, ``ask_next_question`` generates three persona candidates
@@ -1310,15 +1314,27 @@ class InterviewEngine:
         # Preserve the dynamic header first; it contains the capped initial
         # context and first-turn instructions. Trim the optional panel/base
         # prompt before falling back to hard-truncating the header.
+        #
+        # The base prompt opens with the role boundaries that keep the model an
+        # interviewer ("NEVER say I will implement", "always end with a
+        # question"). Those must outrank the panel: a growing header or panel
+        # otherwise pushes them out entirely, which is exactly when they matter
+        # most — a late round with a stored ambiguity snapshot and the
+        # seed-closer perspective attached.
         available_after_header = max_prompt_chars - len(dynamic_header) - _OVERHEAD
         if available_after_header <= 0:
             dynamic_header = dynamic_header[: max_prompt_chars - _OVERHEAD]
             perspective_panel = ""
             base_budget = 0
-        elif len(perspective_panel) > available_after_header:
-            perspective_panel = perspective_panel[:available_after_header]
-            base_budget = 0
         else:
+            reserved_base = min(
+                len(base_prompt),
+                self._BASE_PROMPT_ROLE_FLOOR_CHARS,
+                available_after_header,
+            )
+            panel_budget = available_after_header - reserved_base
+            if len(perspective_panel) > panel_budget:
+                perspective_panel = perspective_panel[:panel_budget]
             base_budget = available_after_header - len(perspective_panel)
 
         trimmed_base = base_prompt[:base_budget] if base_budget < len(base_prompt) else base_prompt
@@ -1458,7 +1474,17 @@ class InterviewEngine:
             state.ambiguity_score is not None
             and state.ambiguity_score <= SEED_CLOSER_ACTIVATION_THRESHOLD
         ):
-            perspectives.append(InterviewPerspective.SEED_CLOSER)
+            # Closure rounds run a narrower panel, led by the closer. Two
+            # reasons, one budget and one substantive: the panel is trimmed
+            # from the tail, so appending the closer would drop it in exactly
+            # the rounds it exists for; and researcher/simplifier drilling is
+            # the behavior closure is meant to stop. The freed characters go
+            # back to the base prompt's role boundaries.
+            perspectives = [
+                InterviewPerspective.SEED_CLOSER,
+                InterviewPerspective.BREADTH_KEEPER,
+                InterviewPerspective.ARCHITECT,
+            ]
 
         if state.is_brownfield and InterviewPerspective.ARCHITECT not in perspectives:
             perspectives.append(InterviewPerspective.ARCHITECT)

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -84,6 +84,18 @@ AGENT_SDK_CLI_PER_MESSAGE_FRAMING_CHARS = 128
 # model locally while still tripling the original 4.8k interview budget.
 AGENT_SDK_CLI_SAFE_PROMPT_CHARS = 14_000
 
+# The two rules that make a generated turn a question at all. They live in the
+# dynamic header — which every build preserves first — instead of only inside
+# the loaded agent prompt, whose tail is the first thing the character budget
+# trims. Leaving them there made their survival depend on where they happen to
+# sit in a markdown file and on how large the header and perspective panel grew
+# that round: in a late round with a stored ambiguity snapshot, the response
+# format was silently dropped from the prompt that needed it most.
+RESPONSE_CONTRACT = (
+    "Response contract: emit exactly ONE question and end with it. "
+    "Never announce implementation work — another agent does that later."
+)
+
 _TOOLLESS_INTERVIEW_BASE_PROMPT = """## Role Boundaries
 - You are only an interviewer.
 - Generate exactly one Socratic question that reduces requirements ambiguity.
@@ -737,12 +749,6 @@ class InterviewEngine:
     _MIN_SYSTEM_PROMPT_CHARS = 1200
     _MAX_INITIAL_CONTEXT_SYSTEM_CHARS = 1800
     _MAX_INITIAL_CONTEXT_TOTAL_CHARS = MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS
-    # Opening span of the base agent prompt that survives trimming ahead of the
-    # perspective panel: the CRITICAL ROLE BOUNDARIES section, which forbids the
-    # generator from answering its own question. Deliberately small — the
-    # dynamic header already carries "Your ONLY job is to ask questions", and a
-    # larger floor starves panels that callers reserve budget for.
-    _BASE_PROMPT_ROLE_FLOOR_CHARS = 500
     _INITIAL_CONTEXT_SUMMARY_QUESTION = INITIAL_CONTEXT_SUMMARY_QUESTION
     suppress_tool_use_prompt_cues: bool = False
     # When True, ``ask_next_question`` generates three persona candidates
@@ -1272,12 +1278,14 @@ class InterviewEngine:
                 f'Do NOT introduce yourself. Do NOT say "I\'ll conduct" or "Let me ask". '
                 f"Just ask a specific, clarifying question immediately.\n\n"
                 f"This is {round_info}. Your ONLY job is to ask questions that reduce ambiguity.\n\n"
+                f"{RESPONSE_CONTRACT}\n\n"
                 f"Initial context: {prompt_initial_context}\n"
             )
         else:
             dynamic_header = (
                 f"You are an expert requirements engineer conducting a Socratic interview.\n\n"
                 f"This is {round_info}. Your ONLY job is to ask questions that reduce ambiguity.\n\n"
+                f"{RESPONSE_CONTRACT}\n\n"
                 f"Initial context: {prompt_initial_context}\n"
             )
 
@@ -1324,25 +1332,20 @@ class InterviewEngine:
         # context and first-turn instructions. Trim the optional panel/base
         # prompt before falling back to hard-truncating the header.
         #
-        # The base prompt opens with the role boundaries that keep the model an
-        # interviewer ("NEVER say I will implement"). Those must outrank the
-        # panel: a growing header or panel otherwise pushes them out entirely,
-        # which is exactly when they matter most — a late round with a stored
-        # ambiguity snapshot and the seed-closer perspective attached.
+        # The interviewer contract does not compete for this budget: it rides in
+        # the dynamic header, which is preserved first. Reserving a slice of the
+        # base agent prompt for the same rules was tried and removed — it bought
+        # one guarantee twice and took the characters from the perspective panel
+        # and, at saturated caps, from the user's own retained context.
         available_after_header = max_prompt_chars - len(dynamic_header) - _OVERHEAD
         if available_after_header <= 0:
             dynamic_header = dynamic_header[: max_prompt_chars - _OVERHEAD]
             perspective_panel = ""
             base_budget = 0
+        elif len(perspective_panel) > available_after_header:
+            perspective_panel = perspective_panel[:available_after_header]
+            base_budget = 0
         else:
-            reserved_base = min(
-                len(base_prompt),
-                self._BASE_PROMPT_ROLE_FLOOR_CHARS,
-                available_after_header,
-            )
-            panel_budget = available_after_header - reserved_base
-            if len(perspective_panel) > panel_budget:
-                perspective_panel = perspective_panel[:panel_budget]
             base_budget = available_after_header - len(perspective_panel)
 
         trimmed_base = base_prompt[:base_budget] if base_budget < len(base_prompt) else base_prompt
@@ -1486,8 +1489,8 @@ class InterviewEngine:
             # reasons, one budget and one substantive: the panel is trimmed
             # from the tail, so appending the closer would drop it in exactly
             # the rounds it exists for; and researcher/simplifier drilling is
-            # the behavior closure is meant to stop. The freed characters go
-            # back to the base prompt's role boundaries.
+            # the behavior closure is meant to stop. The characters this frees
+            # are what let the base agent prompt survive the same round.
             perspectives = [
                 InterviewPerspective.SEED_CLOSER,
                 InterviewPerspective.BREADTH_KEEPER,

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -481,6 +481,13 @@ class InterviewState(BaseModel):
         if detected_terms:
             self.merge_turn_context(InterviewTurnContext(confused_terms=detected_terms))
         self.invalidate_requirement_distillation()
+        # The ambiguity snapshot is derived from the answered rounds, exactly
+        # like the distillation above, so it dies where its inputs change
+        # rather than at each call site that remembers to clear it. Leaving it
+        # to callers let a durable save land rounds from revision N+1 next to a
+        # score from revision N: an interrupted process then resumed with a
+        # score that _select_perspectives reads as current.
+        self.clear_stored_ambiguity()
         self.mark_updated()
         return round_data
 
@@ -731,8 +738,10 @@ class InterviewEngine:
     _MAX_INITIAL_CONTEXT_SYSTEM_CHARS = 1800
     _MAX_INITIAL_CONTEXT_TOTAL_CHARS = MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS
     # Opening span of the base agent prompt that survives trimming ahead of the
-    # perspective panel: the role boundaries, context boundaries, and response
-    # format that keep the generator asking questions instead of answering them.
+    # perspective panel: the CRITICAL ROLE BOUNDARIES section, which forbids the
+    # generator from answering its own question. Deliberately small — the
+    # dynamic header already carries "Your ONLY job is to ask questions", and a
+    # larger floor starves panels that callers reserve budget for.
     _BASE_PROMPT_ROLE_FLOOR_CHARS = 500
     _INITIAL_CONTEXT_SUMMARY_QUESTION = INITIAL_CONTEXT_SUMMARY_QUESTION
     suppress_tool_use_prompt_cues: bool = False
@@ -1316,11 +1325,10 @@ class InterviewEngine:
         # prompt before falling back to hard-truncating the header.
         #
         # The base prompt opens with the role boundaries that keep the model an
-        # interviewer ("NEVER say I will implement", "always end with a
-        # question"). Those must outrank the panel: a growing header or panel
-        # otherwise pushes them out entirely, which is exactly when they matter
-        # most — a late round with a stored ambiguity snapshot and the
-        # seed-closer perspective attached.
+        # interviewer ("NEVER say I will implement"). Those must outrank the
+        # panel: a growing header or panel otherwise pushes them out entirely,
+        # which is exactly when they matter most — a late round with a stored
+        # ambiguity snapshot and the seed-closer perspective attached.
         available_after_header = max_prompt_chars - len(dynamic_header) - _OVERHEAD
         if available_after_header <= 0:
             dynamic_header = dynamic_header[: max_prompt_chars - _OVERHEAD]

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -21,6 +21,7 @@ from ouroboros.bigbang.ambiguity import (
     AMBIGUITY_THRESHOLD,
     AmbiguityScore,
     AmbiguityScorer,
+    get_completion_floor_failures,
     qualifies_for_seed_completion,
 )
 from ouroboros.bigbang.interview import (
@@ -338,14 +339,20 @@ async def _run_interview_loop(
 ) -> InterviewLoopOutcome:
     """Run the interview question loop until completion or user exit.
 
-    Implements tiered confirmation:
-    - Rounds 1-3: Auto-continue (minimum context)
-    - Rounds 4-15: Ask "Continue?" after each round
-    - Rounds 16+: Ask "Continue?" with diminishing returns warning
+    Rounds 1-2 auto-continue to gather minimum context. From
+    ``MIN_ROUNDS_BEFORE_EARLY_EXIT`` on, each round ends by measuring ambiguity
+    and asking the question that score implies:
 
-    From the first confirmation round on, ambiguity is measured before the
-    prompt so the user is asked the question the score actually implies:
-    "proceed to Seed?" once the score qualifies, "more questions?" otherwise.
+    - Qualifying score (overall threshold *and* every component floor, brownfield
+      aware): "proceed to Seed generation?". Approving ends the interview and is
+      reported in the outcome, so the caller starts generation with the same
+      score instead of asking again or sampling a second one. Declining keeps
+      the interview open.
+    - Otherwise, or with no scorer: "Continue with more questions?", where
+      declining completes the interview without approving generation.
+
+    A scoring failure clears any stored snapshot and falls back to the
+    score-blind prompt for that round rather than deciding on a stale score.
 
     Args:
         engine: Interview engine instance.
@@ -354,8 +361,8 @@ async def _run_interview_loop(
             score-blind confirmation prompt.
 
     Returns:
-        The updated state together with whether the user approved Seed
-        generation at the score-aware prompt.
+        ``InterviewLoopOutcome``: the updated state, whether the user approved
+        Seed generation at the score-aware prompt, and the score they approved.
     """
     seed_approved = False
     approved_score: AmbiguityScore | None = None
@@ -710,11 +717,33 @@ async def _generate_seed_from_interview(
             error=str(save_result.error),
         )
 
-    if not ambiguity_score.is_ready_for_seed:
-        print_warning(
-            f"Ambiguity score ({ambiguity_score.overall_score:.2f}) is too high. "
-            "Consider more interview rounds to clarify requirements."
-        )
+    # One predicate for one decision. The loop's confirmation already asks
+    # whether the interview is seed-ready using overall ambiguity *and* the
+    # per-component floors; checking only the overall score here let a score
+    # the loop had just classified as not ready walk into generation through
+    # the outer confirmation, unforced and without the warning that exists for
+    # exactly that case.
+    floor_failures = get_completion_floor_failures(
+        ambiguity_score,
+        is_brownfield=state.is_brownfield,
+    )
+    seed_ready = qualifies_for_seed_completion(
+        ambiguity_score,
+        is_brownfield=state.is_brownfield,
+    )
+
+    if not seed_ready:
+        if ambiguity_score.is_ready_for_seed and floor_failures:
+            # Naming the overall score here would read as a contradiction: it
+            # is under the threshold. The blocked dimensions are the reason.
+            print_warning(
+                f"Some requirement dimensions are still unclear: {'; '.join(floor_failures)}."
+            )
+        else:
+            print_warning(
+                f"Ambiguity score ({ambiguity_score.overall_score:.2f}) is too high. "
+                "Consider more interview rounds to clarify requirements."
+            )
         console.print()
         console.print("[bold]What would you like to do?[/]")
         console.print("  [cyan]1[/] - Continue interview with more questions")
@@ -754,7 +783,7 @@ async def _generate_seed_from_interview(
         seed_result = await generator.generate(
             state,
             ambiguity_score,
-            force=not ambiguity_score.is_ready_for_seed,
+            force=not seed_ready,
         )
 
     if seed_result.is_err:

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -5,6 +5,7 @@ Supports both LiteLLM (external API) and Claude Code (Max Plan) modes.
 """
 
 import asyncio
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum, auto
 from pathlib import Path
@@ -310,6 +311,23 @@ async def _refresh_ambiguity(
     return None if score_result.is_err else score_result.value
 
 
+@dataclass(frozen=True, slots=True)
+class InterviewLoopOutcome:
+    """How the interview loop ended, not just where it left the state.
+
+    ``seed_generation_approved`` is true only when the user answered the
+    score-aware "proceed to Seed generation?" confirmation. The outer flow
+    consumes it instead of asking the same question a second time, so one
+    affirmative answer means what it says.
+    """
+
+    state: InterviewState
+    seed_generation_approved: bool = False
+    # The score the approval was given for. Reused by seed generation so the
+    # answer cannot be undone by a second, independently sampled score.
+    approved_score: AmbiguityScore | None = None
+
+
 async def _run_interview_loop(
     engine: InterviewEngine,
     state: InterviewState,
@@ -317,7 +335,7 @@ async def _run_interview_loop(
     event_store=None,
     disabled_event_stores: set[int] | None = None,
     scorer: AmbiguityScorer | None = None,
-) -> InterviewState:
+) -> InterviewLoopOutcome:
     """Run the interview question loop until completion or user exit.
 
     Implements tiered confirmation:
@@ -336,8 +354,11 @@ async def _run_interview_loop(
             score-blind confirmation prompt.
 
     Returns:
-        Updated interview state.
+        The updated state together with whether the user approved Seed
+        generation at the score-aware prompt.
     """
+    seed_approved = False
+    approved_score: AmbiguityScore | None = None
     while not state.is_complete:
         current_round = state.current_round_number
         console.print(f"[bold]Round {current_round}[/]")
@@ -421,10 +442,12 @@ async def _run_interview_loop(
                 score,
                 is_brownfield=state.is_brownfield,
             ):
-                should_continue = not Confirm.ask(
+                seed_approved = Confirm.ask(
                     "[bold cyan]Ambiguity is low enough — proceed to Seed generation?[/]",
                     default=True,
                 )
+                approved_score = score if seed_approved else None
+                should_continue = not seed_approved
             else:
                 should_continue = Confirm.ask(
                     "Continue with more questions?",
@@ -437,7 +460,11 @@ async def _run_interview_loop(
                 await engine.save_state(state)
                 break
 
-    return state
+    return InterviewLoopOutcome(
+        state=state,
+        seed_generation_approved=seed_approved,
+        approved_score=approved_score,
+    )
 
 
 def _raise_for_aborted_interview(state: InterviewState) -> None:
@@ -520,13 +547,14 @@ async def _run_interview(
 
     try:
         loop_event_store = None if event_store is None else event_store
-        state = await _run_interview_loop(
+        outcome = await _run_interview_loop(
             engine,
             state,
             event_store=loop_event_store,
             disabled_event_stores=disabled_event_stores,
             scorer=loop_scorer,
         )
+        state = outcome.state
 
         # Outer loop for retry on high ambiguity
         while True:
@@ -547,8 +575,12 @@ async def _run_interview(
 
             console.print()
 
-            # Ask if user wants to proceed to Seed generation
-            should_generate_seed = Confirm.ask(
+            # Ask if user wants to proceed to Seed generation — unless the
+            # loop already asked it. Approving the score-aware prompt and then
+            # being asked the same thing again would make that answer mean
+            # nothing, and a decline at the second prompt would contradict the
+            # action the first one named.
+            should_generate_seed = outcome.seed_generation_approved or Confirm.ask(
                 "[bold cyan]Proceed to generate Seed specification?[/]",
                 default=True,
             )
@@ -562,7 +594,11 @@ async def _run_interview(
 
             # Generate Seed
             seed_path, result = await _generate_seed_from_interview(
-                state, llm_adapter, llm_backend, engine=engine
+                state,
+                llm_adapter,
+                llm_backend,
+                engine=engine,
+                approved_score=outcome.approved_score,
             )
 
             if result == SeedGenerationResult.CONTINUE_INTERVIEW:
@@ -578,13 +614,14 @@ async def _run_interview(
                     if event_store is None or id(event_store) in disabled_event_stores
                     else event_store
                 )
-                state = await _run_interview_loop(
+                outcome = await _run_interview_loop(
                     engine,
                     state,
                     event_store=loop_event_store,
                     disabled_event_stores=disabled_event_stores,
                     scorer=loop_scorer,
                 )
+                state = outcome.state
                 continue
 
             if result == SeedGenerationResult.CANCELLED:
@@ -621,6 +658,7 @@ async def _generate_seed_from_interview(
     llm_backend: str | None = None,
     *,
     engine: InterviewEngine,
+    approved_score: AmbiguityScore | None = None,
 ) -> tuple[Path | None, SeedGenerationResult]:
     """Generate Seed from completed interview.
 
@@ -628,6 +666,10 @@ async def _generate_seed_from_interview(
         state: Completed interview state.
         llm_adapter: LLM adapter for scoring and generation.
         engine: Interview engine that owns durable state persistence.
+        approved_score: The score the user already approved for generation, for
+            the same answers. Reused instead of sampling a second score, which
+            could disagree and drop the user into the "too ambiguous" menu right
+            after they approved generation.
 
     Returns:
         Tuple of (path to generated seed file or None, result status).
@@ -636,18 +678,21 @@ async def _generate_seed_from_interview(
     console.print("[bold cyan]Generating Seed specification...[/]")
 
     # Step 1: Calculate ambiguity score
-    with console.status("[cyan]Calculating ambiguity score...[/]", spinner="dots"):
-        scorer = AmbiguityScorer(
-            llm_adapter=llm_adapter,
-            model=get_clarification_model(llm_backend),
-        )
-        score_result = await scorer.score(state)
+    if approved_score is not None:
+        ambiguity_score = approved_score
+    else:
+        with console.status("[cyan]Calculating ambiguity score...[/]", spinner="dots"):
+            scorer = AmbiguityScorer(
+                llm_adapter=llm_adapter,
+                model=get_clarification_model(llm_backend),
+            )
+            score_result = await scorer.score(state)
 
-    if score_result.is_err:
-        print_error(f"Failed to calculate ambiguity: {score_result.error.message}")
-        return None, SeedGenerationResult.CANCELLED
+        if score_result.is_err:
+            print_error(f"Failed to calculate ambiguity: {score_result.error.message}")
+            return None, SeedGenerationResult.CANCELLED
 
-    ambiguity_score = score_result.value
+        ambiguity_score = score_result.value
     console.print(f"[muted]Ambiguity score: {ambiguity_score.overall_score:.2f}[/]")
 
     # Persist the evaluation like the MCP path does (#1901): without this the

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -16,7 +16,12 @@ import structlog
 import typer
 import yaml
 
-from ouroboros.bigbang.ambiguity import AmbiguityScorer
+from ouroboros.bigbang.ambiguity import (
+    AMBIGUITY_THRESHOLD,
+    AmbiguityScore,
+    AmbiguityScorer,
+    qualifies_for_seed_completion,
+)
 from ouroboros.bigbang.interview import (
     MIN_ROUNDS_BEFORE_EARLY_EXIT,
     InterviewEngine,
@@ -58,6 +63,11 @@ from ouroboros.providers import create_llm_adapter, resolve_llm_backend
 from ouroboros.providers.base import LLMAdapter
 
 log = structlog.get_logger(__name__)
+
+# Retry budget for the per-round scorer that runs between two interactive
+# prompts. The scorer's own default is unlimited retries, which would hang the
+# interview loop instead of falling back to the score-blind prompt.
+_LOOP_AMBIGUITY_MAX_RETRIES = 3
 
 
 class SeedGenerationResult(Enum):
@@ -257,12 +267,56 @@ async def _get_init_event_store():
     return event_store
 
 
+async def _refresh_ambiguity(
+    engine: InterviewEngine,
+    state: InterviewState,
+    scorer: AmbiguityScorer | None,
+) -> AmbiguityScore | None:
+    """Score the in-progress interview and persist the snapshot on state.
+
+    The stored snapshot is what turns on the seed-closer perspective and the
+    ambiguity block in the question prompt, so a failed score must clear it
+    rather than leave a stale one behind (the same contract the MCP live
+    scoring path follows).
+    """
+    if scorer is None:
+        return None
+
+    with console.status("[cyan]Measuring ambiguity...[/]", spinner="dots"):
+        score_result = await scorer.score(state)
+
+    if score_result.is_err:
+        state.clear_stored_ambiguity()
+        log.warning(
+            "cli.init.live_ambiguity_failed",
+            interview_id=state.interview_id,
+            error=str(score_result.error),
+        )
+    else:
+        score = score_result.value
+        state.store_ambiguity(
+            score=score.overall_score,
+            breakdown=score.breakdown.model_dump(mode="json"),
+        )
+
+    save_result = await engine.save_state(state)
+    if save_result.is_err:
+        log.warning(
+            "cli.init.persist_live_ambiguity_failed",
+            interview_id=state.interview_id,
+            error=str(save_result.error),
+        )
+
+    return None if score_result.is_err else score_result.value
+
+
 async def _run_interview_loop(
     engine: InterviewEngine,
     state: InterviewState,
     *,
     event_store=None,
     disabled_event_stores: set[int] | None = None,
+    scorer: AmbiguityScorer | None = None,
 ) -> InterviewState:
     """Run the interview question loop until completion or user exit.
 
@@ -271,9 +325,15 @@ async def _run_interview_loop(
     - Rounds 4-15: Ask "Continue?" after each round
     - Rounds 16+: Ask "Continue?" with diminishing returns warning
 
+    From the first confirmation round on, ambiguity is measured before the
+    prompt so the user is asked the question the score actually implies:
+    "proceed to Seed?" once the score qualifies, "more questions?" otherwise.
+
     Args:
         engine: Interview engine instance.
         state: Current interview state.
+        scorer: Optional ambiguity scorer. When omitted, the loop keeps the
+            score-blind confirmation prompt.
 
     Returns:
         Updated interview state.
@@ -351,10 +411,25 @@ async def _run_interview_loop(
 
         # Tiered confirmation logic
         if current_round >= MIN_ROUNDS_BEFORE_EARLY_EXIT:
-            should_continue = Confirm.ask(
-                "Continue with more questions?",
-                default=True,
-            )
+            score = await _refresh_ambiguity(engine, state, scorer)
+            if score is not None:
+                console.print(
+                    f"[muted]Ambiguity score: {score.overall_score:.2f} "
+                    f"(Seed threshold: <= {AMBIGUITY_THRESHOLD})[/]"
+                )
+            if score is not None and qualifies_for_seed_completion(
+                score,
+                is_brownfield=state.is_brownfield,
+            ):
+                should_continue = not Confirm.ask(
+                    "[bold cyan]Ambiguity is low enough — proceed to Seed generation?[/]",
+                    default=True,
+                )
+            else:
+                should_continue = Confirm.ask(
+                    "Continue with more questions?",
+                    default=True,
+                )
             if not should_continue:
                 complete_result = await engine.complete_interview(state)
                 if complete_result.is_ok:
@@ -408,6 +483,13 @@ async def _run_interview(
         state_dir=state_dir or Path.home() / ".ouroboros" / "data",
         model=get_clarification_model(llm_backend),
     )
+    # Bounded retries: the loop scorer runs between two interactive prompts,
+    # so an unresolvable scoring failure must surface, not retry forever.
+    loop_scorer = AmbiguityScorer(
+        llm_adapter=llm_adapter,
+        model=get_clarification_model(llm_backend),
+        max_retries=_LOOP_AMBIGUITY_MAX_RETRIES,
+    )
 
     # Load or start interview
     if resume_id:
@@ -443,6 +525,7 @@ async def _run_interview(
             state,
             event_store=loop_event_store,
             disabled_event_stores=disabled_event_stores,
+            scorer=loop_scorer,
         )
 
         # Outer loop for retry on high ambiguity
@@ -500,6 +583,7 @@ async def _run_interview(
                     state,
                     event_store=loop_event_store,
                     disabled_event_stores=disabled_event_stores,
+                    scorer=loop_scorer,
                 )
                 continue
 

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -66,9 +66,10 @@ from ouroboros.providers.base import LLMAdapter
 
 log = structlog.get_logger(__name__)
 
-# Retry budget for the per-round scorer that runs between two interactive
-# prompts. The scorer's own default is unlimited retries, which would hang the
-# interview loop instead of falling back to the score-blind prompt.
+# Retry budget for the per-round scorer, which runs between two interactive
+# prompts. ``AmbiguityScorer`` defaults to 10 attempts with doubling token
+# budgets; a person waiting at a prompt should see the score-blind fallback
+# well before that. Matches the MCP live-scoring budget.
 _LOOP_AMBIGUITY_MAX_RETRIES = 3
 
 

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -1244,6 +1244,59 @@ class TestInterviewEngineSystemPrompt:
 
         assert "### seed-closer" in prompt
 
+    def test_closure_round_keeps_role_boundaries_alongside_seed_closer(self) -> None:
+        """A closure round must not trade the interviewer role for the closer.
+
+        Storing a snapshot grows the header and attaches another perspective,
+        both of which are preserved ahead of the base agent prompt. Without a
+        reserved floor that pushed out the boundaries that forbid the model
+        from answering its own question — in exactly the rounds where the model
+        is most tempted to start implementing.
+        """
+        mock_adapter = MagicMock()
+        engine = InterviewEngine(llm_adapter=mock_adapter)
+
+        breakdown = {
+            "goal_clarity": {
+                "name": "Goal Clarity",
+                "clarity_score": 0.90,
+                "weight": 0.4,
+                "justification": "Goal is clear.",
+            },
+            "constraint_clarity": {
+                "name": "Constraint Clarity",
+                "clarity_score": 0.85,
+                "weight": 0.3,
+                "justification": "Constraints are clear.",
+            },
+            "success_criteria_clarity": {
+                "name": "Success Criteria Clarity",
+                "clarity_score": 0.80,
+                "weight": 0.3,
+                "justification": "Criteria are measurable.",
+            },
+        }
+        state = InterviewState(
+            interview_id="test_001",
+            initial_context="Add deadlines to the kanban widget",
+            ambiguity_score=0.18,
+            ambiguity_breakdown=breakdown,
+        )
+        for round_number in range(1, 7):
+            state.rounds.append(
+                InterviewRound(
+                    round_number=round_number,
+                    question=f"Q{round_number}?",
+                    user_response=f"A{round_number}",
+                )
+            )
+
+        prompt = engine._build_system_prompt(state)
+
+        assert "### seed-closer" in prompt
+        assert 'NEVER say "I will implement X"' in prompt
+        assert "NEVER promise to build demos" in prompt
+
     def test_system_prompt_omits_seed_closer_when_closure_mode_is_inactive(self) -> None:
         """High ambiguity should keep the closure perspective disabled."""
         mock_adapter = MagicMock()

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -13,6 +13,7 @@ from ouroboros.bigbang.interview import (
     AGENT_SDK_CLI_SAFE_PROMPT_CHARS,
     INITIAL_CONTEXT_SUMMARY_QUESTION,
     MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS,
+    RESPONSE_CONTRACT,
     InterviewEngine,
     InterviewRound,
     InterviewState,
@@ -1276,14 +1277,93 @@ class TestInterviewEngineSystemPrompt:
         assert resumed.value.ambiguity_breakdown is None
         assert len(resumed.value.rounds) == 2
 
+    @pytest.mark.parametrize("max_chars", [None, 3500, 1200, 700])
+    @pytest.mark.parametrize("stored_score", [None, 0.18])
+    def test_response_contract_survives_every_prompt_budget(
+        self,
+        max_chars: int | None,
+        stored_score: float | None,
+    ) -> None:
+        """The two rules that make a turn a question survive any budget.
+
+        Their previous home was the tail of the loaded agent prompt, so whether
+        the model was told to end with a question depended on how large the
+        header and perspective panel happened to grow that round. Reserving a
+        slice of that prompt only moved the shortage onto the panel and, at
+        saturated caps, onto the user's own retained context. The contract now
+        rides in the dynamic header, which every build preserves first.
+        """
+        engine = InterviewEngine(llm_adapter=MagicMock())
+        state = InterviewState(
+            interview_id="test_contract",
+            initial_context="Add deadlines to the kanban widget",
+        )
+        for round_number in range(1, 7):
+            state.rounds.append(
+                InterviewRound(
+                    round_number=round_number,
+                    question=f"Q{round_number}?",
+                    user_response=f"A{round_number}",
+                )
+            )
+        if stored_score is not None:
+            state.store_ambiguity(
+                score=stored_score,
+                breakdown={
+                    "goal_clarity": {
+                        "name": "Goal Clarity",
+                        "clarity_score": 0.9,
+                        "weight": 0.4,
+                        "justification": "clear",
+                    },
+                    "constraint_clarity": {
+                        "name": "Constraint Clarity",
+                        "clarity_score": 0.85,
+                        "weight": 0.3,
+                        "justification": "clear",
+                    },
+                    "success_criteria_clarity": {
+                        "name": "Success Criteria Clarity",
+                        "clarity_score": 0.8,
+                        "weight": 0.3,
+                        "justification": "clear",
+                    },
+                },
+            )
+
+        prompt = engine._build_system_prompt(state, max_chars=max_chars)
+
+        assert RESPONSE_CONTRACT in prompt
+        if max_chars is not None:
+            assert len(prompt) <= max_chars
+
+    def test_response_contract_survives_a_saturating_initial_context(self) -> None:
+        """A context long enough to be capped must not evict the contract."""
+        engine = InterviewEngine(llm_adapter=MagicMock())
+        state = InterviewState(
+            interview_id="test_contract_ctx",
+            initial_context="C" * 4_000,
+        )
+
+        prompt = engine._build_system_prompt(
+            state,
+            initial_context="C" * 4_000,
+            max_chars=engine._MIN_SYSTEM_PROMPT_CHARS,
+        )
+
+        assert RESPONSE_CONTRACT in prompt
+        assert len(prompt) <= engine._MIN_SYSTEM_PROMPT_CHARS
+
     def test_closure_round_keeps_role_boundaries_alongside_seed_closer(self) -> None:
         """A closure round must not trade the interviewer role for the closer.
 
         Storing a snapshot grows the header and attaches another perspective,
-        both of which are preserved ahead of the base agent prompt. Without a
-        reserved floor that pushed out the boundaries that forbid the model
-        from answering its own question — in exactly the rounds where the model
-        is most tempted to start implementing.
+        both of which are preserved ahead of the base agent prompt, and that
+        pushed out the boundaries forbidding the model from answering its own
+        question — in exactly the rounds where it is most tempted to start
+        implementing. The always-present contract is pinned separately by
+        ``test_response_contract_survives_every_prompt_budget``; this pins the
+        fuller agent-prompt wording at the default cap.
         """
         mock_adapter = MagicMock()
         engine = InterviewEngine(llm_adapter=mock_adapter)

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -1244,6 +1244,38 @@ class TestInterviewEngineSystemPrompt:
 
         assert "### seed-closer" in prompt
 
+    @pytest.mark.asyncio
+    async def test_resume_after_recording_an_answer_loads_no_stale_score(
+        self, tmp_path: Path
+    ) -> None:
+        """The durable file must never pair new rounds with an old score.
+
+        The window this closes: an answer is accepted and saved, then the
+        process dies before the rescore lands. Resuming must not read the
+        previous revision's score as current, because
+        ``_select_perspectives`` would treat it as closure evidence for an
+        interview whose inputs have since changed.
+        """
+        engine = InterviewEngine(llm_adapter=MagicMock(), state_dir=tmp_path)
+        state = InterviewState(
+            interview_id="interview_resume",
+            initial_context="Add deadlines to the kanban widget",
+        )
+        state.record_answer("Q1", "A1")
+        state.store_ambiguity(score=0.18, breakdown={"from": "revision N"})
+
+        record_result = await engine.record_response(state, "A2", "Q2")
+        assert record_result.is_ok
+        # Only the answer's save happens — the rescore never runs.
+        save_result = await engine.save_state(record_result.value)
+        assert save_result.is_ok
+
+        resumed = await engine.load_state("interview_resume")
+        assert resumed.is_ok
+        assert resumed.value.ambiguity_score is None
+        assert resumed.value.ambiguity_breakdown is None
+        assert len(resumed.value.rounds) == 2
+
     def test_closure_round_keeps_role_boundaries_alongside_seed_closer(self) -> None:
         """A closure round must not trade the interviewer role for the closer.
 

--- a/tests/unit/cli/test_init_ambiguity_gate.py
+++ b/tests/unit/cli/test_init_ambiguity_gate.py
@@ -1,0 +1,189 @@
+"""The CLI interview loop must ask the question its ambiguity score implies.
+
+Before this gate existed the loop asked "Continue with more questions?" every
+round without ever measuring ambiguity, so a seed-ready interview looked
+identical to an unclear one and the stored snapshot that activates the
+seed-closer perspective was never written.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.bigbang.ambiguity import AmbiguityScore, ComponentScore, ScoreBreakdown
+from ouroboros.bigbang.interview import InterviewRound, InterviewState, InterviewStatus
+from ouroboros.cli.commands.init import _run_interview_loop
+from ouroboros.core.errors import ProviderError
+from ouroboros.core.types import Result
+
+_SEED_PROMPT = "[bold cyan]Ambiguity is low enough — proceed to Seed generation?[/]"
+_MORE_QUESTIONS_PROMPT = "Continue with more questions?"
+
+
+def _score(overall: float, *, clarity: float = 0.9) -> AmbiguityScore:
+    def component(name: str) -> ComponentScore:
+        return ComponentScore(
+            name=name,
+            clarity_score=clarity,
+            weight=1 / 3,
+            justification="test",
+        )
+
+    return AmbiguityScore(
+        overall_score=overall,
+        breakdown=ScoreBreakdown(
+            goal_clarity=component("goal_clarity"),
+            constraint_clarity=component("constraint_clarity"),
+            success_criteria_clarity=component("success_criteria_clarity"),
+        ),
+    )
+
+
+class FakeScorer:
+    def __init__(self, result) -> None:
+        self._result = result
+        self.calls = 0
+
+    async def score(self, state: InterviewState):
+        self.calls += 1
+        return self._result
+
+
+class FakeEngine:
+    """Engine stub that keeps the interview in progress until completed."""
+
+    def __init__(self) -> None:
+        self.completed = False
+
+    async def ask_next_question(self, state: InterviewState):
+        return Result.ok("What should it do?")
+
+    async def record_response(
+        self,
+        state: InterviewState,
+        user_response: str,
+        question: str,
+    ):
+        state.rounds.append(
+            InterviewRound(
+                round_number=state.current_round_number,
+                question=question,
+                user_response=user_response,
+            )
+        )
+        return Result.ok(state)
+
+    async def save_state(self, state: InterviewState):
+        return Result.ok(None)
+
+    async def complete_interview(self, state: InterviewState):
+        self.completed = True
+        state.status = InterviewStatus.COMPLETED
+        return Result.ok(state)
+
+
+def _state_at_confirmation_round() -> InterviewState:
+    """State with enough answered rounds that the loop reaches the prompt."""
+    state = InterviewState(interview_id="interview_gate")
+    for round_number in range(1, 3):
+        state.rounds.append(
+            InterviewRound(
+                round_number=round_number,
+                question=f"Q{round_number}",
+                user_response=f"A{round_number}",
+            )
+        )
+    return state
+
+
+@pytest.fixture
+def prompts(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record every confirmation prompt, answering the one that ends the loop."""
+    asked: list[str] = []
+
+    def fake_confirm(prompt: str, **_kwargs) -> bool:
+        asked.append(prompt)
+        # "proceed to Seed?" -> yes; "more questions?" -> no. Either answer
+        # completes the interview, so the loop terminates in one round.
+        return prompt == _SEED_PROMPT
+
+    async def fake_prompt(_prompt: str) -> str:
+        return "Deadlines are an optional card attribute."
+
+    monkeypatch.setattr("ouroboros.cli.commands.init.Confirm.ask", fake_confirm)
+    monkeypatch.setattr("ouroboros.cli.commands.init.multiline_prompt_async", fake_prompt)
+    return asked
+
+
+@pytest.mark.asyncio
+async def test_seed_ready_score_offers_seed_instead_of_more_questions(
+    prompts: list[str],
+) -> None:
+    state = _state_at_confirmation_round()
+    engine = FakeEngine()
+    scorer = FakeScorer(Result.ok(_score(0.15)))
+
+    final_state = await _run_interview_loop(engine, state, scorer=scorer)
+
+    assert scorer.calls == 1
+    assert prompts == [_SEED_PROMPT]
+    assert engine.completed
+    assert final_state.is_complete
+    assert final_state.ambiguity_score == 0.15
+
+
+@pytest.mark.asyncio
+async def test_high_score_keeps_the_more_questions_prompt_and_stores_snapshot(
+    prompts: list[str],
+) -> None:
+    state = _state_at_confirmation_round()
+    engine = FakeEngine()
+    scorer = FakeScorer(Result.ok(_score(0.45, clarity=0.5)))
+
+    await _run_interview_loop(engine, state, scorer=scorer)
+
+    assert scorer.calls == 1
+    assert prompts == [_MORE_QUESTIONS_PROMPT]
+    # The stored snapshot is what activates the seed-closer perspective and the
+    # ambiguity block in the next round's question prompt.
+    assert state.ambiguity_score == 0.45
+
+
+@pytest.mark.asyncio
+async def test_component_floor_failure_does_not_offer_seed(prompts: list[str]) -> None:
+    """A low overall score with a weak component is not seed-ready."""
+    state = _state_at_confirmation_round()
+    engine = FakeEngine()
+    scorer = FakeScorer(Result.ok(_score(0.15, clarity=0.5)))
+
+    await _run_interview_loop(engine, state, scorer=scorer)
+
+    assert prompts == [_MORE_QUESTIONS_PROMPT]
+
+
+@pytest.mark.asyncio
+async def test_scoring_failure_clears_snapshot_and_falls_back(prompts: list[str]) -> None:
+    state = _state_at_confirmation_round()
+    state.store_ambiguity(score=0.1, breakdown={"stale": True})
+    engine = FakeEngine()
+    scorer = FakeScorer(Result.err(ProviderError("scorer unavailable")))
+
+    await _run_interview_loop(engine, state, scorer=scorer)
+
+    assert scorer.calls == 1
+    assert prompts == [_MORE_QUESTIONS_PROMPT]
+    # A stale snapshot must not survive a failed rescore.
+    assert state.ambiguity_score is None
+    assert state.ambiguity_breakdown is None
+
+
+@pytest.mark.asyncio
+async def test_no_scorer_keeps_legacy_prompt(prompts: list[str]) -> None:
+    """Callers without a scorer (existing tests, embedders) are unaffected."""
+    state = _state_at_confirmation_round()
+    engine = FakeEngine()
+
+    await _run_interview_loop(engine, state)
+
+    assert prompts == [_MORE_QUESTIONS_PROMPT]
+    assert state.ambiguity_score is None

--- a/tests/unit/cli/test_init_ambiguity_gate.py
+++ b/tests/unit/cli/test_init_ambiguity_gate.py
@@ -12,7 +12,7 @@ import pytest
 
 from ouroboros.bigbang.ambiguity import AmbiguityScore, ComponentScore, ScoreBreakdown
 from ouroboros.bigbang.interview import InterviewRound, InterviewState, InterviewStatus
-from ouroboros.cli.commands.init import _run_interview_loop
+from ouroboros.cli.commands.init import SeedGenerationResult, _run_interview_loop
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.types import Result
 
@@ -123,7 +123,7 @@ async def test_seed_ready_score_offers_seed_instead_of_more_questions(
     engine = FakeEngine()
     scorer = FakeScorer(Result.ok(_score(0.15)))
 
-    final_state = await _run_interview_loop(engine, state, scorer=scorer)
+    final_state = (await _run_interview_loop(engine, state, scorer=scorer)).state
 
     assert scorer.calls == 1
     assert prompts == [_SEED_PROMPT]
@@ -173,6 +173,114 @@ async def test_scoring_failure_clears_snapshot_and_falls_back(prompts: list[str]
     assert scorer.calls == 1
     assert prompts == [_MORE_QUESTIONS_PROMPT]
     # A stale snapshot must not survive a failed rescore.
+    assert state.ambiguity_score is None
+    assert state.ambiguity_breakdown is None
+
+
+@pytest.mark.asyncio
+async def test_seed_approval_crosses_the_loop_boundary(prompts: list[str]) -> None:
+    """Approving at the score-aware prompt must not be asked again outside.
+
+    The loop returns the decision, not only the completed state, so the outer
+    flow can start generation instead of re-asking "proceed to generate Seed
+    specification?" — a second prompt would let the user decline the action
+    they just approved.
+    """
+    state = _state_at_confirmation_round()
+    scorer = FakeScorer(Result.ok(_score(0.15)))
+
+    outcome = await _run_interview_loop(FakeEngine(), state, scorer=scorer)
+
+    assert outcome.seed_generation_approved
+    assert outcome.state.is_complete
+    # Carried so generation reuses it instead of sampling a second score that
+    # could disagree and drop the user into the "too ambiguous" menu.
+    assert outcome.approved_score is not None
+    assert outcome.approved_score.overall_score == 0.15
+
+
+@pytest.mark.asyncio
+async def test_stopping_questions_without_a_qualifying_score_is_not_seed_approval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Answering "no" to more questions ends the interview but approves nothing."""
+
+    def fake_confirm(prompt: str, **_kwargs) -> bool:
+        return False
+
+    async def fake_prompt(_prompt: str) -> str:
+        return "Deadlines are an optional card attribute."
+
+    monkeypatch.setattr("ouroboros.cli.commands.init.Confirm.ask", fake_confirm)
+    monkeypatch.setattr("ouroboros.cli.commands.init.multiline_prompt_async", fake_prompt)
+
+    state = _state_at_confirmation_round()
+    scorer = FakeScorer(Result.ok(_score(0.45, clarity=0.5)))
+
+    outcome = await _run_interview_loop(FakeEngine(), state, scorer=scorer)
+
+    assert outcome.state.is_complete
+    assert not outcome.seed_generation_approved
+
+
+@pytest.mark.asyncio
+async def test_approved_score_starts_generation_without_a_second_score(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """One affirmative answer must actually start generation.
+
+    Without carrying the approved score, generation samples an independent
+    second score; a disagreeing sample drops the user into the "too ambiguous"
+    menu immediately after they approved generation.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from ouroboros.cli.commands import init as init_module
+
+    scorer_constructed = False
+
+    def _scorer_factory(*_args, **_kwargs):
+        nonlocal scorer_constructed
+        scorer_constructed = True
+        raise AssertionError("generation must not sample a second score")
+
+    generator = MagicMock()
+    generator.generate = AsyncMock(return_value=Result.err(ProviderError("stop here")))
+    monkeypatch.setattr(init_module, "AmbiguityScorer", _scorer_factory)
+    monkeypatch.setattr(init_module, "SeedGenerator", lambda *_args, **_kwargs: generator)
+
+    engine = MagicMock()
+    engine.save_state = AsyncMock(return_value=Result.ok(tmp_path / "state.json"))
+    state = _state_at_confirmation_round()
+
+    seed_path, result = await init_module._generate_seed_from_interview(
+        state,
+        MagicMock(),
+        engine=engine,
+        approved_score=_score(0.15),
+    )
+
+    assert not scorer_constructed
+    assert seed_path is None
+    # Generation was reached (and failed on the stubbed generator), which is the
+    # point: approval was not re-litigated by a second score.
+    assert result == SeedGenerationResult.CANCELLED
+    generator.generate.assert_awaited_once()
+
+
+def test_recording_an_answer_invalidates_the_previous_snapshot() -> None:
+    """A durable save must never pair round N+1 with the score from round N.
+
+    ``record_answer`` clears the snapshot where the inputs change, so an
+    interruption between the answer's save and the rescore resumes with no
+    score rather than a stale one that could activate the seed-closer.
+    """
+    state = _state_at_confirmation_round()
+    state.store_ambiguity(score=0.18, breakdown={"from": "revision N"})
+
+    state.record_answer("Q3", "A3")
+
     assert state.ambiguity_score is None
     assert state.ambiguity_breakdown is None
 

--- a/tests/unit/cli/test_init_ambiguity_gate.py
+++ b/tests/unit/cli/test_init_ambiguity_gate.py
@@ -269,6 +269,85 @@ async def test_approved_score_starts_generation_without_a_second_score(
     generator.generate.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("choice", "expected"),
+    [("3", SeedGenerationResult.CANCELLED), ("1", SeedGenerationResult.CONTINUE_INTERVIEW)],
+)
+async def test_failed_component_floor_blocks_generation_despite_low_overall(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    choice: str,
+    expected: SeedGenerationResult,
+) -> None:
+    """A score the loop rejected must not walk into generation unforced.
+
+    Overall 0.15 is under the threshold while every component floor fails. The
+    loop asks "Continue with more questions?" for exactly this score, so the
+    generation boundary must reach the same verdict instead of generating
+    silently on the overall number alone.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from ouroboros.cli.commands import init as init_module
+
+    generator = MagicMock()
+    generator.generate = AsyncMock(side_effect=AssertionError("must not generate unforced"))
+    monkeypatch.setattr(init_module, "SeedGenerator", lambda *_args, **_kwargs: generator)
+    monkeypatch.setattr(init_module.Prompt, "ask", lambda *_args, **_kwargs: choice)
+
+    warnings: list[str] = []
+    monkeypatch.setattr(init_module, "print_warning", warnings.append)
+
+    engine = MagicMock()
+    engine.save_state = AsyncMock(return_value=Result.ok(tmp_path / "state.json"))
+    state = _state_at_confirmation_round()
+
+    seed_path, result = await init_module._generate_seed_from_interview(
+        state,
+        MagicMock(),
+        engine=engine,
+        approved_score=_score(0.15, clarity=0.5),
+    )
+
+    assert seed_path is None
+    assert result == expected
+    generator.generate.assert_not_awaited()
+    # The overall score is under the threshold, so naming it would read as a
+    # contradiction. The blocked dimensions are the reason.
+    assert warnings and "dimensions are still unclear" in warnings[0]
+    assert "Goal Clarity" in warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_failed_component_floor_forces_generation_when_user_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Choosing "generate anyway" must actually force past the same gate."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from ouroboros.cli.commands import init as init_module
+
+    generator = MagicMock()
+    generator.generate = AsyncMock(return_value=Result.err(ProviderError("stop here")))
+    monkeypatch.setattr(init_module, "SeedGenerator", lambda *_args, **_kwargs: generator)
+    monkeypatch.setattr(init_module.Prompt, "ask", lambda *_args, **_kwargs: "2")
+    monkeypatch.setattr(init_module, "print_warning", lambda *_args, **_kwargs: None)
+
+    engine = MagicMock()
+    engine.save_state = AsyncMock(return_value=Result.ok(tmp_path / "state.json"))
+
+    await init_module._generate_seed_from_interview(
+        _state_at_confirmation_round(),
+        MagicMock(),
+        engine=engine,
+        approved_score=_score(0.15, clarity=0.5),
+    )
+
+    assert generator.generate.await_args.kwargs["force"] is True
+
+
 def test_recording_an_answer_invalidates_the_previous_snapshot() -> None:
     """A durable save must never pair round N+1 with the score from round N.
 

--- a/tests/unit/cli/test_init_hitl.py
+++ b/tests/unit/cli/test_init_hitl.py
@@ -147,7 +147,7 @@ async def test_question_generation_failure_declined_retry_persists_aborted_state
     state = InterviewState(interview_id="interview_question_failure")
     engine = FakeEngine()
 
-    final_state = await _run_interview_loop(engine, state)
+    final_state = (await _run_interview_loop(engine, state)).state
 
     assert final_state.status == InterviewStatus.ABORTED
     assert final_state.rounds == []
@@ -229,7 +229,7 @@ async def test_empty_interview_response_retries_same_hitl_request_without_cancel
     store = FakeEventStore()
     engine = FakeEngine()
 
-    final_state = await _run_interview_loop(engine, state, event_store=store)
+    final_state = (await _run_interview_loop(engine, state, event_store=store)).state
 
     events = [event for batch in store.batches for event in batch]
     assert [event.type for event in events] == [
@@ -286,7 +286,7 @@ async def test_rejected_interview_response_retries_without_answered_event(
     store = FakeEventStore()
     engine = FakeEngine()
 
-    final_state = await _run_interview_loop(engine, state, event_store=store)
+    final_state = (await _run_interview_loop(engine, state, event_store=store)).state
 
     events = [event for batch in store.batches for event in batch]
     assert [event.type for event in events] == [
@@ -382,7 +382,7 @@ async def test_interview_loop_records_and_saves_answer_when_hitl_append_fails(
     store = StoreFailsAfterSave()
     engine = FakeEngine()
 
-    final_state = await _run_interview_loop(engine, state, event_store=store)
+    final_state = (await _run_interview_loop(engine, state, event_store=store)).state
 
     assert store.calls == 1
     assert order == ["save", "append"]

--- a/tests/unit/cli/test_init_runtime.py
+++ b/tests/unit/cli/test_init_runtime.py
@@ -10,6 +10,7 @@ from typer.testing import CliRunner
 from ouroboros.bigbang.ambiguity import AmbiguityScore, ComponentScore, ScoreBreakdown
 from ouroboros.bigbang.interview import InterviewState, InterviewStatus
 from ouroboros.cli.commands.init import (
+    InterviewLoopOutcome,
     SeedGenerationResult,
     _generate_seed_from_interview,
     _get_adapter,
@@ -69,7 +70,7 @@ class TestInitWorkflowRuntimeHandoff:
             patch("ouroboros.cli.commands.init.InterviewEngine", return_value=engine),
             patch(
                 "ouroboros.cli.commands.init._run_interview_loop",
-                new=AsyncMock(return_value=aborted_state),
+                new=AsyncMock(return_value=InterviewLoopOutcome(state=aborted_state)),
             ),
             patch(
                 "ouroboros.cli.commands.init._get_init_event_store",
@@ -111,7 +112,12 @@ class TestInitWorkflowRuntimeHandoff:
         engine = MagicMock()
         engine.start_interview = AsyncMock(return_value=Result.ok(initial_state))
         engine.save_state = AsyncMock(return_value=Result.ok(tmp_path / "state.json"))
-        run_loop = AsyncMock(side_effect=[completed_state, aborted_state])
+        run_loop = AsyncMock(
+            side_effect=[
+                InterviewLoopOutcome(state=completed_state),
+                InterviewLoopOutcome(state=aborted_state),
+            ]
+        )
         generate_seed = AsyncMock(
             side_effect=[
                 (None, SeedGenerationResult.CONTINUE_INTERVIEW),


### PR DESCRIPTION
Closes #2175.

## Summary

The `init start` interview loop asked "Continue with more questions?" every round without ever measuring ambiguity — the first score was computed after the loop exited, inside `_generate_seed_from_interview`. The prompt therefore carried no information about the 0.2 threshold, and because no score was ever stored, `_select_perspectives` could never attach the seed-closer perspective (it requires `ambiguity_score is not None and <= 0.25`). The panel rule that shipped instead was "only ask a closure question when closure mode is active; otherwise keep drilling", so the model was actively instructed not to offer Seed generation.

This scores once per confirmation round and asks the question the score implies.

- `_refresh_ambiguity()` scores the in-progress interview, persists the snapshot with `state.store_ambiguity()`, and clears it on failure so a stale score cannot drive closure — the contract the MCP live-scoring path follows. Retries are bounded at 3 because the scorer's own default is unlimited and it runs between two interactive prompts.
- The confirmation branches on `qualifies_for_seed_completion()` (overall 0.2 plus every component floor, brownfield-aware): "Ambiguity is low enough — proceed to Seed generation?" when it qualifies, the existing prompt otherwise. The score is printed either way.
- `scorer` is an optional keyword argument, so callers that pass none keep the previous behavior.

Storing the score is what re-enables the closure path: the seed-closer perspective now attaches at <= 0.25, and the panel sits ahead of the base agent prompt in the trimming order, so the closure instruction survives the system-prompt budget.

The MCP interview path already did all of this (`authoring_handlers.py` rescores each round and routes on `qualifies_for_seed_completion`). This closes the gap between the two entry points over the same `InterviewEngine`.

## Second commit: the snapshot was pushing the interviewer role out of the prompt

Verified after the first commit by dumping the built system prompt: storing a snapshot grows the dynamic header and attaches the seed-closer perspective, and both are preserved ahead of the base agent prompt. At a stored score of 0.18 the prompt silently lost `NEVER say "I will implement X"`, `NEVER promise to build demos`, and `You MUST always end with a question` — in exactly the rounds where the model is most tempted to answer its own question. The first commit alone would have made that failure mode more likely, not less.

Closure rounds now run a narrower panel (seed-closer first, then breadth-keeper and architect), since the panel is trimmed from the tail and appending the closer dropped it in the rounds it exists for.

A reserved slice of the base agent prompt was tried here and **removed in a later commit**: raising it far enough to also cover `You MUST always end with a question` starved the panel and, at saturated caps, the user's own retained initial context. The final shape instead puts the two rules that make a turn a question — emit exactly one question and end with it; never announce implementation work — in the dynamic header, which every build preserves first. That is one mechanism rather than two, and it holds at every budget (verified at the default cap, 3500, 1200, 700, and with a 4,000-character initial context).

Measured on a 6-round interview with a 0.18 snapshot: `### seed-closer` present with its full closure question patterns, panel tail (simplifier) dropped instead. Pinned by `test_response_contract_survives_every_prompt_budget`, `test_response_contract_survives_a_saturating_initial_context`, and `test_closure_round_keeps_role_boundaries_alongside_seed_closer`.

## Third commit: one seed-ready predicate at both gates

The loop asked its confirmation with `qualifies_for_seed_completion()` (overall threshold plus component floors, brownfield aware) while `_generate_seed_from_interview()` still checked only `is_ready_for_seed`. A score of overall `0.15` with every component clarity at `0.5` therefore got "Continue with more questions?" from the loop and unforced generation from the outer path. Both gates now use the same predicate, `force` follows the same verdict, and the warning names the failing dimensions instead of an overall score that is under the threshold.

`SeedGenerator.generate()` keeps its own overall-only gate; that is the engine-level floor shared with MCP, and component floors are the caller's completion policy.

## Test plan

- [x] `uv run pytest tests/unit/bigbang tests/unit/cli -q` — 3103 passed, 7 skipped
- [x] `uv run pytest tests/unit/mcp tests/unit/auto -q` — 3964 passed, 1 skipped
- [x] `uv run pytest tests/integration tests/conformance -q` — 304 passed, 4 skipped, 1 xfailed
- [x] New `tests/unit/cli/test_init_ambiguity_gate.py` — 5 passed, covering: seed-ready score offers Seed and completes the interview; high score keeps the existing prompt and stores the snapshot; low overall score with a failing component floor does **not** offer Seed; scoring failure clears a stale snapshot and falls back; no scorer keeps the legacy prompt
- [x] `uv run ruff check src/ tests/` and `uv run ruff format --check` clean
- [x] `uv run mypy src/ouroboros/cli/commands/init.py` clean

## Cost

One scoring call per round from `MIN_ROUNDS_BEFORE_EARLY_EXIT` (round 3) on. `_generate_seed_from_interview` still scores once more before generation; that duplicate is left in place to keep this change minimal and to preserve the authoritative gate immediately before generation.

## Not in this PR

Two adjacent defects observed in the same session, noted in #2175 and needing their own issues:

- `_get_adapter` builds the interview adapter with `allowed_tools=None, max_turns=5`, which for CLI-agent backends such as `kiro` means no tool envelope and an explicit multi-turn license during question generation.
- `InterviewEngine.ask_next_question` applies no shape validation to the returned text, so an agent transcript is accepted and printed as the next question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
