### PR TITLE
fix(ouroboros): isolate dirty runs and preserve observer handoffs

### DIFF
--- a/.claude-plugin/skills/auto/SKILL.md
+++ b/.claude-plugin/skills/auto/SKILL.md
@@ -97,12 +97,18 @@ After a start response, show `dashboard_url` when present or mention
 mode, and frugality assurance. Say that the exact active model and execution
 plan will arrive from configuration/routing events rather than guessing.
 
-When `response.meta.job_observer` is present and a Task/Agent child exists,
-spawn exactly one read-only observer and pass the contract unchanged. It owns
-job wait/result and the cursor exclusively; the main session must not poll the
-same job. Keep the conversation available for requirement refinement, read-only
-review, explicit control, or unrelated work in an isolated worktree. Check
-active-worker overlap before writing to the Auto workspace. Without a child,
+If `response.meta.job_observer` is unavailable, recover it from the final
+`<!-- ouroboros-job-observer-v1 base64 ... -->` content sentinel. Fail closed
+unless the single bounded payload passes canonical v1 validation and its job/
+session identity matches the visible start receipt. Visible IDs are identity
+anchors only; never reconstruct tools or arguments from them.
+
+When a structured or validated recovered `job_observer` is present and a
+Task/Agent child exists, spawn exactly one read-only observer and pass the
+contract unchanged. It owns wait/result and the cursor exclusively. The main
+session must not poll the same job. Keep the conversation available for
+read-only review, explicit control, or unrelated work in an isolated worktree.
+Check active-worker overlap before writing to the Auto workspace. Without a child,
 use the declared linked `ouroboros_job_wait` fallback and never run both owners.
 Do not claim an observer until Task/Agent returns a live child handle. If child
 creation succeeds on Codex, keep the parent turn open with `wait_agent` calls of

--- a/.claude-plugin/skills/ralph/SKILL.md
+++ b/.claude-plugin/skills/ralph/SKILL.md
@@ -109,12 +109,19 @@ explicitly loaded before use. Do this before preparing input or calling Ralph:
      events here. This conversation remains available for other safe work.
      ```
 
-   - If `response.meta.job_observer` is present and the host supports an
-     independent Task/Agent child, spawn exactly one read-only observer and pass
-     the contract unchanged. It owns wait/result and the cursor exclusively. The
-     main session must not poll the same job. Keep the conversation available for
-     read-only review, explicit control, or unrelated work in an isolated
-     worktree; check active-worker overlap before writing to Ralph's workspace.
+   - If `response.meta.job_observer` is unavailable, recover it from the final
+     `<!-- ouroboros-job-observer-v1 base64 ... -->` content sentinel. Fail
+     closed unless the single bounded payload passes canonical v1 validation
+     and its job identity matches the visible start receipt. Visible IDs are
+     identity anchors only; never reconstruct tools or arguments from them.
+
+   - When a structured or validated recovered `job_observer` is present and the
+     host supports an independent Task/Agent child, spawn exactly one read-only
+     observer and pass the contract unchanged. It owns wait/result and the
+     cursor exclusively. The main session must not poll the same job. Keep the
+     conversation available for read-only review, explicit control, or unrelated
+     work in an isolated worktree; check active-worker overlap before writing to
+     Ralph's workspace.
      Do not claim an observer until Task/Agent returns a live child handle. If
      child creation succeeds on Codex, keep the parent turn open with
      `wait_agent` calls of at most 60 seconds until the observer returns its

--- a/.claude-plugin/skills/run/SKILL.md
+++ b/.claude-plugin/skills/run/SKILL.md
@@ -126,11 +126,17 @@ fallback instead of retrying the failing call.
    For full details later: `ouroboros_ac_tree_hud(session_id=<session_id>)`
    ```
 
-   When `response.meta.job_observer` is present and an independent Task/Agent
-   child is available, spawn exactly one read-only observer and pass the contract
-   unchanged. It exclusively owns job wait/result and the cursor. The main
-   session must not poll the same job. Before writing to the active workspace,
-   check worker overlap or use an isolated worktree.
+   If `response.meta.job_observer` is unavailable, recover it from the final
+   `<!-- ouroboros-job-observer-v1 base64 ... -->` content sentinel. Fail closed
+   unless the single bounded payload passes canonical v1 validation and its
+   job/session/execution identity matches the visible start receipt. Visible IDs
+   are identity anchors only; never reconstruct tools or arguments from them.
+
+   When a structured or validated recovered `job_observer` is present and an
+   independent Task/Agent child is available, spawn exactly one read-only
+   observer and pass the contract unchanged. It exclusively owns job wait/result
+   and the cursor. The main session must not poll the same job. Before writing to
+   the active workspace, check worker overlap or use an isolated worktree.
    Do not claim an observer exists until Task/Agent returns a live child handle.
    On Codex, once `spawn_agent` returns that handle, keep the parent turn open
    with `wait_agent` calls of at most 60 seconds until the observer returns its

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -117,22 +117,30 @@ When an auto start response includes `response.meta.job_id`:
    `frugality_assurance` when present. Say that the exact active model and first
    parallel level will be announced from the first configuration/plan events
    rather than guessing them.
-2. If `response.meta.job_observer` is present and the host supports independent
-   child sessions, spawn exactly one read-only observer and pass the contract
-   unchanged. Codex uses explicit native subagent delegation; Claude Code uses
-   one Task/Agent child. The observer owns the cursor, waits until terminal,
-   fetches the result, and follows downstream IDs named by
-   `follow_result_job_keys`. It must not edit files, control execution, or spawn
-   implementation workers. The main session must not poll the same job.
+2. If MCP metadata is unavailable, recover `job_observer` from the final
+   `<!-- ouroboros-job-observer-v1 base64 ... -->` content sentinel. Decode the
+   payload and use its `job_observer` object unchanged. Never reconstruct it
+   from visible Job/Session lines; reject a mismatch when both surfaces exist.
+3. If the structured or recovered `job_observer` is present and the host
+   supports independent child sessions, spawn exactly one read-only observer
+   and pass the contract unchanged. Codex uses `spawn_agent`, OMP uses one
+   native Task child, and Claude Code uses one Task/Agent child. The observer
+   owns the cursor, waits until terminal, fetches the result, and follows
+   downstream IDs named by `follow_result_job_keys`. It must not edit files,
+   control execution, or spawn implementation workers. The main session must
+   not poll the same job.
    On Codex, call `spawn_agent` exactly once with `task_name="run_observer"`;
    a `wait` call is not a spawn, and the handoff may claim an observer only after
    the spawn result returns a live child ID/path. Once acknowledged, keep the
    parent turn open with `wait_agent` calls of at most 60 seconds while the child
    remains active. A child `send_message` only queues a mailbox event; it cannot
    revive an ended parent turn. Relay meaningful updates and wait again until
-   the observer sends its terminal summary. User input may interrupt the wait;
-   handle it and resume waiting while observation remains active unless the user
-   asks to stop live observation or replaces the active request. Then end only
+   the observer sends its terminal summary.
+   On OMP, submit exactly one native Task child named `RunObserver`, require its
+   live agent/job ID, and use the host wait/inbox relay until terminal.
+   User input may interrupt the wait; handle it and resume waiting while
+   observation remains active unless the user asks to stop live observation or
+   replaces the active request. Then end only
    the relay loop, keep the durable job running, and offer next-turn or explicit-
    status catch-up. If the observer child fails, is cancelled, or exits before a
    terminal summary, use that same fallback instead of waiting indefinitely.
@@ -141,7 +149,7 @@ When an auto start response includes `response.meta.job_id`:
    continues after the stdio turn; say that durable progress will be caught up
    on the next parent turn or an explicit status request. Keep the current turn
    open in the fallback polling loop only when the user asked for live watching.
-3. If child-to-parent progress messages are supported, the observer relays only
+4. If child-to-parent progress messages are supported, the observer relays only
    meaningful `phase_changed`, `progress_advanced`, `attention_required`, and
    `terminal` events in at most 1-2 lines. During interview, it may use
    `ouroboros_session_status(session_id=<auto_session_id>)` to surface a new
@@ -156,14 +164,14 @@ When an auto start response includes `response.meta.job_id`:
    report only material changes. Never relay raw commands or reasoning.
    Before the main session writes to the active auto workspace, check for overlap
    with worker files or move the unrelated work to an isolated worktree.
-4. When no independent child session exists and the user explicitly asks to
+5. When no independent child session exists and the user explicitly asks to
    keep watching in this turn, enter the fallback low-noise loop. Otherwise end
    the turn safely and resume from the durable cursor on the next interaction:
    - `ouroboros_job_wait(job_id=<job_id>, cursor=<cursor>, timeout_seconds=120, view="summary", stream="linked", wait_for="attention_or_ac_change")`
    - update `cursor = response.meta.cursor` after every wait/status response
    - treat `response.meta` as the source of truth; use response text only as a
      human-readable hint
-5. Relay only meaningful changes: status changes, phase changes, new
+6. Relay only meaningful changes: status changes, phase changes, new
    execution/session/lineage handles, progress counters, blocker/error text, or
    a terminal state. If `response.meta.changed is false`, continue silently
    unless the user asked for heartbeat updates.
@@ -185,7 +193,7 @@ When an auto start response includes `response.meta.job_id`:
    `fallback_mode="after_turn"`. Use `mode="inform"` for a read-only AC question
    or assurance request, omit `fallback_mode` entirely in that mode, and relay
    the bounded reply from the completed event.
-6. **During the interview phase, surface the live Q&A — not just the round
+7. **During the interview phase, surface the live Q&A — not just the round
    counter.** Whenever the relayed phase is `interview` (e.g. progress reads
    `interview round N/50`), call
    `ouroboros_session_status(session_id=<auto_session_id>)` and relay to the
@@ -200,14 +208,14 @@ When an auto start response includes `response.meta.job_id`:
    nothing for the auto session, and it shows only the last 3 answers (each
    truncated). Keep it low-noise: relay the pending question and any newly
    answered rounds, not the same 3 entries every poll.
-7. If the job status is non-terminal (`queued`, `running`, or another active
+8. If the job status is non-terminal (`queued`, `running`, or another active
    status), keep waiting. Do not tell the user to call job tools themselves.
-8. When the job reaches a terminal status, the polling owner calls
+9. When the job reaches a terminal status, the polling owner calls
    `ouroboros_job_result(job_id)`
    and summarize the final auto-session outcome. If the final auto result is
    `detached`, keep tracking the surfaced downstream job/Ralph handles when
    available instead of presenting `detached` as completion.
-9. If `response.meta.status == "delegated_to_plugin"` and
+10. If `response.meta.status == "delegated_to_plugin"` and
    `response.meta.job_id is None`, report that OpenCode plugin mode delegated
    the work to the child Task/session. Do not call job wait/result without a
    real job id; follow the host Task widget/session lifecycle.

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -118,17 +118,18 @@ When an auto start response includes `response.meta.job_id`:
    parallel level will be announced from the first configuration/plan events
    rather than guessing them.
 2. If MCP metadata is unavailable, recover `job_observer` from the final
-   `<!-- ouroboros-job-observer-v1 base64 ... -->` content sentinel. Decode the
-   payload and use its `job_observer` object unchanged. Never reconstruct it
-   from visible Job/Session lines; reject a mismatch when both surfaces exist.
+   `<!-- ouroboros-job-observer-v1 base64 ... -->` content sentinel. Fail closed
+   unless the bounded payload passes canonical v1 validation and its job/session
+   identity matches the visible start receipt. Visible IDs are identity anchors,
+   not a source for reconstructing tools or arguments. Reject validation failure
+   or any mismatch between structured and inline surfaces.
 3. If the structured or recovered `job_observer` is present and the host
    supports independent child sessions, spawn exactly one read-only observer
    and pass the contract unchanged. Codex uses `spawn_agent`, OMP uses one
    native Task child, and Claude Code uses one Task/Agent child. The observer
    owns the cursor, waits until terminal, fetches the result, and follows
    downstream IDs named by `follow_result_job_keys`. It must not edit files,
-   control execution, or spawn implementation workers. The main session must
-   not poll the same job.
+   control execution, or spawn implementation workers. The main session must not poll the same job.
    On Codex, call `spawn_agent` exactly once with `task_name="run_observer"`;
    a `wait` call is not a spawn, and the handoff may claim an observer only after
    the spawn result returns a live child ID/path. Once acknowledged, keep the

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -109,22 +109,29 @@ explicitly loaded before use. Do this before preparing input or calling Ralph:
      events here. This conversation remains available for other safe work.
      ```
 
-   - If `response.meta.job_observer` is present and the host supports an
-     independent child session, spawn exactly one read-only observer and pass
-     that contract unchanged. The observer exclusively owns job wait/result
-     calls and the cursor. The main session retains only user conversation,
-     explicit on-demand status, and cancellation when the user requests it. The
-     main session must not poll the same job while the observer is active. It may
-     refine requirements, perform read-only review, or work in an unrelated
-     isolated worktree; check active-worker conflicts before writing to Ralph's
-     workspace.
+   - If MCP metadata is unavailable, recover `job_observer` from the final
+     `<!-- ouroboros-job-observer-v1 base64 ... -->` content sentinel. Decode
+     the payload and use its object unchanged; never infer it from visible IDs.
+     Reject a mismatch when both structured and inline surfaces exist.
+
+   - If the structured or recovered `job_observer` is present and the host
+     supports an independent child session, spawn exactly one read-only
+     observer and pass that contract unchanged. The observer exclusively owns
+     job wait/result calls and the cursor. The main session retains only user
+     conversation, explicit on-demand status, and cancellation when the user
+     requests it. The main session must not poll the same job while the observer
+     is active. It may refine requirements, perform read-only review, or work in
+     an unrelated isolated worktree; check active-worker conflicts before
+     writing to Ralph's workspace.
      On Codex, call `spawn_agent` exactly once with `task_name="run_observer"`;
      `wait` is not a spawn, and do not claim an observer until a live child
      ID/path is returned. Once acknowledged, keep the parent turn open with
      `wait_agent` calls of at most 60 seconds while the observer is active. Child
      `send_message` calls only enqueue mailbox events and cannot revive an ended
-     parent turn. Relay meaningful updates and wait again until the terminal
-     summary arrives. User input may interrupt the wait; handle it and resume
+     parent turn. Relay meaningful updates and wait again until terminal.
+     On OMP, submit exactly one native Task child named `RunObserver`, require
+     its live agent/job ID, and use the host wait/inbox relay until terminal.
+     User input may interrupt the wait; handle it and resume
      waiting while observation remains active unless the user asks to stop live
      observation or replaces the active request. Then end only the relay loop,
      keep the durable job running, and offer next-turn or explicit-status catch-

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -109,10 +109,12 @@ explicitly loaded before use. Do this before preparing input or calling Ralph:
      events here. This conversation remains available for other safe work.
      ```
 
-   - If MCP metadata is unavailable, recover `job_observer` from the final
-     `<!-- ouroboros-job-observer-v1 base64 ... -->` content sentinel. Decode
-     the payload and use its object unchanged; never infer it from visible IDs.
-     Reject a mismatch when both structured and inline surfaces exist.
+   - If `response.meta.job_observer` is unavailable, recover it from the final
+     `<!-- ouroboros-job-observer-v1 base64 ... -->` content sentinel. Fail
+     closed unless the bounded payload passes canonical v1 validation and its
+     job identity matches the visible start receipt. Use that ID only as an
+     identity anchor, never to reconstruct tools or arguments. Reject validation
+     failure or any mismatch between structured and inline surfaces.
 
    - If the structured or recovered `job_observer` is present and the host
      supports an independent child session, spawn exactly one read-only

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -160,16 +160,37 @@ fallback instead of retrying the failing call.
    For full details later: `ouroboros_ac_tree_hud(session_id=<session_id>)`
    ```
 
-   When `response.meta.job_observer` is present and the host has an independent
-   child/subagent session primitive, spawn exactly one observer session and pass
-   that object unchanged. Codex requires explicit native subagent delegation;
-   Claude Code uses one Task/Agent child. The observer must:
+   **Text-only host compatibility (OMP and similar bridges):**
+
+   If `response.meta.job_observer` is unavailable, inspect the response content
+   for the final sentinel block:
+
+   ```text
+   <!-- ouroboros-job-observer-v1 base64
+   <payload>
+   -->
+   ```
+
+   Base64-decode `<payload>`, parse the JSON object, and use its
+   `job_observer` value exactly as if it came from `response.meta`. Never
+   reconstruct the observer contract from the human-readable Job/Session lines.
+   If both surfaces exist but differ, stop and report a transport-integrity
+   failure instead of spawning two observers.
+
+   When a structured or recovered `job_observer` is present and the host has an
+   independent child/subagent session primitive, spawn exactly one observer
+   session and pass that object unchanged. Codex uses `spawn_agent`, OMP uses
+   one native Task child, and Claude Code uses one Task/Agent child. The observer must:
 
    - On Codex, call the native `spawn_agent` primitive exactly once with
-     `task_name="run_observer"` and include `response.meta.job_observer`
-     unchanged in the child message. A `wait` call is not a spawn.
+     `task_name="run_observer"` and include the structured or recovered
+     `job_observer` unchanged in the child message. A `wait` call is not a spawn.
    - Require the spawn result to return a live child ID/path before saying an
      observer is connected or before ending the start turn.
+   - On OMP, submit exactly one Task item named `RunObserver` with the recovered
+     or structured contract unchanged, require the returned live agent/job ID,
+     and use the host wait/inbox relay until the observer returns terminal.
+     A job-status poll in the parent is not an observer spawn.
 
    - remain read-only: no repository edits, execution control, or worker fan-out;
    - own the job cursor exclusively and reload deferred MCP schemas immediately

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -171,11 +171,14 @@ fallback instead of retrying the failing call.
    -->
    ```
 
-   Base64-decode `<payload>`, parse the JSON object, and use its
-   `job_observer` value exactly as if it came from `response.meta`. Never
-   reconstruct the observer contract from the human-readable Job/Session lines.
-   If both surfaces exist but differ, stop and report a transport-integrity
-   failure instead of spawning two observers.
+   Base64-decode `<payload>`, then fail closed unless it passes the canonical v1
+   validation implemented by `extract_job_observer_inline_handoff`: exactly one
+   bounded terminal sentinel; fixed protocol, role, ownership, wait/result tools,
+   restrictions, and follow-result keys; internally consistent IDs; and a
+   `job_id` matching the visible start receipt. Use visible Job/Session/Execution
+   IDs only as identity anchors, never to reconstruct the nested contract. If
+   structured and inline surfaces differ or validation fails, do not spawn an
+   observer; report a transport-integrity failure.
 
    When a structured or recovered `job_observer` is present and the host has an
    independent child/subagent session primitive, spawn exactly one observer

--- a/src/ouroboros/codex/ouroboros.md
+++ b/src/ouroboros/codex/ouroboros.md
@@ -47,24 +47,33 @@ If a user input starts with `ooo auto`, call `ouroboros_start_auto`. Full auto
 runs routinely exceed interactive MCP tool-call timeouts, so the background
 starter is the supported default. It returns `job_id` and `auto_session_id`
 quickly; report both briefly, retain the `job_id` plus latest cursor, and keep
-monitoring ownership inside the agent UX. When the response includes
-`meta.job_observer`, explicitly delegate that object to exactly one native Codex
-subagent session. That observer is read-only and exclusively owns
-`ouroboros_job_wait`, its cursor, `ouroboros_job_result`, and any downstream job
-IDs named by `follow_result_job_keys`. Keep the main session available for the
-user; do not poll the same job from both sessions. The main session may perform
-an on-demand status check only when the user asks. If native subagents are not
-available, use the contract's main-session fallback and relay only meaningful
-changes. Do not hand the user polling instructions as the final UX. If that MCP
-tool is unavailable, or any required job polling/result MCP tool is unavailable,
-stop and report that the MCP dispatch surface is incomplete instead of
-continuing as a normal Codex task. Do not emulate the workflow with ordinary
-shell or coding work.
+monitoring ownership inside the agent UX.
+
+Use `meta.job_observer` when the host exposes MCP metadata. Otherwise recover
+the same contract from the final
+`<!-- ouroboros-job-observer-v1 base64 ... -->` content sentinel: base64-decode
+the payload, parse JSON, and use its `job_observer` value unchanged. Never infer
+the observer contract from displayed Job/Session lines. If structured and inline
+contracts both exist but differ, stop on transport-integrity failure.
+
+Delegate the contract to exactly one native Codex subagent session. That
+observer is read-only and exclusively owns `ouroboros_job_wait`, its cursor,
+`ouroboros_job_result`, and any downstream job IDs named by
+`follow_result_job_keys`. Keep the main session available for the user; do not
+poll the same job from both sessions. The main session may perform an on-demand
+status check only when the user asks. If native subagents are not available, use
+the contract's main-session fallback and relay only meaningful changes. Do not
+hand the user polling instructions as the final UX. If that MCP tool is
+unavailable, or any required job polling/result MCP tool is unavailable, stop
+and report that the MCP dispatch surface is incomplete instead of continuing as
+a normal Codex task. Do not emulate the workflow with ordinary shell or coding
+work.
 
 For Codex delegation, call the native `spawn_agent` primitive exactly once with
-`task_name="run_observer"` and include `meta.job_observer` unchanged in the child
-message. A `wait` call does not create an observer. Do not claim delegation or
-end the start turn until the spawn result returns a live child ID/path. After a
+`task_name="run_observer"` and include the structured or recovered observer
+contract unchanged in the child message. A `wait` call does not create an
+observer. Do not claim delegation or end the start turn until the spawn result
+returns a live child ID/path. After a
 live child is acknowledged, keep the parent turn open with `wait_agent` while
 the observer is active. The observer's `send_message` only queues a parent
 mailbox event; it cannot revive a parent turn that already ended. Relay each

--- a/src/ouroboros/codex/ouroboros.md
+++ b/src/ouroboros/codex/ouroboros.md
@@ -59,8 +59,8 @@ identity anchors only, not a source for reconstructing executable fields. If
 structured and inline contracts differ or validation fails, stop on
 transport-integrity failure.
 
-Delegate the contract to exactly one native Codex subagent session. That
-observer is read-only and exclusively owns `ouroboros_job_wait`, its cursor,
+When the response exposes an observer contract, explicitly delegate that object to exactly one native Codex subagent session.
+That observer is read-only and exclusively owns `ouroboros_job_wait`, its cursor,
 `ouroboros_job_result`, and any downstream job IDs named by
 `follow_result_job_keys`. Keep the main session available for the user; do not
 poll the same job from both sessions. The main session may perform an on-demand

--- a/src/ouroboros/codex/ouroboros.md
+++ b/src/ouroboros/codex/ouroboros.md
@@ -50,11 +50,14 @@ quickly; report both briefly, retain the `job_id` plus latest cursor, and keep
 monitoring ownership inside the agent UX.
 
 Use `meta.job_observer` when the host exposes MCP metadata. Otherwise recover
-the same contract from the final
-`<!-- ouroboros-job-observer-v1 base64 ... -->` content sentinel: base64-decode
-the payload, parse JSON, and use its `job_observer` value unchanged. Never infer
-the observer contract from displayed Job/Session lines. If structured and inline
-contracts both exist but differ, stop on transport-integrity failure.
+the contract from the final `<!-- ouroboros-job-observer-v1 base64 ... -->`
+content sentinel and fail closed unless it passes canonical v1 validation:
+exactly one bounded terminal sentinel, fixed protocol/ownership/tools and
+read-only restrictions, internally consistent IDs, allowlisted downstream keys,
+and a job identity matching the visible start receipt. The visible IDs are
+identity anchors only, not a source for reconstructing executable fields. If
+structured and inline contracts differ or validation fails, stop on
+transport-integrity failure.
 
 Delegate the contract to exactly one native Codex subagent session. That
 observer is read-only and exclusively owns `ouroboros_job_wait`, its cursor,

--- a/src/ouroboros/core/worktree.py
+++ b/src/ouroboros/core/worktree.py
@@ -637,19 +637,19 @@ def prepare_task_workspace(
     allow_dirty: bool = False,
     allow_untracked_evidence: bool = False,
 ) -> TaskWorkspace:
-    """Create or reuse a task worktree and acquire its active lock."""
+    """Create or reuse a clean task worktree without touching caller changes."""
     source_path = Path(source_cwd).expanduser().resolve()
     repo_root = _resolve_repo_root(source_path)
     if allow_untracked_evidence and not allow_dirty:
         _ensure_only_untracked_evidence(repo_root)
-    elif not allow_dirty:
-        _ensure_clean_checkout(repo_root)
 
     repo_name = repo_root.name
     branch = _managed_branch_name(repo_root, durable_id)
     worktree_path = _worktree_root() / repo_name / durable_id
     effective_cwd = worktree_path / _relative_subdir(repo_root, source_path)
     _ensure_worktree(repo_root, worktree_path, branch)
+    if not allow_dirty:
+        _ensure_clean_checkout(worktree_path)
 
     workspace = TaskWorkspace(
         durable_id=durable_id,

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -91,7 +91,10 @@ from ouroboros.mcp.tools.auto_start_lease_store import (
 from ouroboros.mcp.tools.background import start_background_tool_job
 from ouroboros.mcp.tools.evaluation_handlers import LateralThinkHandler
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler, StartExecuteSeedHandler
-from ouroboros.mcp.tools.job_observer import build_job_observer_contract
+from ouroboros.mcp.tools.job_observer import (
+    append_job_observer_inline_handoff,
+    build_job_observer_contract,
+)
 from ouroboros.mcp.tools.qa import QAHandler
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.mcp.tools.run_successors import resolve_run_successor_handler
@@ -928,6 +931,12 @@ class StartAutoHandler:
 
         dashboard_url = await resolve_dashboard_base_url(self._event_store)
         dashboard_line = f"Live Dashboard: {dashboard_url}\n" if dashboard_url else ""
+        observer = build_job_observer_contract(
+            job_id=snapshot.job_id,
+            cursor=getattr(snapshot, "cursor", 0),
+            session_id=auto_session_id,
+            follow_result_job_keys=_FOLLOW_JOBS,
+        )
         text = (
             "Started background auto session.\n\n"
             "Status: queued\n"
@@ -943,6 +952,7 @@ class StartAutoHandler:
             "Track with ouroboros_job_wait / ouroboros_job_status until terminal, "
             "then fetch ouroboros_job_result."
         )
+        text = append_job_observer_inline_handoff(text, observer)
         meta = {
             "job_id": snapshot.job_id,
             "auto_session_id": auto_session_id,
@@ -954,12 +964,7 @@ class StartAutoHandler:
             "status_tool": "ouroboros_job_status",
             "wait_tool": "ouroboros_job_wait",
             "result_tool": "ouroboros_job_result",
-            "job_observer": build_job_observer_contract(
-                job_id=snapshot.job_id,
-                cursor=getattr(snapshot, "cursor", 0),
-                session_id=auto_session_id,
-                follow_result_job_keys=_FOLLOW_JOBS,
-            ),
+            "job_observer": observer,
         }
         return Result.ok(
             MCPToolResult(

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -36,7 +36,10 @@ from ouroboros.mcp.tools.fanout_handler import (  # noqa: F401
     FetchArtifactHandler,
     SubmitFanoutResultsHandler,
 )
-from ouroboros.mcp.tools.job_observer import build_job_observer_contract
+from ouroboros.mcp.tools.job_observer import (
+    append_job_observer_inline_handoff,
+    build_job_observer_contract,
+)
 from ouroboros.mcp.tools.subagent import (
     DELEGATED_TO_SUBAGENT,
     FanoutRegistry,
@@ -2216,22 +2219,24 @@ class StartEvaluateHandler:
             acceptance_may_have_occurred=background_acceptance.may_have_accepted,
         )
 
+        observer = build_job_observer_contract(
+            job_id=snapshot.job_id,
+            cursor=snapshot.cursor,
+            session_id=session_id,
+            follow_result_job_keys=("chained_ralph_job_id",),
+        )
         text = (
             f"Started background evaluation.\n\nJob ID: {snapshot.job_id}\n"
             f"Session ID: {session_id}\n\nUse ouroboros_job_status, ouroboros_job_wait, "
             "or ouroboros_job_result to monitor it."
         )
+        text = append_job_observer_inline_handoff(text, observer)
         meta = {
             "job_id": snapshot.job_id,
             "session_id": session_id,
             "status": snapshot.status.value,
             "cursor": snapshot.cursor,
-            "job_observer": build_job_observer_contract(
-                job_id=snapshot.job_id,
-                cursor=snapshot.cursor,
-                session_id=session_id,
-                follow_result_job_keys=("chained_ralph_job_id",),
-            ),
+            "job_observer": observer,
         }
         return Result.ok(
             MCPToolResult(

--- a/src/ouroboros/mcp/tools/evolution_handlers.py
+++ b/src/ouroboros/mcp/tools/evolution_handlers.py
@@ -55,7 +55,10 @@ from ouroboros.mcp.tools.evolve_start_claim import (
     PreparedEvolveClaim,
     evolve_lineage_busy_error,
 )
-from ouroboros.mcp.tools.job_observer import build_job_observer_contract
+from ouroboros.mcp.tools.job_observer import (
+    append_job_observer_inline_handoff,
+    build_job_observer_contract,
+)
 from ouroboros.mcp.tools.subagent import (
     DELEGATED_TO_PLUGIN,
     DELEGATED_TO_SUBAGENT,
@@ -1740,6 +1743,11 @@ class StartEvolveStepHandler:
         except MCPToolError as exc:
             return Result.err(exc)
 
+        observer = build_job_observer_contract(
+            job_id=snapshot.job_id,
+            cursor=snapshot.cursor,
+            execution_id=snapshot.links.execution_id,
+        )
         text = (
             f"Started background evolve_step.\n\n"
             f"Job ID: {snapshot.job_id}\n"
@@ -1747,17 +1755,14 @@ class StartEvolveStepHandler:
             f"Execution ID: {snapshot.links.execution_id}\n\n"
             "Use ouroboros_job_status, ouroboros_job_wait, or ouroboros_job_result to monitor it."
         )
+        text = append_job_observer_inline_handoff(text, observer)
         meta = {
             "job_id": snapshot.job_id,
             "lineage_id": lineage_id,
             "execution_id": snapshot.links.execution_id,
             "status": snapshot.status.value,
             "cursor": snapshot.cursor,
-            "job_observer": build_job_observer_contract(
-                job_id=snapshot.job_id,
-                cursor=snapshot.cursor,
-                execution_id=snapshot.links.execution_id,
-            ),
+            "job_observer": observer,
         }
         return Result.ok(
             MCPToolResult(

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -52,7 +52,10 @@ from ouroboros.mcp.job_manager import JobLinks, JobManager
 from ouroboros.mcp.tools._dashboard import resolve_dashboard_run_url
 from ouroboros.mcp.tools.background import start_background_tool_job
 from ouroboros.mcp.tools.bridge_mixin import BridgeAwareMixin
-from ouroboros.mcp.tools.job_observer import build_job_observer_contract
+from ouroboros.mcp.tools.job_observer import (
+    append_job_observer_inline_handoff,
+    build_job_observer_contract,
+)
 from ouroboros.mcp.tools.subagent import (
     DELEGATED_TO_PLUGIN,
     DELEGATED_TO_SUBAGENT,
@@ -2722,6 +2725,16 @@ class StartExecuteSeedHandler:
             snapshot.links.execution_id or execution_id, self._event_store
         )
         dashboard_line = f"Live Dashboard: {dashboard_url}\n" if dashboard_url else ""
+        observer = build_job_observer_contract(
+            job_id=snapshot.job_id,
+            cursor=snapshot.cursor,
+            session_id=snapshot.links.session_id,
+            execution_id=snapshot.links.execution_id,
+            follow_result_job_keys=(
+                "chained_evaluate_job_id",
+                "chained_ralph_job_id",
+            ),
+        )
         text = (
             f"Started background execution.\n\n"
             f"Job ID: {snapshot.job_id}\n"
@@ -2737,6 +2750,7 @@ class StartExecuteSeedHandler:
             "Use ouroboros_ac_tree_hud(session_id, cursor) for live progress and "
             "ouroboros_job_result(job_id) for the final output."
         )
+        text = append_job_observer_inline_handoff(text, observer)
         meta: dict[str, Any] = {
             "job_id": snapshot.job_id,
             "session_id": snapshot.links.session_id,
@@ -2748,16 +2762,7 @@ class StartExecuteSeedHandler:
             "llm_backend": llm_backend,
             "efficiency_mode": execution_preferences.efficiency_mode.value,
             "frugality_assurance": execution_preferences.frugality_assurance.value,
-            "job_observer": build_job_observer_contract(
-                job_id=snapshot.job_id,
-                cursor=snapshot.cursor,
-                session_id=snapshot.links.session_id,
-                execution_id=snapshot.links.execution_id,
-                follow_result_job_keys=(
-                    "chained_evaluate_job_id",
-                    "chained_ralph_job_id",
-                ),
-            ),
+            "job_observer": observer,
             **_run_only_verification_meta(snapshot.links.session_id),
         }
         if idempotency_key:

--- a/src/ouroboros/mcp/tools/job_observer.py
+++ b/src/ouroboros/mcp/tools/job_observer.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import base64
+from collections.abc import Mapping
+import json
 from typing import Any
 
 JOB_OBSERVER_PROTOCOL = "ouroboros.job_observer.v1"
+JOB_OBSERVER_INLINE_OPEN = "<!-- ouroboros-job-observer-v1 base64\n"
+JOB_OBSERVER_INLINE_CLOSE = "\n-->"
 
 
 def build_job_observer_contract(
@@ -138,4 +143,45 @@ def build_job_observer_contract(
     }
 
 
-__all__ = ["JOB_OBSERVER_PROTOCOL", "build_job_observer_contract"]
+def append_job_observer_inline_handoff(
+    text: str,
+    contract: Mapping[str, Any],
+) -> str:
+    """Append a hidden observer contract for text-only MCP hosts such as OMP."""
+    payload = json.dumps(
+        {"job_observer": dict(contract)},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    encoded = base64.b64encode(payload.encode("utf-8")).decode("ascii")
+    return f"{text.rstrip()}\n\n{JOB_OBSERVER_INLINE_OPEN}{encoded}{JOB_OBSERVER_INLINE_CLOSE}"
+
+
+def extract_job_observer_inline_handoff(text: str) -> dict[str, Any] | None:
+    """Recover the canonical observer contract from text-only MCP output."""
+    open_idx = text.rfind(JOB_OBSERVER_INLINE_OPEN)
+    if open_idx == -1:
+        return None
+    close_idx = text.find(JOB_OBSERVER_INLINE_CLOSE, open_idx)
+    if close_idx == -1:
+        return None
+    encoded = text[open_idx + len(JOB_OBSERVER_INLINE_OPEN) : close_idx]
+    try:
+        decoded = base64.b64decode(encoded.encode("ascii"), validate=True).decode("utf-8")
+        payload = json.loads(decoded)
+    except (UnicodeDecodeError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    contract = payload.get("job_observer")
+    return dict(contract) if isinstance(contract, dict) else None
+
+
+__all__ = [
+    "JOB_OBSERVER_INLINE_CLOSE",
+    "JOB_OBSERVER_INLINE_OPEN",
+    "JOB_OBSERVER_PROTOCOL",
+    "append_job_observer_inline_handoff",
+    "build_job_observer_contract",
+    "extract_job_observer_inline_handoff",
+]

--- a/src/ouroboros/mcp/tools/job_observer.py
+++ b/src/ouroboros/mcp/tools/job_observer.py
@@ -5,11 +5,23 @@ from __future__ import annotations
 import base64
 from collections.abc import Mapping
 import json
+import re
 from typing import Any
 
 JOB_OBSERVER_PROTOCOL = "ouroboros.job_observer.v1"
 JOB_OBSERVER_INLINE_OPEN = "<!-- ouroboros-job-observer-v1 base64\n"
 JOB_OBSERVER_INLINE_CLOSE = "\n-->"
+_JOB_OBSERVER_INLINE_MAX_DECODED_BYTES = 8_192
+_JOB_OBSERVER_INLINE_MAX_ENCODED_CHARS = 10_924
+_JOB_OBSERVER_JOB_ID_PATTERN = re.compile(r"^job_[A-Za-z0-9][A-Za-z0-9_.:-]*$")
+_JOB_OBSERVER_FOLLOW_RESULT_KEYS = frozenset(
+    {
+        "job_id",
+        "ralph_job_id",
+        "chained_evaluate_job_id",
+        "chained_ralph_job_id",
+    }
+)
 
 
 def build_job_observer_contract(
@@ -29,6 +41,11 @@ def build_job_observer_contract(
     hosts use the declared fallback.
     """
     normalized_cursor = cursor if isinstance(cursor, int) and not isinstance(cursor, bool) else 0
+    normalized_follow_result_job_keys = list(follow_result_job_keys)
+    if len(normalized_follow_result_job_keys) != len(set(normalized_follow_result_job_keys)):
+        raise ValueError("Observer follow-result job keys must be unique")
+    if not set(normalized_follow_result_job_keys).issubset(_JOB_OBSERVER_FOLLOW_RESULT_KEYS):
+        raise ValueError("Observer follow-result job key is not allowed by protocol v1")
     if normalized_cursor < 0:
         normalized_cursor = 0
 
@@ -56,7 +73,7 @@ def build_job_observer_contract(
             "tool": "ouroboros_job_result",
             "arguments": {"job_id": job_id},
         },
-        "follow_result_job_keys": list(follow_result_job_keys),
+        "follow_result_job_keys": normalized_follow_result_job_keys,
         "main_session_policy": "start_and_on_demand_only",
         "host_lifecycle": {
             "spawn_required_for_live_relay": True,
@@ -143,38 +160,118 @@ def build_job_observer_contract(
     }
 
 
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Build one JSON object while rejecting keys hidden by last-write-wins."""
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"Duplicate JSON object key {key!r}")
+        result[key] = value
+    return result
+
+
+def validate_job_observer_contract(
+    value: object,
+    *,
+    expected_job_id: str | None = None,
+    expected_session_id: str | None = None,
+    expected_execution_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Return a complete canonical observer contract or fail closed."""
+    if not isinstance(value, dict):
+        return None
+
+    job_id = value.get("job_id")
+    cursor = value.get("cursor")
+    session_id = value.get("session_id")
+    execution_id = value.get("execution_id")
+    follow_result_job_keys = value.get("follow_result_job_keys")
+
+    if not isinstance(job_id, str) or not _JOB_OBSERVER_JOB_ID_PATTERN.fullmatch(job_id):
+        return None
+    if expected_job_id is not None and job_id != expected_job_id:
+        return None
+    if not isinstance(cursor, int) or isinstance(cursor, bool) or cursor < 0:
+        return None
+    if session_id is not None and (not isinstance(session_id, str) or not session_id):
+        return None
+    if expected_session_id is not None and session_id != expected_session_id:
+        return None
+    if execution_id is not None and (not isinstance(execution_id, str) or not execution_id):
+        return None
+    if expected_execution_id is not None and execution_id != expected_execution_id:
+        return None
+    if not isinstance(follow_result_job_keys, list) or any(
+        not isinstance(key, str) or key not in _JOB_OBSERVER_FOLLOW_RESULT_KEYS
+        for key in follow_result_job_keys
+    ):
+        return None
+    if len(follow_result_job_keys) != len(set(follow_result_job_keys)):
+        return None
+    expected = build_job_observer_contract(
+        job_id=job_id,
+        cursor=cursor,
+        session_id=session_id,
+        execution_id=execution_id,
+        follow_result_job_keys=tuple(follow_result_job_keys),
+    )
+    return dict(value) if value == expected else None
+
+
 def append_job_observer_inline_handoff(
     text: str,
     contract: Mapping[str, Any],
 ) -> str:
-    """Append a hidden observer contract for text-only MCP hosts such as OMP."""
+    """Append one bounded canonical observer contract for text-only hosts."""
+    canonical = validate_job_observer_contract(dict(contract))
+    if canonical is None:
+        raise ValueError("Observer inline handoff requires a canonical protocol v1 contract")
     payload = json.dumps(
-        {"job_observer": dict(contract)},
+        {"job_observer": canonical},
         sort_keys=True,
         separators=(",", ":"),
-    )
-    encoded = base64.b64encode(payload.encode("utf-8")).decode("ascii")
+    ).encode("utf-8")
+    if len(payload) > _JOB_OBSERVER_INLINE_MAX_DECODED_BYTES:
+        raise ValueError("Observer inline handoff exceeds the bounded payload size")
+    encoded = base64.b64encode(payload).decode("ascii")
     return f"{text.rstrip()}\n\n{JOB_OBSERVER_INLINE_OPEN}{encoded}{JOB_OBSERVER_INLINE_CLOSE}"
 
 
-def extract_job_observer_inline_handoff(text: str) -> dict[str, Any] | None:
-    """Recover the canonical observer contract from text-only MCP output."""
-    open_idx = text.rfind(JOB_OBSERVER_INLINE_OPEN)
-    if open_idx == -1:
+def extract_job_observer_inline_handoff(
+    text: str,
+    *,
+    expected_job_id: str,
+    expected_session_id: str | None = None,
+    expected_execution_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Recover and validate the canonical observer contract from text output."""
+    if text.count(JOB_OBSERVER_INLINE_OPEN) != 1:
         return None
+    open_idx = text.rfind(JOB_OBSERVER_INLINE_OPEN)
     close_idx = text.find(JOB_OBSERVER_INLINE_CLOSE, open_idx)
     if close_idx == -1:
         return None
+    if text[close_idx + len(JOB_OBSERVER_INLINE_CLOSE) :].strip():
+        return None
     encoded = text[open_idx + len(JOB_OBSERVER_INLINE_OPEN) : close_idx]
+    if not encoded or len(encoded) > _JOB_OBSERVER_INLINE_MAX_ENCODED_CHARS:
+        return None
     try:
-        decoded = base64.b64decode(encoded.encode("ascii"), validate=True).decode("utf-8")
-        payload = json.loads(decoded)
-    except (UnicodeDecodeError, ValueError, json.JSONDecodeError):
+        payload_bytes = base64.b64decode(encoded.encode("ascii"), validate=True)
+        if len(payload_bytes) > _JOB_OBSERVER_INLINE_MAX_DECODED_BYTES:
+            return None
+        decoded = payload_bytes.decode("utf-8")
+        payload = json.loads(decoded, object_pairs_hook=_reject_duplicate_json_keys)
+    except (RecursionError, UnicodeDecodeError, ValueError, json.JSONDecodeError):
         return None
-    if not isinstance(payload, dict):
+    if not isinstance(payload, dict) or set(payload) != {"job_observer"}:
         return None
-    contract = payload.get("job_observer")
-    return dict(contract) if isinstance(contract, dict) else None
+    return validate_job_observer_contract(
+        payload["job_observer"],
+        expected_job_id=expected_job_id,
+        expected_session_id=expected_session_id,
+        expected_execution_id=expected_execution_id,
+    )
 
 
 __all__ = [
@@ -184,4 +281,5 @@ __all__ = [
     "append_job_observer_inline_handoff",
     "build_job_observer_contract",
     "extract_job_observer_inline_handoff",
+    "validate_job_observer_contract",
 ]

--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -19,7 +19,10 @@ from ouroboros.mcp.tools.evolution_handlers import (
     EvolveStepHandler,
     _resolve_conductor_directive,
 )
-from ouroboros.mcp.tools.job_observer import build_job_observer_contract
+from ouroboros.mcp.tools.job_observer import (
+    append_job_observer_inline_handoff,
+    build_job_observer_contract,
+)
 from ouroboros.mcp.tools.subagent import (
     DELEGATED_TO_PLUGIN,
     build_ralph_subagent,
@@ -523,6 +526,10 @@ class RalphHandler:
             opencode_mode=self.opencode_mode,
         )
 
+        observer = build_job_observer_contract(
+            job_id=snapshot.job_id,
+            cursor=snapshot.cursor,
+        )
         text = (
             "Started background Ralph loop.\n\n"
             f"Job ID: {snapshot.job_id}\n"
@@ -531,16 +538,14 @@ class RalphHandler:
             "Use ouroboros_job_status, ouroboros_job_wait, ouroboros_job_result, "
             "or ouroboros_cancel_job to monitor it."
         )
+        text = append_job_observer_inline_handoff(text, observer)
         meta = {
             "job_id": snapshot.job_id,
             "lineage_id": config.lineage_id,
             "status": snapshot.status.value,
             "cursor": snapshot.cursor,
             "max_generations": config.max_generations,
-            "job_observer": build_job_observer_contract(
-                job_id=snapshot.job_id,
-                cursor=snapshot.cursor,
-            ),
+            "job_observer": observer,
         }
         return Result.ok(
             MCPToolResult(

--- a/tests/unit/core/test_worktree.py
+++ b/tests/unit/core/test_worktree.py
@@ -370,7 +370,7 @@ class TestWorktreeHardening:
 
         assert "git commit --allow-empty" in exc_info.value.message
 
-    def test_maybe_prepare_creates_worktree_from_dirty_source_when_allowed(
+    def test_maybe_prepare_creates_clean_worktree_from_dirty_source_by_default(
         self, tmp_path: Path
     ) -> None:
         repo_root = tmp_path / "repo"
@@ -385,7 +385,6 @@ class TestWorktreeHardening:
             workspace = maybe_prepare_task_workspace(
                 repo_root,
                 "orch_test_dirty",
-                allow_dirty=True,
             )
 
         try:
@@ -393,6 +392,7 @@ class TestWorktreeHardening:
             assert workspace.worktree_path != str(repo_root)
             assert Path(workspace.worktree_path).is_dir()
             assert workspace.effective_cwd == workspace.worktree_path
+            assert self._git(Path(workspace.worktree_path), "status", "--porcelain") == ""
             assert not (Path(workspace.worktree_path) / "dirty.txt").exists()
             assert (repo_root / "dirty.txt").read_text(encoding="utf-8") == (
                 "uncommitted caller work\n"

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -49,6 +49,7 @@ from ouroboros.mcp.tools.execution_handlers import (
     _classify_synchronous_execution_status,
     _pause_metadata_from_progress,
 )
+from ouroboros.mcp.tools.job_observer import extract_job_observer_inline_handoff
 from ouroboros.mcp.tools.pm_handler import PMInterviewHandler
 from ouroboros.mcp.tools.qa import QAHandler
 from ouroboros.mcp.types import ToolInputType
@@ -2077,6 +2078,7 @@ class TestAsyncJobHandlers:
             "chained_evaluate_job_id",
             "chained_ralph_job_id",
         ]
+        assert extract_job_observer_inline_handoff(result.value.text_content) == observer
         assert "Verification Status: executed_unverified" in result.value.text_content
         assert "Formal Evaluation: NOT evaluated" in result.value.text_content
         assert "Next: ooo evaluate orch_" in result.value.text_content

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -2078,7 +2078,15 @@ class TestAsyncJobHandlers:
             "chained_evaluate_job_id",
             "chained_ralph_job_id",
         ]
-        assert extract_job_observer_inline_handoff(result.value.text_content) == observer
+        assert (
+            extract_job_observer_inline_handoff(
+                result.value.text_content,
+                expected_job_id=observer["job_id"],
+                expected_session_id=observer["session_id"],
+                expected_execution_id=observer["execution_id"],
+            )
+            == observer
+        )
         assert "Verification Status: executed_unverified" in result.value.text_content
         assert "Formal Evaluation: NOT evaluated" in result.value.text_content
         assert "Next: ooo evaluate orch_" in result.value.text_content

--- a/tests/unit/mcp/tools/test_job_observer.py
+++ b/tests/unit/mcp/tools/test_job_observer.py
@@ -1,12 +1,24 @@
 """Tests for the structured background-job observer handoff."""
 
+import base64
+import json
+
+import pytest
+
 from ouroboros.mcp.tools.job_observer import (
+    JOB_OBSERVER_INLINE_CLOSE,
     JOB_OBSERVER_INLINE_OPEN,
     JOB_OBSERVER_PROTOCOL,
     append_job_observer_inline_handoff,
     build_job_observer_contract,
     extract_job_observer_inline_handoff,
 )
+
+
+def _raw_inline_handoff(contract: dict[str, object]) -> str:
+    payload = json.dumps({"job_observer": contract}, sort_keys=True, separators=(",", ":"))
+    encoded = base64.b64encode(payload.encode("utf-8")).decode("ascii")
+    return f"Started\n\n{JOB_OBSERVER_INLINE_OPEN}{encoded}{JOB_OBSERVER_INLINE_CLOSE}"
 
 
 def test_job_observer_contract_assigns_exclusive_read_only_ownership() -> None:
@@ -148,10 +160,134 @@ def test_inline_handoff_round_trips_canonical_observer_contract() -> None:
     text = append_job_observer_inline_handoff("Started background execution.", contract)
 
     assert JOB_OBSERVER_INLINE_OPEN in text
-    assert extract_job_observer_inline_handoff(text) == contract
+    assert (
+        extract_job_observer_inline_handoff(
+            text,
+            expected_job_id="job_123",
+            expected_session_id="orch_123",
+            expected_execution_id="exec_123",
+        )
+        == contract
+    )
 
 
 def test_inline_handoff_rejects_malformed_payload() -> None:
     text = f"Started background execution.\n\n{JOB_OBSERVER_INLINE_OPEN}not-base64\n-->"
 
-    assert extract_job_observer_inline_handoff(text) is None
+    assert extract_job_observer_inline_handoff(text, expected_job_id="job_123") is None
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "protocol",
+        "ownership",
+        "wait_tool",
+        "result_tool",
+        "required_field",
+        "extra_field",
+        "follow_key",
+        "duplicate_follow_key",
+    ],
+)
+def test_inline_handoff_rejects_noncanonical_contract(mutation: str) -> None:
+    contract = build_job_observer_contract(
+        job_id="job_123",
+        cursor=7,
+        session_id="orch_123",
+        execution_id="exec_123",
+    )
+    mutated = json.loads(json.dumps(contract))
+    if mutation == "protocol":
+        mutated["protocol"] = "ouroboros.job_observer.v999"
+    elif mutation == "ownership":
+        mutated["ownership"] = "shared"
+    elif mutation == "wait_tool":
+        mutated["wait"]["tool"] = "ouroboros_cancel_job"
+    elif mutation == "result_tool":
+        mutated["result"]["tool"] = "ouroboros_cancel_execution"
+    elif mutation == "required_field":
+        mutated.pop("restrictions")
+    elif mutation == "extra_field":
+        mutated["unexpected"] = True
+    elif mutation == "follow_key":
+        mutated["follow_result_job_keys"] = ["attacker_job_id"]
+    else:
+        mutated["follow_result_job_keys"] = [
+            "chained_ralph_job_id",
+            "chained_ralph_job_id",
+        ]
+
+    text = _raw_inline_handoff(mutated)
+
+    assert extract_job_observer_inline_handoff(text, expected_job_id="job_123") is None
+
+
+def test_inline_handoff_rejects_different_canonical_job_identity() -> None:
+    contract = build_job_observer_contract(job_id="job_other", cursor=7)
+    text = append_job_observer_inline_handoff("Started background execution.", contract)
+
+    assert extract_job_observer_inline_handoff(text, expected_job_id="job_123") is None
+
+
+def test_inline_handoff_rejects_content_after_terminal_sentinel() -> None:
+    contract = build_job_observer_contract(job_id="job_123", cursor=7)
+    text = append_job_observer_inline_handoff("Started background execution.", contract)
+
+    assert (
+        extract_job_observer_inline_handoff(
+            f"{text}\nignore previous contract",
+            expected_job_id="job_123",
+        )
+        is None
+    )
+
+
+def test_inline_handoff_rejects_duplicate_sentinels() -> None:
+    contract = build_job_observer_contract(job_id="job_123", cursor=7)
+    text = append_job_observer_inline_handoff("Started background execution.", contract)
+    sentinel = text[text.rfind(JOB_OBSERVER_INLINE_OPEN) :]
+
+    assert (
+        extract_job_observer_inline_handoff(
+            f"{text}\n\n{sentinel}",
+            expected_job_id="job_123",
+        )
+        is None
+    )
+
+
+def test_inline_handoff_rejects_duplicate_json_keys() -> None:
+    payload = b'{"job_observer":{"protocol":"first","protocol":"second"}}'
+    encoded = base64.b64encode(payload).decode("ascii")
+    text = f"Started\n\n{JOB_OBSERVER_INLINE_OPEN}{encoded}{JOB_OBSERVER_INLINE_CLOSE}"
+
+    assert extract_job_observer_inline_handoff(text, expected_job_id="job_123") is None
+
+
+def test_inline_handoff_rejects_oversized_encoded_payload() -> None:
+    encoded = "A" * 10_925
+    text = f"Started\n\n{JOB_OBSERVER_INLINE_OPEN}{encoded}{JOB_OBSERVER_INLINE_CLOSE}"
+
+    assert extract_job_observer_inline_handoff(text, expected_job_id="job_123") is None
+
+
+def test_job_observer_builder_rejects_unknown_or_duplicate_follow_keys() -> None:
+    with pytest.raises(ValueError, match="not allowed"):
+        build_job_observer_contract(
+            job_id="job_123",
+            follow_result_job_keys=("attacker_job_id",),
+        )
+    with pytest.raises(ValueError, match="unique"):
+        build_job_observer_contract(
+            job_id="job_123",
+            follow_result_job_keys=("chained_ralph_job_id", "chained_ralph_job_id"),
+        )
+
+
+def test_inline_handoff_encoder_rejects_noncanonical_contract() -> None:
+    contract = build_job_observer_contract(job_id="job_123")
+    contract["ownership"] = "shared"
+
+    with pytest.raises(ValueError, match="canonical protocol v1"):
+        append_job_observer_inline_handoff("Started", contract)

--- a/tests/unit/mcp/tools/test_job_observer.py
+++ b/tests/unit/mcp/tools/test_job_observer.py
@@ -1,8 +1,11 @@
 """Tests for the structured background-job observer handoff."""
 
 from ouroboros.mcp.tools.job_observer import (
+    JOB_OBSERVER_INLINE_OPEN,
     JOB_OBSERVER_PROTOCOL,
+    append_job_observer_inline_handoff,
     build_job_observer_contract,
+    extract_job_observer_inline_handoff,
 )
 
 
@@ -131,3 +134,24 @@ def test_job_observer_contract_normalizes_non_integer_cursor() -> None:
 
     assert contract["cursor"] == 0
     assert contract["wait"]["arguments"]["cursor"] == 0
+
+
+def test_inline_handoff_round_trips_canonical_observer_contract() -> None:
+    contract = build_job_observer_contract(
+        job_id="job_123",
+        cursor=7,
+        session_id="orch_123",
+        execution_id="exec_123",
+        follow_result_job_keys=("chained_evaluate_job_id",),
+    )
+
+    text = append_job_observer_inline_handoff("Started background execution.", contract)
+
+    assert JOB_OBSERVER_INLINE_OPEN in text
+    assert extract_job_observer_inline_handoff(text) == contract
+
+
+def test_inline_handoff_rejects_malformed_payload() -> None:
+    text = f"Started background execution.\n\n{JOB_OBSERVER_INLINE_OPEN}not-base64\n-->"
+
+    assert extract_job_observer_inline_handoff(text) is None

--- a/tests/unit/mcp/tools/test_ralph_handler.py
+++ b/tests/unit/mcp/tools/test_ralph_handler.py
@@ -11,6 +11,7 @@ import pytest
 from ouroboros.core.conductor import ConductorDirective
 from ouroboros.core.types import Result
 from ouroboros.mcp.job_manager import JobManager, JobStatus
+from ouroboros.mcp.tools.job_observer import extract_job_observer_inline_handoff
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler, StartRalphHandler
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.persistence.event_store import EventStore
@@ -228,6 +229,13 @@ async def test_ralph_handler_returns_job_id_and_completes_loop() -> None:
         assert started.is_ok
         job_id = started.value.meta["job_id"]
         assert job_id.startswith("job_")
+        assert (
+            extract_job_observer_inline_handoff(
+                started.value.text_content,
+                expected_job_id=job_id,
+            )
+            == started.value.meta["job_observer"]
+        )
 
         snapshot = await job_manager.get_snapshot(job_id)
         # 60s rather than 30s: GitHub Actions runners under load have been

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -39,6 +39,10 @@ from ouroboros.mcp.tools.auto_handler import (
     _reconcile_execution_job_snapshot,
 )
 from ouroboros.mcp.tools.job_handlers import JobResultHandler, JobStatusHandler, JobWaitHandler
+from ouroboros.mcp.tools.job_observer import (
+    JOB_OBSERVER_INLINE_OPEN,
+    extract_job_observer_inline_handoff,
+)
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.persistence.event_store import EventStore
 
@@ -86,6 +90,7 @@ If `ouroboros_auto` is unavailable or interpreted as normal text, stop and repor
 
 _AUTO_ID_RE = re.compile(r"auto_[0-9a-f]+")
 _UUID_HEX_RE = re.compile(r"\b[0-9a-f]{32}\b")
+_JOB_ID_RE = re.compile(r"job_(?:auto_)?[0-9a-f]+")
 
 
 def _linux_owner_identity(pid: int, *, start_ticks: int = 111) -> dict[str, object]:
@@ -118,6 +123,19 @@ def _normalize_detached_auto_response(value):
     if isinstance(value, (list, tuple)):
         return [_normalize_detached_auto_response(item) for item in value]
     if isinstance(value, str):
+        if JOB_OBSERVER_INLINE_OPEN in value:
+            visible = value[: value.rfind(JOB_OBSERVER_INLINE_OPEN)].rstrip()
+            job_id_line = next(line for line in visible.splitlines() if line.startswith("job_id: "))
+            observer = extract_job_observer_inline_handoff(
+                value,
+                expected_job_id=job_id_line.removeprefix("job_id: "),
+            )
+            assert observer is not None
+            return {
+                "visible_text": _normalize_detached_auto_response(visible),
+                "job_observer": _normalize_detached_auto_response(observer),
+            }
+        value = _JOB_ID_RE.sub("job_<id>", value)
         value = _AUTO_ID_RE.sub("auto_<id>", value)
         value = _UUID_HEX_RE.sub("<uuid>", value)
         return value
@@ -148,7 +166,14 @@ def _assert_detached_start_text_has_guidance_with_handles(
     auto_session_id: str,
 ) -> None:
     text = result.text_content
-    assert text == (
+    observer = extract_job_observer_inline_handoff(
+        text,
+        expected_job_id=job_id,
+        expected_session_id=auto_session_id,
+    )
+    assert observer == result.meta["job_observer"]
+    visible_text = text[: text.rfind(JOB_OBSERVER_INLINE_OPEN)].rstrip()
+    assert visible_text == (
         "Started background auto session.\n\n"
         "Status: queued\n"
         f"job_id: {job_id}\n"

--- a/tests/unit/mcp/tools/test_start_evaluate.py
+++ b/tests/unit/mcp/tools/test_start_evaluate.py
@@ -24,6 +24,7 @@ from ouroboros.mcp.tools.evaluation_handlers import (
     EvaluateHandler,
     StartEvaluateHandler,
 )
+from ouroboros.mcp.tools.job_observer import extract_job_observer_inline_handoff
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.persistence.event_store import EventStore
 
@@ -1281,6 +1282,14 @@ class TestBackgroundJobPath:
         assert observer["job_id"] == "job_abc123"
         assert observer["session_id"] == "orch_xyz"
         assert observer["recommended_host_action"] == "spawn_observer_session"
+        assert (
+            extract_job_observer_inline_handoff(
+                result.value.text_content,
+                expected_job_id="job_abc123",
+                expected_session_id="orch_xyz",
+            )
+            == observer
+        )
         # Inner evaluate must NOT have been called synchronously — fire-and-forget.
         fake_inner_handler.handle.assert_not_called()
         job_manager.start_job.assert_awaited_once()

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -62,6 +62,7 @@ from ouroboros.mcp.errors import MCPToolError
 from ouroboros.mcp.job_manager import JobManager, JobStatus
 from ouroboros.mcp.server.adapter import _extract_feedback_metadata_from_artifact
 from ouroboros.mcp.tools.evolution_handlers import EvolveStepHandler, StartEvolveStepHandler
+from ouroboros.mcp.tools.job_observer import extract_job_observer_inline_handoff
 from ouroboros.mcp.tools.synapse_handler import SynapseTargetsHandler
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.orchestrator.synapse import EventStoreSessionSignalTargetResolver
@@ -338,6 +339,14 @@ async def test_start_evolve_links_generation_selected_after_interleaving(
         stale = f"evolve:{lineage_id}:generation:1"
         assert started.value.meta["execution_id"] == expected
         assert started.value.meta["job_observer"]["execution_id"] == expected
+        assert (
+            extract_job_observer_inline_handoff(
+                started.value.text_content,
+                expected_job_id=started.value.meta["job_id"],
+                expected_execution_id=expected,
+            )
+            == started.value.meta["job_observer"]
+        )
         assert started.value.structured_content["execution_id"] == expected
 
         await asyncio.wait_for(generation_started.wait(), timeout=1.0)


### PR DESCRIPTION
## Summary

- Allow `ooo run` to create a clean managed worktree from `HEAD` even when the caller checkout contains unrelated uncommitted work.
- Preserve the canonical read-only observer contract for OMP and other text-only MCP hosts through a versioned base64 content sentinel.
- Keep structured MCP metadata primary while making text fallback recovery bounded, identity-bound, and fail-closed.

## Changes

- Move cleanliness validation from the caller checkout to the created task worktree while retaining evidence-only restrictions.
- Add canonical observer envelope validation: one terminal sentinel, bounded payloads, duplicate-key rejection, fixed wait/result tools, allowlisted downstream keys, and mandatory trusted job identity binding.
- Attach the fallback to run, auto, evaluate, evolve, and Ralph background starters.
- Synchronize primary and packaged skill guidance for OMP/Codex/Task observer ownership.
- Preserve the visible detached-auto response contract and add parity assertions for all background starters.

## Notes

- Verification: 512 focused/regression tests passed; Ruff and targeted MyPy passed.
- Full local suite reached 18,892 passes before an unrelated macOS installer Unicode fixture failed; the touched observer/worktree suites remain green.
- Branch-local MCP smoke confirmed dirty-checkout isolation, equal structured/inline observer contracts, live dashboard visibility, and a real OMP child owning job wait/result through terminal.
- The reviewer-assessment smoke Seed itself finished 0/3 because its worker ACs exhausted recovery or blocked; that execution-quality failure is separate from this PR's worktree and observer transport scope.
- Labeled `no-issue`; this is a standalone runtime reliability fix without an existing issue tracker item.