### PR TITLE
fix(doctor): report non-UTF-8 installation JSON as failure

### DIFF
--- a/src/ouroboros/cli/commands/doctor.py
+++ b/src/ouroboros/cli/commands/doctor.py
@@ -48,6 +48,8 @@ class InstallSurface:
 def _read_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
     try:
         raw = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        return None, f"invalid UTF-8 at byte {exc.start}: {exc.reason}"
     except OSError as exc:
         return None, str(exc)
     try:

--- a/tests/unit/cli/test_install_doctor.py
+++ b/tests/unit/cli/test_install_doctor.py
@@ -684,6 +684,23 @@ def test_cli_install_doctor_json_uses_home(monkeypatch, tmp_path: Path) -> None:
     assert any(surface["name"] == "claude_plugin_launcher" for surface in payload)
 
 
+def test_cli_install_doctor_json_reports_non_utf8_manifest(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _write_current_install(tmp_path, version="1.2.3")
+    manifest = tmp_path / "plugins" / "ouroboros" / ".codex-plugin" / "plugin.json"
+    manifest.write_bytes(b"\xff")
+
+    result = runner.invoke(app, ["doctor", "install", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    by_name = {surface["name"]: surface for surface in payload}
+    assert by_name["codex_personal_plugin"]["status"] == "fail"
+    assert "invalid UTF-8" in by_name["codex_personal_plugin"]["message"]
+    assert by_name["claude_plugin_launcher"]["status"] == "pass"
+
+
 def test_cli_doctor_help_registered() -> None:
     result = runner.invoke(app, ["doctor", "--help"])
 


### PR DESCRIPTION
## Summary

- Catch UTF-8 decoding failures in the shared installation JSON reader.
- Report a failed surface while preserving valid `--json` output for the remaining checks.
- Cover the CLI path with a manifest containing an actual invalid UTF-8 byte.

## Test plan

- [x] `uv run pytest tests/unit/cli/test_install_doctor.py -q`
- [x] `uv run ruff check src/ouroboros/cli/commands/doctor.py tests/unit/cli/test_install_doctor.py`
- [x] `uv run ruff format --check src/ouroboros/cli/commands/doctor.py tests/unit/cli/test_install_doctor.py`

## Related issues

Closes #2198