### PR TITLE
fix(project-paths): keep stable_base as root for relative file references

### DIFF
--- a/src/ouroboros/core/project_paths.py
+++ b/src/ouroboros/core/project_paths.py
@@ -151,9 +151,16 @@ def resolve_seed_project_path(seed: Any, *, stable_base: Path) -> SeedProjectPat
        by the seed generator as documentation pointers, often to individual
        *files* whose paths only make sense relative to the real project
        root. A reference candidate is only accepted when its resolved path
-       actually exists on disk: an existing file is returned as-is (callers
-       collapse to its parent), and a non-existent path is logged and
-       skipped so the caller's runtime cwd is never set to a synthetic
+       actually exists on disk. A **relative** reference that resolves to an
+       existing file proves ``stable_base`` is the base its seed-relative
+       paths (including ``expected_artifacts``) were written against, so
+       ``stable_base`` itself is returned as the project root — collapsing
+       the file to its parent instead pushed the runtime cwd into a
+       subdirectory (``app/widgets`` for ``app/widgets/kanban.js``) and made
+       every AC's artifact verification unsatisfiable (#2194). An absolute
+       existing-file reference carries no base information and is returned
+       as-is (callers collapse to its parent). A non-existent path is logged
+       and skipped so the caller's runtime cwd is never set to a synthetic
        join (e.g. ``<.ouroboros/seeds>/<reference.path>``).
 
     ``rejected`` is set only when at least one candidate was *encoded but
@@ -205,6 +212,8 @@ def resolve_seed_project_path(seed: Any, *, stable_base: Path) -> SeedProjectPat
                 stable_base=str(stable_base.resolve()),
             )
             continue
+        if resolved.is_file() and not Path(candidate).expanduser().is_absolute():
+            return SeedProjectPathResolution(path=stable_base.resolve(), rejected=False)
         return SeedProjectPathResolution(path=resolved, rejected=False)
 
     if containment_rejected:

--- a/tests/unit/cli/test_run_qa.py
+++ b/tests/unit/cli/test_run_qa.py
@@ -188,10 +188,16 @@ def test_resolve_cli_project_dir_rejects_raw_metadata_project_escape(
     assert "escapes" in mock_print.call_args[0][0]
 
 
-def test_resolve_cli_project_dir_uses_parent_when_context_reference_is_file(
+def test_resolve_cli_project_dir_keeps_target_dir_when_context_reference_is_file(
     tmp_path: Path,
 ) -> None:
-    """A primary file reference should not become the runtime cwd itself."""
+    """A primary file reference must not become the runtime cwd or drag it deeper.
+
+    The reference ``src/main.py`` resolved against ``target_dir``, which
+    proves ``target_dir`` is the base the seed's relative paths (including
+    ``expected_artifacts``) were written against. Collapsing to the file's
+    parent (``src/``) made those artifacts unresolvable (#2194).
+    """
     seed_file = tmp_path / "seed-library" / "seed.yaml"
     seed_file.parent.mkdir()
     seed_file.write_text("goal: ignored\n", encoding="utf-8")
@@ -212,10 +218,7 @@ def test_resolve_cli_project_dir_uses_parent_when_context_reference_is_file(
     }
     seed = Seed.from_dict(seed_data)
 
-    assert (
-        _resolve_cli_project_dir(seed, seed_file, seed_data=seed_data)
-        == source_file.parent.resolve()
-    )
+    assert _resolve_cli_project_dir(seed, seed_file, seed_data=seed_data) == target_dir.resolve()
 
 
 def test_resolve_cli_project_dir_global_seed_store_without_hints_does_not_return_home(

--- a/tests/unit/core/test_project_paths.py
+++ b/tests/unit/core/test_project_paths.py
@@ -324,22 +324,50 @@ class TestResolveSeedProjectPath:
         assert result.path is None
         assert result.rejected is False
 
-    def test_reference_existing_file_returned_for_caller_to_normalize(
+    def test_relative_file_reference_returns_stable_base_as_root(
         self,
         tmp_path: Path,
     ) -> None:
-        """An existing-file reference is returned so the caller can collapse it.
+        """A relative existing-file reference names ``stable_base`` as the root.
 
-        ``_resolve_cli_project_dir`` follows this with
-        ``_directory_for_runtime`` to use the file's parent directory as
-        the runtime cwd. Filtering files at the resolver level would
-        regress that established behavior.
+        The reference resolved *because* ``stable_base`` is the base its
+        seed-relative paths were written against, so the project root is
+        ``stable_base`` — not the file's parent. Collapsing to the parent
+        pushed the runtime cwd into a subdirectory and made every AC's
+        ``expected_artifacts`` (same relative-path convention) unresolvable
+        (#2194).
         """
         target_file = tmp_path / "src" / "events.py"
         target_file.parent.mkdir(parents=True)
         target_file.write_text("# fixture file")
 
         refs = [SimpleNamespace(path="src/events.py", role="primary")]
+        seed = SimpleNamespace(
+            metadata=None,
+            brownfield_context=SimpleNamespace(context_references=refs),
+        )
+
+        result = resolve_seed_project_path(seed, stable_base=tmp_path)
+
+        assert result.path == tmp_path.resolve()
+        assert result.rejected is False
+
+    def test_absolute_file_reference_still_returned_for_caller_to_normalize(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """An absolute existing-file reference keeps the collapse contract.
+
+        An absolute path carries no information about which base the seed's
+        relative paths were written against, so the resolver returns the file
+        as-is and the caller (``_directory_for_runtime``) collapses it to its
+        parent, as before.
+        """
+        target_file = tmp_path / "src" / "events.py"
+        target_file.parent.mkdir(parents=True)
+        target_file.write_text("# fixture file")
+
+        refs = [SimpleNamespace(path=str(target_file), role="primary")]
         seed = SimpleNamespace(
             metadata=None,
             brownfield_context=SimpleNamespace(context_references=refs),

--- a/tests/unit/core/test_seed_project_path_callers.py
+++ b/tests/unit/core/test_seed_project_path_callers.py
@@ -171,6 +171,38 @@ class TestCliRunCaller:
 
         assert result == invocation.resolve()
 
+    def test_relative_file_reference_keeps_the_invocation_directory_as_root(
+        self, tmp_path: Path
+    ) -> None:
+        """The interview handoff must not push the cwd into a subdirectory.
+
+        Regression for #2194: a brownfield seed carrying a primary
+        ``context_references`` file (``app/widgets/kanban.js``) collapsed the
+        runtime cwd to the file's parent (``app/widgets``), so every AC's
+        ``expected_artifacts`` — written relative to the project root —
+        resolved to ``app/widgets/app/widgets/...`` and failed verification.
+        """
+        from ouroboros.cli.commands.run import _resolve_cli_project_dir
+
+        seed_store = tmp_path / "seeds"
+        seed_store.mkdir()
+        seed_file = seed_store / "seed.yaml"
+        seed_file.write_text("goal: x\n", encoding="utf-8")
+        invocation = tmp_path / "project"
+        widget = invocation / "app" / "widgets" / "kanban.js"
+        widget.parent.mkdir(parents=True)
+        widget.write_text("// widget\n", encoding="utf-8")
+
+        refs = [SimpleNamespace(path="app/widgets/kanban.js", role="primary")]
+        seed = SimpleNamespace(
+            metadata=None,
+            brownfield_context=SimpleNamespace(context_references=refs),
+        )
+
+        result = _resolve_cli_project_dir(seed, seed_file, fallback_dir=invocation)
+
+        assert result == invocation.resolve()
+
     @pytest.mark.parametrize("target_kind", ["missing", "file"])
     def test_unusable_brownfield_target_does_not_fall_back_to_the_seed_store(
         self, tmp_path: Path, target_kind: str


### PR DESCRIPTION
Fixes #2194

## Problem

A brownfield seed carrying a primary `context_references` file entry (e.g. `app/widgets/kanban.js`) had that file accepted as a project-path candidate when it existed under `stable_base`, and callers collapsed it to the file's **parent** directory as the runtime cwd. Since `expected_artifacts` are written relative to the project root with the same path convention, the verify gate then looked for `<root>/app/widgets/app/widgets/kanban.js` — unsatisfiable — and **every AC failed regardless of what the worker produced**. Observed in the wild on a Kiro workshop run (3/3 ACs failed twice; details in #2194).

All three consumers reached the collapse:
- the interview "Start workflow now? → y" handoff (`init.py` passes only `project_fallback_dir`),
- plain `ouroboros run` without `--project-dir`,
- the MCP verification path (`_resolve_verification_working_dir`).

The central-seed guard in `_resolve_cli_project_dir` that acknowledges exactly this trap does not fire here, because generated seeds live in the global `~/.ouroboros/seeds` store where root detection intentionally returns `None` (#1312 home guard).

## Fix (minimal, one resolver site)

In `resolve_seed_project_path`: a **relative** reference that resolves to an existing **file** proves `stable_base` is the base the seed's relative paths were written against, so return `stable_base` itself as the project root. This fixes all three consumer paths at once.

Unchanged contracts:
- **absolute** file references carry no base information → still returned as-is for the caller's parent-collapse (`_directory_for_runtime`),
- directory references → returned as-is,
- metadata candidates (`project_dir` / `working_directory`) → untouched,
- containment (escape → `rejected=True`) and nonexistent-path skip behavior → untouched.

Bare relative filenames are behavior-neutral: the old parent-collapse already yielded `stable_base`.

## Tests

- `test_project_paths.py`: replaced the test pinning the old collapse with `test_relative_file_reference_returns_stable_base_as_root`, plus a new test pinning the preserved absolute-reference contract.
- `test_seed_project_path_callers.py`: new CLI-caller regression reproducing the kanban scenario end-to-end through `_resolve_cli_project_dir` (fallback dir = invocation dir, primary ref file exists → root stays the invocation dir).
- `test_run_qa.py`: updated the target_dir + file-reference test to expect `target_dir` as root (previous expectation encoded the bug); intent ("a file must not become the cwd itself") still holds.

`tests/unit` full run: 12916 passed; one unrelated flake (`test_goose_runtime_derives_stable_name_for_executor_seeded_handle`) fails only in the full parallel run and passes in isolation both with and without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)