### PR TITLE
fix(init): make "Start workflow now?" actually run the Seed

### DIFF
--- a/docs/guides/seed-authoring.md
+++ b/docs/guides/seed-authoring.md
@@ -740,21 +740,24 @@ ouroboros run minimal_seed.yaml
 
 ### CLI Flag Warnings
 
-#### `--runtime` without `--orchestrator` (init command)
+#### `--runtime` and `--orchestrator` (init command)
 
-**Symptom:**
-```
-Warning: --runtime only affects the workflow execution step when --orchestrator is enabled.
-```
+The two flags act on different stages, and neither gates the other:
 
-**Cause:** `--runtime` (e.g., `--runtime codex`) was passed to `ouroboros init` without `--orchestrator`. The `--runtime` flag only controls which agent runtime backend is used when the generated seed is immediately handed off to workflow execution. Without `--orchestrator`, the workflow handoff step uses a placeholder.
+- `--runtime` selects the agent runtime for the workflow handoff — the execution
+  that starts when you accept "Start workflow now?". It applies whether or not
+  `--orchestrator` is passed.
+- `--orchestrator` selects Claude Code as the LLM backend for the *interview and
+  seed generation*, and is equivalent to `--llm-backend claude_code`.
 
-**Behavior:** This is a **warning only** — the interview and seed generation proceed normally. The runtime flag has no effect.
-
-**Fix:** Add `--orchestrator` if you want to use the specified runtime backend for the post-generation workflow step:
 ```bash
-ouroboros init start --orchestrator --runtime codex "Build a REST API"
+# Interview on the configured backend, execute the Seed with the Codex runtime
+ouroboros init start --runtime codex "Build a REST API"
 ```
+
+Earlier releases warned that `--runtime` had no effect without `--orchestrator`,
+because the handoff without that flag printed a placeholder instead of executing.
+The handoff now always runs, so the warning is gone.
 
 ---
 

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -835,20 +835,22 @@ async def _start_workflow(
     # default. The previous non-orchestrator branch printed "not yet
     # implemented" and returned, so answering yes to "Start workflow now?"
     # did nothing unless the caller had also passed --orchestrator.
+    #
+    # Nothing is caught here. `_run_orchestrator` signals every failure —
+    # unloadable Seed, unsafe project path, workspace error, failed execution —
+    # as `typer.Exit(1)` and has no zero-code exit to absorb, so catching it
+    # printed the error and still finished `init start` successfully. A caller
+    # in a script cannot tell a built product from a failed one, and Ctrl+C read
+    # the same way. Sharing the run command's path means sharing its exit code.
     from ouroboros.cli.commands.run import _run_orchestrator
 
-    try:
-        await _run_orchestrator(
-            seed_path,
-            resume_session=None,
-            parallel=parallel,
-            runtime_backend=runtime_backend,
-            project_fallback_dir=project_fallback_dir,
-        )
-    except typer.Exit:
-        pass  # Normal exit
-    except KeyboardInterrupt:
-        print_info("Workflow interrupted.")
+    await _run_orchestrator(
+        seed_path,
+        resume_session=None,
+        parallel=parallel,
+        runtime_backend=runtime_backend,
+        project_fallback_dir=project_fallback_dir,
+    )
 
 
 def _find_pm_seeds(seeds_dir: Path | None = None) -> list[Path]:

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -839,9 +839,14 @@ async def _start_workflow(
     # Nothing is caught here. `_run_orchestrator` signals every failure —
     # unloadable Seed, unsafe project path, workspace error, failed execution —
     # as `typer.Exit(1)` and has no zero-code exit to absorb, so catching it
-    # printed the error and still finished `init start` successfully. A caller
-    # in a script cannot tell a built product from a failed one, and Ctrl+C read
-    # the same way. Sharing the run command's path means sharing its exit code.
+    # printed the error and still finished `init start` successfully: a caller
+    # in a script could not tell a built product from a failed one.
+    #
+    # `KeyboardInterrupt` is not caught either, but that is about ownership, not
+    # exit codes. The command wrapper below still answers Ctrl+C with exit 0 and
+    # "Interview interrupted. Progress has been saved.", which is the policy for
+    # an interactive command; the point is that one place decides it instead of
+    # this handoff printing a competing line on the way there.
     from ouroboros.cli.commands.run import _run_orchestrator
 
     await _run_orchestrator(

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -1153,11 +1153,6 @@ def start(
     if debug:
         print_info("Debug mode enabled - showing verbose logs")
 
-    if runtime and not orchestrator:
-        print_warning(
-            "--runtime only affects the workflow execution step when --orchestrator is enabled."
-        )
-
     # Show mode info
     selected_llm_backend = _resolve_init_llm_backend(
         orchestrator,

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -649,7 +649,7 @@ async def _run_interview(
             await _start_workflow(
                 seed_path,
                 runtime_backend=workflow_runtime_backend,
-                project_dir=_workflow_project_dir(seed_path),
+                project_fallback_dir=Path.cwd(),
             )
 
     finally:
@@ -809,36 +809,11 @@ async def _generate_seed_from_interview(
     return seed_path, SeedGenerationResult.SUCCESS
 
 
-def _workflow_project_dir(seed_path: Path) -> Path | None:
-    """Directory the generated Seed should be built in.
-
-    An interview is conducted from the project it is about, so the invocation
-    directory is the project — without this the seed's own location decides,
-    and a Seed written to ``~/.ouroboros/seeds`` sends the agent to build
-    inside the seed store.
-
-    Returns ``None`` when the Seed names a brownfield target directory, so the
-    Seed's own target keeps precedence over where the person happened to stand.
-    """
-    try:
-        seed_data = yaml.safe_load(seed_path.read_text(encoding="utf-8"))
-    except (OSError, yaml.YAMLError):
-        return Path.cwd()
-
-    brownfield_context = (seed_data or {}).get("brownfield_context")
-    if isinstance(brownfield_context, dict):
-        target_dir = brownfield_context.get("target_dir")
-        if isinstance(target_dir, str) and target_dir.strip():
-            return None
-
-    return Path.cwd()
-
-
 async def _start_workflow(
     seed_path: Path,
     parallel: bool = True,
     runtime_backend: str | None = None,
-    project_dir: Path | None = None,
+    project_fallback_dir: Path | None = None,
 ) -> None:
     """Start workflow from generated seed.
 
@@ -846,8 +821,12 @@ async def _start_workflow(
         seed_path: Path to the seed YAML file.
         parallel: Execute independent ACs in parallel. Default: True.
         runtime_backend: Optional runtime backend for orchestrator execution.
-        project_dir: Directory to execute in. ``None`` lets the run command
-            resolve it from the Seed, matching ``ouroboros run workflow``.
+        project_fallback_dir: Directory to build in when the Seed does not say
+            where it belongs. An interview is conducted from the project it is
+            about, so the invocation directory stands in for the Seed file's
+            folder — otherwise a Seed written to ``~/.ouroboros/seeds`` makes
+            the Seed store the workspace. Seed metadata and a valid brownfield
+            target still win; the run command weighs all of that in one place.
     """
     console.print()
     console.print("[bold cyan]Starting workflow...[/]")
@@ -864,7 +843,7 @@ async def _start_workflow(
             resume_session=None,
             parallel=parallel,
             runtime_backend=runtime_backend,
-            project_dir=project_dir,
+            project_fallback_dir=project_fallback_dir,
         )
     except typer.Exit:
         pass  # Normal exit

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -648,8 +648,8 @@ async def _run_interview(
         if should_start_workflow:
             await _start_workflow(
                 seed_path,
-                use_orchestrator,
                 runtime_backend=workflow_runtime_backend,
+                project_dir=_workflow_project_dir(seed_path),
             )
 
     finally:
@@ -809,42 +809,67 @@ async def _generate_seed_from_interview(
     return seed_path, SeedGenerationResult.SUCCESS
 
 
+def _workflow_project_dir(seed_path: Path) -> Path | None:
+    """Directory the generated Seed should be built in.
+
+    An interview is conducted from the project it is about, so the invocation
+    directory is the project — without this the seed's own location decides,
+    and a Seed written to ``~/.ouroboros/seeds`` sends the agent to build
+    inside the seed store.
+
+    Returns ``None`` when the Seed names a brownfield target directory, so the
+    Seed's own target keeps precedence over where the person happened to stand.
+    """
+    try:
+        seed_data = yaml.safe_load(seed_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return Path.cwd()
+
+    brownfield_context = (seed_data or {}).get("brownfield_context")
+    if isinstance(brownfield_context, dict):
+        target_dir = brownfield_context.get("target_dir")
+        if isinstance(target_dir, str) and target_dir.strip():
+            return None
+
+    return Path.cwd()
+
+
 async def _start_workflow(
     seed_path: Path,
-    use_orchestrator: bool = False,
     parallel: bool = True,
     runtime_backend: str | None = None,
+    project_dir: Path | None = None,
 ) -> None:
     """Start workflow from generated seed.
 
     Args:
         seed_path: Path to the seed YAML file.
-        use_orchestrator: Whether to use Claude Code orchestrator.
         parallel: Execute independent ACs in parallel. Default: True.
         runtime_backend: Optional runtime backend for orchestrator execution.
+        project_dir: Directory to execute in. ``None`` lets the run command
+            resolve it from the Seed, matching ``ouroboros run workflow``.
     """
     console.print()
     console.print("[bold cyan]Starting workflow...[/]")
 
-    if use_orchestrator:
-        # Direct function call instead of subprocess
-        from ouroboros.cli.commands.run import _run_orchestrator
+    # One execution path, the same one `ouroboros run workflow` takes by
+    # default. The previous non-orchestrator branch printed "not yet
+    # implemented" and returned, so answering yes to "Start workflow now?"
+    # did nothing unless the caller had also passed --orchestrator.
+    from ouroboros.cli.commands.run import _run_orchestrator
 
-        try:
-            await _run_orchestrator(
-                seed_path,
-                resume_session=None,
-                parallel=parallel,
-                runtime_backend=runtime_backend,
-            )
-        except typer.Exit:
-            pass  # Normal exit
-        except KeyboardInterrupt:
-            print_info("Workflow interrupted.")
-    else:
-        # Standard workflow (placeholder for now)
-        print_info(f"Would execute workflow from: {seed_path}")
-        print_info("Standard workflow execution not yet implemented.")
+    try:
+        await _run_orchestrator(
+            seed_path,
+            resume_session=None,
+            parallel=parallel,
+            runtime_backend=runtime_backend,
+            project_dir=project_dir,
+        )
+    except typer.Exit:
+        pass  # Normal exit
+    except KeyboardInterrupt:
+        print_info("Workflow interrupted.")
 
 
 def _find_pm_seeds(seeds_dir: Path | None = None) -> list[Path]:

--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -280,14 +280,28 @@ def _resolve_cli_project_dir(
     *,
     seed_data: dict[str, Any] | None = None,
     project_dir: Path | None = None,
+    fallback_dir: Path | None = None,
 ) -> Path:
-    """Resolve the project directory for CLI execution and verification."""
+    """Resolve the project directory for CLI execution and verification.
+
+    ``fallback_dir`` replaces the Seed file's own folder as the base used when
+    the Seed does not say where it belongs. Callers that hold a better answer
+    than "wherever the file sits" pass it — `init` passes the directory the
+    interview was run from — so a Seed written to the global store cannot turn
+    that store into a workspace. It stays a *fallback*: an explicit
+    ``project_dir``, Seed metadata, and a valid brownfield target all still win,
+    and every one of those decisions is made here, once.
+    """
     if project_dir is not None:
         return project_dir.expanduser().resolve()
 
     seed_data = seed_data or {}
     detected_root = _detect_project_root_from_seed_path(seed_file)
-    seed_base = detected_root or seed_file.parent.resolve()
+    seed_base = (
+        detected_root
+        or (fallback_dir.expanduser().resolve() if fallback_dir is not None else None)
+        or seed_file.parent.resolve()
+    )
     metadata_project_dir = _resolve_raw_metadata_project_dir(seed_data, stable_base=seed_base)
     if metadata_project_dir is not None:
         return _directory_for_runtime(metadata_project_dir)
@@ -585,6 +599,7 @@ async def _run_orchestrator(
     max_decomposition_depth: int | None = None,
     skip_completed: str | None = None,
     project_dir: Path | None = None,
+    project_fallback_dir: Path | None = None,
 ) -> None:
     """Run workflow via orchestrator mode.
 
@@ -600,6 +615,8 @@ async def _run_orchestrator(
         max_decomposition_depth: Optional recursive decomposition depth cap override.
         skip_completed: Optional path to a marker file for already-satisfied ACs.
         project_dir: Optional explicit project directory for seed path resolution.
+        project_fallback_dir: Directory to stand in for the Seed file's folder
+            when the Seed itself does not say where it belongs.
     """
     from ouroboros.core.seed import Seed
     from ouroboros.orchestrator import (
@@ -661,6 +678,7 @@ async def _run_orchestrator(
         seed_file,
         seed_data=seed_data,
         project_dir=project_dir,
+        fallback_dir=project_fallback_dir,
     )
     session_repo = SessionRepository(event_store)
     workspace: TaskWorkspace | None = None

--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -680,6 +680,11 @@ async def _run_orchestrator(
         project_dir=project_dir,
         fallback_dir=project_fallback_dir,
     )
+    # Always visible, never inferred by the reader: this is the directory the
+    # agent will write in. Seed metadata, a brownfield target, a caller's
+    # fallback, and `--project-dir` can each decide it, so printing the winner
+    # is the only way the person knows before the first write lands.
+    print_info(f"Project directory: {project_dir}")
     session_repo = SessionRepository(event_store)
     workspace: TaskWorkspace | None = None
     execution_id: str | None = None

--- a/tests/unit/cli/test_init_runtime.py
+++ b/tests/unit/cli/test_init_runtime.py
@@ -88,6 +88,104 @@ class TestInitWorkflowRuntimeHandoff:
         assert "project_dir" not in kwargs
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("raised", "expected"),
+        [(typer.Exit(1), typer.Exit), (KeyboardInterrupt(), KeyboardInterrupt)],
+    )
+    async def test_start_workflow_propagates_execution_failure(
+        self, raised: BaseException, expected: type[BaseException]
+    ) -> None:
+        """A failed workflow must not leave `init start` looking successful.
+
+        `_run_orchestrator` reports every failure as `typer.Exit(1)` and never
+        exits zero, so catching it printed the error and still returned normally
+        — a script could not tell a built product from a failed one.
+        """
+        with patch(
+            "ouroboros.cli.commands.run._run_orchestrator",
+            new=AsyncMock(side_effect=raised),
+        ):
+            with pytest.raises(expected) as exc_info:
+                await _start_workflow(Path("/tmp/generated-seed.yaml"))
+
+        if expected is typer.Exit:
+            assert exc_info.value.exit_code == 1
+
+    @pytest.mark.asyncio
+    async def test_accepting_the_final_prompt_hands_off_the_invocation_directory(
+        self, tmp_path: Path
+    ) -> None:
+        """The final wiring: accepting runs the Seed from where init was run."""
+        state = InterviewState(
+            interview_id="interview_handoff",
+            initial_context="Build a CLI",
+            status=InterviewStatus.COMPLETED,
+        )
+        engine = MagicMock()
+        engine.start_interview = AsyncMock(return_value=Result.ok(state))
+        engine.save_state = AsyncMock(return_value=Result.ok(tmp_path / "state.json"))
+        seed_path = tmp_path / "seed.yaml"
+        start_workflow = AsyncMock()
+
+        with (
+            patch("ouroboros.cli.commands.init._get_adapter", return_value=MagicMock()),
+            patch("ouroboros.cli.commands.init.InterviewEngine", return_value=engine),
+            patch(
+                "ouroboros.cli.commands.init._run_interview_loop",
+                new=AsyncMock(return_value=InterviewLoopOutcome(state=state)),
+            ),
+            patch(
+                "ouroboros.cli.commands.init._get_init_event_store",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "ouroboros.cli.commands.init._generate_seed_from_interview",
+                new=AsyncMock(return_value=(seed_path, SeedGenerationResult.SUCCESS)),
+            ),
+            patch("ouroboros.cli.commands.init.Confirm.ask", return_value=True),
+            patch("ouroboros.cli.commands.init._start_workflow", new=start_workflow),
+        ):
+            await _run_interview("Build a CLI", state_dir=tmp_path)
+
+        start_workflow.assert_awaited_once()
+        assert start_workflow.await_args.kwargs["project_fallback_dir"] == Path.cwd()
+
+    @pytest.mark.asyncio
+    async def test_declining_the_final_prompt_starts_no_workflow(self, tmp_path: Path) -> None:
+        """Declining stays side-effect free."""
+        state = InterviewState(
+            interview_id="interview_decline",
+            initial_context="Build a CLI",
+            status=InterviewStatus.COMPLETED,
+        )
+        engine = MagicMock()
+        engine.start_interview = AsyncMock(return_value=Result.ok(state))
+        engine.save_state = AsyncMock(return_value=Result.ok(tmp_path / "state.json"))
+        start_workflow = AsyncMock()
+
+        with (
+            patch("ouroboros.cli.commands.init._get_adapter", return_value=MagicMock()),
+            patch("ouroboros.cli.commands.init.InterviewEngine", return_value=engine),
+            patch(
+                "ouroboros.cli.commands.init._run_interview_loop",
+                new=AsyncMock(return_value=InterviewLoopOutcome(state=state)),
+            ),
+            patch(
+                "ouroboros.cli.commands.init._get_init_event_store",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "ouroboros.cli.commands.init._generate_seed_from_interview",
+                new=AsyncMock(return_value=(tmp_path / "seed.yaml", SeedGenerationResult.SUCCESS)),
+            ),
+            patch("ouroboros.cli.commands.init.Confirm.ask", return_value=False),
+            patch("ouroboros.cli.commands.init._start_workflow", new=start_workflow),
+        ):
+            await _run_interview("Build a CLI", state_dir=tmp_path)
+
+        start_workflow.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_aborted_interview_does_not_report_completion_or_generate_seed(
         self,
         tmp_path: Path,
@@ -228,6 +326,21 @@ class TestInitWorkflowRuntimeHandoff:
         assert exc_info.value.exit_code == 1
         run_loop.assert_not_awaited()
         mock_generate_seed.assert_not_awaited()
+
+    def test_cli_exit_code_reports_a_failed_workflow(self) -> None:
+        """The shell must see a failed build as a failure.
+
+        The command wrapper re-raises `typer.Exit`, so the orchestrator's
+        `typer.Exit(1)` now reaches the caller instead of being absorbed at the
+        handoff.
+        """
+        with patch(
+            "ouroboros.cli.commands.init._run_interview",
+            new=AsyncMock(side_effect=typer.Exit(1)),
+        ):
+            result = runner.invoke(app, ["init", "start", "Build a REST API"])
+
+        assert result.exit_code == 1
 
     def test_cli_forwards_llm_backend_to_interview_flow(self) -> None:
         """CLI wiring forwards the explicit LLM backend into the interview coroutine."""

--- a/tests/unit/cli/test_init_runtime.py
+++ b/tests/unit/cli/test_init_runtime.py
@@ -17,6 +17,7 @@ from ouroboros.cli.commands.init import (
     _resolve_init_llm_backend,
     _run_interview,
     _start_workflow,
+    _workflow_project_dir,
 )
 from ouroboros.cli.main import app
 from ouroboros.core.errors import ProviderError, ValidationError
@@ -39,12 +40,56 @@ class TestInitWorkflowRuntimeHandoff:
         ):
             await _start_workflow(
                 Path("/tmp/generated-seed.yaml"),
-                use_orchestrator=True,
                 runtime_backend="codex",
             )
 
         mock_run_orchestrator.assert_awaited_once()
         assert mock_run_orchestrator.await_args.kwargs["runtime_backend"] == "codex"
+
+    @pytest.mark.asyncio
+    async def test_start_workflow_runs_without_the_orchestrator_flag(self) -> None:
+        """Answering yes must execute the Seed, not print a placeholder.
+
+        The handoff used to run only when `--orchestrator` was passed and
+        otherwise printed "Standard workflow execution not yet implemented",
+        so the confirmation named an action it did not perform.
+        """
+        mock_run_orchestrator = AsyncMock()
+
+        with patch(
+            "ouroboros.cli.commands.run._run_orchestrator",
+            new=mock_run_orchestrator,
+        ):
+            await _start_workflow(Path("/tmp/generated-seed.yaml"))
+
+        mock_run_orchestrator.assert_awaited_once()
+
+    def test_workflow_project_dir_is_the_invocation_directory(self, tmp_path: Path) -> None:
+        """A Seed in the seed store must not send the agent into the seed store."""
+        seed_path = tmp_path / "seed_generated.yaml"
+        seed_path.write_text(
+            "goal: add deadlines\nbrownfield_context:\n  project_type: greenfield\n",
+            encoding="utf-8",
+        )
+
+        assert _workflow_project_dir(seed_path) == Path.cwd()
+
+    def test_workflow_project_dir_defers_to_a_brownfield_target(self, tmp_path: Path) -> None:
+        """A Seed that names its own target keeps precedence over the cwd."""
+        seed_path = tmp_path / "seed_brownfield.yaml"
+        seed_path.write_text(
+            f"goal: add deadlines\nbrownfield_context:\n  target_dir: {tmp_path}\n",
+            encoding="utf-8",
+        )
+
+        assert _workflow_project_dir(seed_path) is None
+
+    def test_workflow_project_dir_survives_an_unreadable_seed(self, tmp_path: Path) -> None:
+        """Resolution must not crash the handoff on a malformed Seed."""
+        seed_path = tmp_path / "seed_broken.yaml"
+        seed_path.write_text("goal: [unclosed", encoding="utf-8")
+
+        assert _workflow_project_dir(seed_path) == Path.cwd()
 
     @pytest.mark.asyncio
     async def test_aborted_interview_does_not_report_completion_or_generate_seed(

--- a/tests/unit/cli/test_init_runtime.py
+++ b/tests/unit/cli/test_init_runtime.py
@@ -17,7 +17,6 @@ from ouroboros.cli.commands.init import (
     _resolve_init_llm_backend,
     _run_interview,
     _start_workflow,
-    _workflow_project_dir,
 )
 from ouroboros.cli.main import app
 from ouroboros.core.errors import ProviderError, ValidationError
@@ -64,32 +63,29 @@ class TestInitWorkflowRuntimeHandoff:
 
         mock_run_orchestrator.assert_awaited_once()
 
-    def test_workflow_project_dir_is_the_invocation_directory(self, tmp_path: Path) -> None:
-        """A Seed in the seed store must not send the agent into the seed store."""
-        seed_path = tmp_path / "seed_generated.yaml"
-        seed_path.write_text(
-            "goal: add deadlines\nbrownfield_context:\n  project_type: greenfield\n",
-            encoding="utf-8",
-        )
+    @pytest.mark.asyncio
+    async def test_start_workflow_passes_the_invocation_directory_as_fallback(self) -> None:
+        """The handoff supplies a fallback dir; the run command still decides.
 
-        assert _workflow_project_dir(seed_path) == Path.cwd()
+        `init` deliberately does not read the Seed to pick a directory. A second
+        reader of the same metadata can disagree with the run command's own
+        rules — a stale `target_dir` was honored here and rejected there, which
+        landed execution back in `~/.ouroboros/seeds`.
+        """
+        mock_run_orchestrator = AsyncMock()
 
-    def test_workflow_project_dir_defers_to_a_brownfield_target(self, tmp_path: Path) -> None:
-        """A Seed that names its own target keeps precedence over the cwd."""
-        seed_path = tmp_path / "seed_brownfield.yaml"
-        seed_path.write_text(
-            f"goal: add deadlines\nbrownfield_context:\n  target_dir: {tmp_path}\n",
-            encoding="utf-8",
-        )
+        with patch(
+            "ouroboros.cli.commands.run._run_orchestrator",
+            new=mock_run_orchestrator,
+        ):
+            await _start_workflow(
+                Path("/tmp/generated-seed.yaml"),
+                project_fallback_dir=Path("/tmp/project"),
+            )
 
-        assert _workflow_project_dir(seed_path) is None
-
-    def test_workflow_project_dir_survives_an_unreadable_seed(self, tmp_path: Path) -> None:
-        """Resolution must not crash the handoff on a malformed Seed."""
-        seed_path = tmp_path / "seed_broken.yaml"
-        seed_path.write_text("goal: [unclosed", encoding="utf-8")
-
-        assert _workflow_project_dir(seed_path) == Path.cwd()
+        kwargs = mock_run_orchestrator.await_args.kwargs
+        assert kwargs["project_fallback_dir"] == Path("/tmp/project")
+        assert "project_dir" not in kwargs
 
     @pytest.mark.asyncio
     async def test_aborted_interview_does_not_report_completion_or_generate_seed(

--- a/tests/unit/core/test_seed_project_path_callers.py
+++ b/tests/unit/core/test_seed_project_path_callers.py
@@ -152,6 +152,94 @@ class TestCliRunCaller:
         result = _resolve_cli_project_dir(seed, seed_file)
         assert result == tmp_path.resolve()
 
+    def test_fallback_dir_stands_in_for_the_seed_file_folder(self, tmp_path: Path) -> None:
+        """A Seed that says nothing must not make its own folder the workspace.
+
+        `init` writes Seeds to `~/.ouroboros/seeds`, so the file's folder is the
+        Seed store, not a project.
+        """
+        from ouroboros.cli.commands.run import _resolve_cli_project_dir
+
+        seed_store = tmp_path / "seeds"
+        seed_store.mkdir()
+        seed_file = seed_store / "seed.yaml"
+        seed_file.write_text("goal: x\n", encoding="utf-8")
+        invocation = tmp_path / "project"
+        invocation.mkdir()
+
+        result = _resolve_cli_project_dir(self._seed(None), seed_file, fallback_dir=invocation)
+
+        assert result == invocation.resolve()
+
+    @pytest.mark.parametrize("target_kind", ["missing", "file"])
+    def test_unusable_brownfield_target_does_not_fall_back_to_the_seed_store(
+        self, tmp_path: Path, target_kind: str
+    ) -> None:
+        """An unusable `target_dir` must not send execution back to the store.
+
+        `_resolve_brownfield_target_dir` drops stale and file-valued targets, and
+        whatever fills that hole becomes the workspace. Before the fallback
+        existed that was the Seed file's own folder.
+        """
+        from ouroboros.cli.commands.run import _resolve_cli_project_dir
+
+        seed_store = tmp_path / "seeds"
+        seed_store.mkdir()
+        seed_file = seed_store / "seed.yaml"
+        seed_file.write_text("goal: x\n", encoding="utf-8")
+        invocation = tmp_path / "project"
+        invocation.mkdir()
+        target = str(tmp_path / "gone") if target_kind == "missing" else str(seed_file)
+
+        result = _resolve_cli_project_dir(
+            self._seed(None),
+            seed_file,
+            seed_data={"brownfield_context": {"target_dir": target}},
+            fallback_dir=invocation,
+        )
+
+        assert result == invocation.resolve()
+
+    def test_usable_brownfield_target_outranks_the_fallback(self, tmp_path: Path) -> None:
+        """A Seed that names a real target keeps it over the caller's directory."""
+        from ouroboros.cli.commands.run import _resolve_cli_project_dir
+
+        seed_store = tmp_path / "seeds"
+        seed_store.mkdir()
+        seed_file = seed_store / "seed.yaml"
+        seed_file.write_text("goal: x\n", encoding="utf-8")
+        invocation = tmp_path / "project"
+        invocation.mkdir()
+        target = tmp_path / "brownfield-repo"
+        target.mkdir()
+
+        result = _resolve_cli_project_dir(
+            self._seed(None),
+            seed_file,
+            seed_data={"brownfield_context": {"target_dir": str(target)}},
+            fallback_dir=invocation,
+        )
+
+        assert result == target.resolve()
+
+    def test_explicit_project_dir_outranks_the_fallback(self, tmp_path: Path) -> None:
+        """`--project-dir` stays the last word."""
+        from ouroboros.cli.commands.run import _resolve_cli_project_dir
+
+        seed_file = tmp_path / "seed.yaml"
+        seed_file.write_text("goal: x\n", encoding="utf-8")
+        explicit = tmp_path / "explicit"
+        explicit.mkdir()
+
+        result = _resolve_cli_project_dir(
+            self._seed(None),
+            seed_file,
+            project_dir=explicit,
+            fallback_dir=tmp_path / "ignored",
+        )
+
+        assert result == explicit.resolve()
+
     def test_contained_seed_uses_resolved_path(self, tmp_path: Path) -> None:
         from ouroboros.cli.commands.run import _resolve_cli_project_dir
 


### PR DESCRIPTION
Closes #2185.

## Summary

`init start` asks "Start workflow now? [y/n] (y)" and then does nothing unless the same invocation also passed `--orchestrator/-o` — the other branch printed "Would execute workflow from: …" plus "Standard workflow execution not yet implemented" and returned. The confirmation named an action it did not perform.

- The handoff now takes the single execution path `ouroboros run workflow` already takes by default. The flagged branch is deleted rather than inverted; that placeholder has been unimplemented since the pipeline landed (`4b72e0e7`, 2026-01), while `run workflow` moved to orchestrator-by-default (`--no-orchestrator/-O` to opt out). `init` was the one entry point still holding the opposite default.
- It also passes the invocation directory. Without it, `_resolve_cli_project_dir` falls back to the Seed's own location, and `init` writes Seeds to `~/.ouroboros/seeds` — so the agent would build inside the seed store. This is not hypothetical: running a generated Seed by hand today logs `cwd=/Users/<user>/.ouroboros/seeds`. An interview is conducted from the project it is about, so that directory is the project.
- A Seed that names a brownfield `target_dir` keeps precedence, and so does Seed metadata and an explicit `--project-dir`. All of that precedence lives in `_resolve_cli_project_dir`, which now takes a `fallback_dir` standing in for the Seed file's own folder; `init` supplies the invocation directory and interprets nothing itself.

Review round 1 corrected the shape of that second point. The first attempt had `init` read the Seed to decide, which meant two readers of the same metadata under different rules: `init` deferred to any non-empty `target_dir`, while `_resolve_brownfield_target_dir` drops targets that are missing or not directories — so a stale target fell through to the Seed's folder, back inside `~/.ouroboros/seeds`. Deleting the second reader closes that, and it also removes a crash: `yaml.safe_load` on a valid `- item` document made `init` raise `AttributeError` before the run command's own loader could report the real error.

`--orchestrator` still selects the interview's LLM backend (`_resolve_init_llm_backend`); only the workflow handoff stops reading it.

## Test plan

- [x] `uv run pytest tests/unit/cli tests/unit/core -q` — 2800 passed, 7 skipped
- [x] `uv run pytest tests/unit/mcp tests/unit/auto tests/unit/bigbang -q` — 5035 passed, 1 skipped
- [x] `uv run pytest tests/integration tests/conformance -q` — 304 passed, 4 skipped, 1 xfailed
- [x] `uv run ruff check`, `ruff format --check`, `mypy src/ouroboros/cli/commands/init.py` — clean
- [x] New tests: yes-without-`-o` reaches `_run_orchestrator`; the handoff forwards the invocation directory and no longer passes `project_dir`; and at the resolver — a Seed that says nothing resolves to the fallback, a missing or file-valued `target_dir` resolves to the fallback rather than the Seed store, a real `target_dir` outranks it, and `--project-dir` outranks everything

## Not in this PR

`ouroboros run workflow --no-orchestrator` has the same kind of placeholder (`run.py:1020`). It sits behind an explicit opt-out flag the user has to type rather than behind a confirmation prompt, so it is left alone.
