### PR TITLE
feat(pi): deliver system prompt and tool allow-list natively

### DIFF
--- a/docs/runtime-capability-matrix.md
+++ b/docs/runtime-capability-matrix.md
@@ -100,7 +100,8 @@ allow-list, and `permission_mode`. Each is one of:
 > `--dangerously-skip-permissions` and `--yolo --accept-hooks`, respectively. Pi keeps the
 > requested mode in runtime metadata because its CLI does not expose an approval switch.
 > \*Pi's native `--append-system-prompt` and `--tools` flags deliver these parameters
-> directly; Pi binaries without those flags fall back to user-message composition and
+> directly; `--no-tools` enforces an explicit empty allow-list (all tools disabled).
+> Pi binaries without those flags fall back to user-message composition and
 > report `translated`.
 
 **Observability:** when a workflow supplies a parameter the active runtime does not honor

--- a/docs/runtime-capability-matrix.md
+++ b/docs/runtime-capability-matrix.md
@@ -102,7 +102,10 @@ allow-list, and `permission_mode`. Each is one of:
 > \*Pi's native `--append-system-prompt` and `--tools` flags deliver these parameters
 > directly; `--no-tools` enforces an explicit empty allow-list (all tools disabled).
 > Pi binaries without those flags fall back to user-message composition and
-> report `translated`.
+> report `translated`. A binary that has `--tools` but lacks `--no-tools` reports
+> `translated` for `tool_restriction_support` and **fails closed** when `tools=[]`
+> is requested — the runtime emits a `ToolRestrictionUnenforced` error instead of
+> silently widening to unrestricted access.
 
 **Observability:** when a workflow supplies a parameter the active runtime does not honor
 natively, the orchestrator surfaces a one-time notice (console + a structured

--- a/docs/runtime-capability-matrix.md
+++ b/docs/runtime-capability-matrix.md
@@ -80,15 +80,15 @@ allow-list, and `permission_mode`. Each is one of:
 
 | Parameter       | Claude Code | Codex | Gemini | Goose | Copilot | OpenCode | Hermes | Pi | Kiro |
 | --------------- | :---------: | :---: | :-----: | :---: | :-----: | :------: | :----: | :-: | :--: |
-| `system_prompt` | native | translated | translated | translated | translated | translated | translated | translated | translated |
+| `system_prompt` | native | translated | translated | translated | translated | translated | translated | native* | translated |
 | `permission_mode` | native | native | native | native | native | translated | translated | ignored | translated |
-| `tools` (allow-list) | native | translated | translated | translated | translated | translated | translated | translated | translated |
+| `tools` (allow-list) | native | translated | translated | translated | translated | translated | translated | native* | translated |
 | `reasoning_effort` | native | native | ignored | ignored | native | ignored | ignored | ignored | ignored |
 | `model` (per call) | native | native | ignored | ignored | ignored | ignored | ignored | ignored | ignored |
 
 > Most CLI runtimes compose the system prompt **into the user message** (e.g.
 > `## System Instructions\n...`) rather than passing a native system directive. Codex,
-> Gemini, Goose, Copilot, OpenCode, Hermes, and Pi also render requested tool
+> Gemini, Goose, Copilot, OpenCode, and Hermes also render requested tool
 > allow-lists only as prompt guidance, so `tools` is translated rather than a
 > native runtime allow-list when the list is non-empty. An explicit empty
 > allow-list (`tools=[]`) cannot be translated by those prompt-only composers
@@ -99,6 +99,9 @@ allow-list, and `permission_mode`. Each is one of:
 > OpenCode and Hermes translate full bypass onto
 > `--dangerously-skip-permissions` and `--yolo --accept-hooks`, respectively. Pi keeps the
 > requested mode in runtime metadata because its CLI does not expose an approval switch.
+> \*Pi's native `--append-system-prompt` and `--tools` flags deliver these parameters
+> directly; Pi binaries without those flags fall back to user-message composition and
+> report `translated`.
 
 **Observability:** when a workflow supplies a parameter the active runtime does not honor
 natively, the orchestrator surfaces a one-time notice (console + a structured

--- a/docs/runtime-guides/pi.md
+++ b/docs/runtime-guides/pi.md
@@ -84,7 +84,7 @@ For a normal execution task, Ouroboros launches:
 
 ```text
 pi --mode json [--model <MODEL>] [--session <SESSION_ID>]
-  [--append-system-prompt <SYSTEM>] [--tools <TOOLS>] <PROMPT>
+  [--append-system-prompt <SYSTEM>] [--tools <TOOLS>] [--no-tools] <PROMPT>
 ```
 
 | Argument | Why |
@@ -93,7 +93,8 @@ pi --mode json [--model <MODEL>] [--session <SESSION_ID>]
 | `--model` | Optional model override passed by the caller |
 | `--session` | Optional native Pi session id for targeted resume |
 | `--append-system-prompt` | Native delivery of Ouroboros' `system_prompt` parameter (appended to Pi's base coding prompt) |
-| `--tools` | Native tool allow-list: Pi's own flag enables only the listed tools. Claude-style names (`Read`, `Bash`, …) are mapped to Pi's lowercase built-ins (`read`, `bash`, …); unknown names pass through for extension tools |
+| `--tools` | Native tool allow-list: Pi's own flag enables only the listed tools. Claude-style names (`Read`, `Bash`, `Glob`, …) are mapped to Pi's lowercase built-ins (`read`, `bash`, `find`, …); unknown names pass through for extension tools |
+| `--no-tools` | Explicit tool-free mode: emitted when Ouroboros requests `tools=[]` (no tools allowed). Distinguishes "use defaults" (`tools=None`, flag omitted) from "disable all tools" |
 | `<PROMPT>` | The composed task prompt from Ouroboros |
 
 The native parameter flags are probed once via `pi --help`. Pi binaries without

--- a/docs/runtime-guides/pi.md
+++ b/docs/runtime-guides/pi.md
@@ -83,7 +83,8 @@ orchestrator:
 For a normal execution task, Ouroboros launches:
 
 ```text
-pi --mode json [--model <MODEL>] [--session <SESSION_ID>] <PROMPT>
+pi --mode json [--model <MODEL>] [--session <SESSION_ID>]
+  [--append-system-prompt <SYSTEM>] [--tools <TOOLS>] <PROMPT>
 ```
 
 | Argument | Why |
@@ -91,7 +92,15 @@ pi --mode json [--model <MODEL>] [--session <SESSION_ID>] <PROMPT>
 | `--mode json` | Requests Pi's headless JSONL event stream |
 | `--model` | Optional model override passed by the caller |
 | `--session` | Optional native Pi session id for targeted resume |
+| `--append-system-prompt` | Native delivery of Ouroboros' `system_prompt` parameter (appended to Pi's base coding prompt) |
+| `--tools` | Native tool allow-list: Pi's own flag enables only the listed tools. Claude-style names (`Read`, `Bash`, …) are mapped to Pi's lowercase built-ins (`read`, `bash`, …); unknown names pass through for extension tools |
 | `<PROMPT>` | The composed task prompt from Ouroboros |
+
+The native parameter flags are probed once via `pi --help`. Pi binaries without
+`--append-system-prompt` / `--tools` keep the previous behavior: system
+instructions and tool guidance are composed into the user message as text, and
+the runtime declares `system_prompt_support` / `tool_restriction_support` as
+`translated` instead of `native`.
 
 Ouroboros parses the initial `session` event into a `RuntimeHandle`, streams
 `message_update` `text_delta` events as assistant output, and reads terminal

--- a/src/ouroboros/orchestrator/pi_runtime.py
+++ b/src/ouroboros/orchestrator/pi_runtime.py
@@ -195,6 +195,14 @@ class PiRuntime:
     @property
     def capabilities(self) -> RuntimeCapabilities:
         native_params = self._supports_native_param_flags()
+        # Tool restriction is only truly NATIVE when *both* ``--tools`` (positive
+        # allow-list) and ``--no-tools`` (disable all) are available.  A Pi
+        # binary that ships ``--tools`` but not ``--no-tools`` cannot enforce
+        # ``tools=[]``; reporting NATIVE would silently widen to unrestricted.
+        # Mark that partial state as TRANSLATED so the negotiation layer can
+        # surface the gap (and ``_tool_restriction_support_for_request`` correctly
+        # downgrades empty-list requests to IGNORED).
+        full_tool_restriction = native_params and self._supports_no_tools_flag()
         return RuntimeCapabilities(
             skill_dispatch=True,
             targeted_resume=True,
@@ -207,7 +215,7 @@ class PiRuntime:
                 ParamSupport.NATIVE if native_params else ParamSupport.TRANSLATED
             ),
             tool_restriction_support=(
-                ParamSupport.NATIVE if native_params else ParamSupport.TRANSLATED
+                ParamSupport.NATIVE if full_tool_restriction else ParamSupport.TRANSLATED
             ),
             permission_mode_support=ParamSupport.IGNORED,
             session_signals=SessionSignalCapabilities(
@@ -517,6 +525,29 @@ class PiRuntime:
         if tools and not native_params:
             tool_list = "\n".join(f"- {t}" for t in tools)
             composed_parts.append(f"## Tooling Guidance\nPrefer these tools:\n{tool_list}")
+
+        # Fail closed: when the caller requests tools=[] (disable all tools)
+        # and the Pi CLI lacks --no-tools, we cannot enforce that restriction.
+        # Rather than silently widening to unrestricted, emit an explicit error.
+        if tools is not None and not tools and native_params and not self._supports_no_tools_flag():
+            yield AgentMessage(
+                type="result",
+                content=(
+                    f"{self._display_name} cannot enforce tools=[] (no-tools restriction): "
+                    "installed Pi CLI lacks --no-tools flag. "
+                    "Refusing to execute with silently unrestricted tool access."
+                ),
+                data={
+                    "subtype": "error",
+                    "error_type": "ToolRestrictionUnenforced",
+                    "parameter": "tools",
+                    "requested": [],
+                    "effective": "unrestricted",
+                },
+                resume_handle=current_handle,
+            )
+            return
+
         composed_parts.append(prompt)
         composed_prompt = "\n\n".join(p for p in composed_parts if p.strip())
 

--- a/src/ouroboros/orchestrator/pi_runtime.py
+++ b/src/ouroboros/orchestrator/pi_runtime.py
@@ -48,23 +48,32 @@ _SAFE_SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 _MAX_LINE_BUFFER_BYTES = 50 * 1024 * 1024  # 50 MB
 
 # Ouroboros speaks a Claude-style capitalized tool vocabulary while Pi's
-# built-in tools are lowercase (``read``, ``bash``, ``edit``, ``write``).
-# Unknown names pass through unchanged so extension/custom tool names keep
-# working; unmatched allow-list entries are inert for Pi.
+# built-in tools are lowercase (``read``, ``bash``, ``edit``, ``write``,
+# ``grep``, ``find``, ``ls``).  Unknown names pass through unchanged so
+# extension/custom tool names keep working; unmatched allow-list entries
+# are inert for Pi.
 _PI_TOOL_FLAG_NAMES: dict[str, str] = {
     "Read": "read",
     "Write": "write",
     "Edit": "edit",
     "Bash": "bash",
-    "Glob": "glob",
+    "Command": "bash",
+    "Execute": "bash",
+    "Glob": "find",
     "Grep": "grep",
+    "LS": "ls",
+    "Ls": "ls",
 }
 
 _NATIVE_PARAM_PROBE_TIMEOUT_SECONDS = 10.0
 
 
-def _probe_pi_native_param_flags(cli_path: str) -> bool:
-    """Detect whether the Pi CLI accepts ``--append-system-prompt`` and ``--tools``.
+def _probe_pi_native_param_flags(cli_path: str) -> tuple[bool, bool]:
+    """Detect whether the Pi CLI accepts native parameter flags.
+
+    Returns a tuple ``(has_tools_flag, has_no_tools_flag)`` where:
+    - ``has_tools_flag`` means ``--append-system-prompt`` and ``--tools`` are present.
+    - ``has_no_tools_flag`` means ``--no-tools`` is also present.
 
     Both flags have shipped with Pi for a long time, but a missing or very old
     binary must keep working: probing ``--help`` once lets the runtime fall
@@ -78,11 +87,13 @@ def _probe_pi_native_param_flags(cli_path: str) -> bool:
             timeout=_NATIVE_PARAM_PROBE_TIMEOUT_SECONDS,
         )
     except (OSError, subprocess.TimeoutExpired, ValueError):
-        return False
+        return (False, False)
     if result.returncode != 0:
-        return False
+        return (False, False)
     help_text = f"{result.stdout}\n{result.stderr}"
-    return "--append-system-prompt" in help_text and "--tools" in help_text
+    has_tools = "--append-system-prompt" in help_text and "--tools" in help_text
+    has_no_tools = "--no-tools" in help_text
+    return (has_tools, has_no_tools)
 
 
 class PiRuntime:
@@ -125,7 +136,7 @@ class PiRuntime:
         **_kwargs: Any,
     ) -> None:
         self._cli_path = self._resolve_cli_path(cli_path)
-        self._native_param_flags: bool | None = None
+        self._native_param_flags: tuple[bool, bool] | None = None
         self._permission_mode_requested = permission_mode is not None
         self._permission_mode = permission_mode
         self._model = model
@@ -210,7 +221,13 @@ class PiRuntime:
         """Lazily probe the CLI once for native parameter flag support."""
         if self._native_param_flags is None:
             self._native_param_flags = _probe_pi_native_param_flags(self._cli_path)
-        return self._native_param_flags
+        return self._native_param_flags[0]
+
+    def _supports_no_tools_flag(self) -> bool:
+        """Return whether the Pi CLI supports ``--no-tools``."""
+        if self._native_param_flags is None:
+            self._native_param_flags = _probe_pi_native_param_flags(self._cli_path)
+        return self._native_param_flags[1]
 
     # -- CLI resolution ----------------------------------------------------
 
@@ -254,9 +271,13 @@ class PiRuntime:
         if self._supports_native_param_flags():
             if system_prompt:
                 command.extend(["--append-system-prompt", system_prompt])
-            if tools:
-                pi_names = ",".join(_PI_TOOL_FLAG_NAMES.get(tool, tool) for tool in tools)
-                command.extend(["--tools", pi_names])
+            if tools is not None:
+                if tools:
+                    pi_names = ",".join(_PI_TOOL_FLAG_NAMES.get(tool, tool) for tool in tools)
+                    command.extend(["--tools", pi_names])
+                elif self._supports_no_tools_flag():
+                    # Explicit empty list means "disable all tools"; use --no-tools.
+                    command.append("--no-tools")
 
         command.append(prompt)
         return command

--- a/src/ouroboros/orchestrator/pi_runtime.py
+++ b/src/ouroboros/orchestrator/pi_runtime.py
@@ -16,6 +16,7 @@ import os
 from pathlib import Path
 import re
 import shutil
+import subprocess
 from typing import Any
 
 from ouroboros.core.errors import ProviderError
@@ -45,6 +46,43 @@ log = get_logger(__name__)
 
 _SAFE_SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 _MAX_LINE_BUFFER_BYTES = 50 * 1024 * 1024  # 50 MB
+
+# Ouroboros speaks a Claude-style capitalized tool vocabulary while Pi's
+# built-in tools are lowercase (``read``, ``bash``, ``edit``, ``write``).
+# Unknown names pass through unchanged so extension/custom tool names keep
+# working; unmatched allow-list entries are inert for Pi.
+_PI_TOOL_FLAG_NAMES: dict[str, str] = {
+    "Read": "read",
+    "Write": "write",
+    "Edit": "edit",
+    "Bash": "bash",
+    "Glob": "glob",
+    "Grep": "grep",
+}
+
+_NATIVE_PARAM_PROBE_TIMEOUT_SECONDS = 10.0
+
+
+def _probe_pi_native_param_flags(cli_path: str) -> bool:
+    """Detect whether the Pi CLI accepts ``--append-system-prompt`` and ``--tools``.
+
+    Both flags have shipped with Pi for a long time, but a missing or very old
+    binary must keep working: probing ``--help`` once lets the runtime fall
+    back to composing system prompt and tool guidance into the user message.
+    """
+    try:
+        result = subprocess.run(  # noqa: ASYNC100 - one-shot startup probe
+            [cli_path, "--help"],
+            capture_output=True,
+            text=True,
+            timeout=_NATIVE_PARAM_PROBE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired, ValueError):
+        return False
+    if result.returncode != 0:
+        return False
+    help_text = f"{result.stdout}\n{result.stderr}"
+    return "--append-system-prompt" in help_text and "--tools" in help_text
 
 
 class PiRuntime:
@@ -87,6 +125,7 @@ class PiRuntime:
         **_kwargs: Any,
     ) -> None:
         self._cli_path = self._resolve_cli_path(cli_path)
+        self._native_param_flags: bool | None = None
         self._permission_mode_requested = permission_mode is not None
         self._permission_mode = permission_mode
         self._model = model
@@ -144,15 +183,21 @@ class PiRuntime:
 
     @property
     def capabilities(self) -> RuntimeCapabilities:
+        native_params = self._supports_native_param_flags()
         return RuntimeCapabilities(
             skill_dispatch=True,
             targeted_resume=True,
             structured_output=True,
-            # System prompt and tool guidance are composed into the user
-            # message, not passed as native runtime parameters. Pi also has no
-            # permission-mode flag.
-            system_prompt_support=ParamSupport.TRANSLATED,
-            tool_restriction_support=ParamSupport.TRANSLATED,
+            # ``--append-system-prompt`` and ``--tools`` deliver the system
+            # prompt and the tool allow-list natively when the installed Pi
+            # supports them; older binaries fall back to user-message
+            # composition. Pi has no permission-mode flag (no approval gate).
+            system_prompt_support=(
+                ParamSupport.NATIVE if native_params else ParamSupport.TRANSLATED
+            ),
+            tool_restriction_support=(
+                ParamSupport.NATIVE if native_params else ParamSupport.TRANSLATED
+            ),
             permission_mode_support=ParamSupport.IGNORED,
             session_signals=SessionSignalCapabilities(
                 inform_delivery=True,
@@ -160,6 +205,12 @@ class PiRuntime:
                 after_turn_delivery=True,
             ),
         )
+
+    def _supports_native_param_flags(self) -> bool:
+        """Lazily probe the CLI once for native parameter flag support."""
+        if self._native_param_flags is None:
+            self._native_param_flags = _probe_pi_native_param_flags(self._cli_path)
+        return self._native_param_flags
 
     # -- CLI resolution ----------------------------------------------------
 
@@ -178,12 +229,17 @@ class PiRuntime:
         *,
         prompt: str,
         resume_session_id: str | None = None,
+        system_prompt: str | None = None,
+        tools: list[str] | None = None,
     ) -> list[str]:
         """Assemble the CLI argument list for ``pi --mode json <prompt>``.
 
         Pi's documented JSON mode accepts the task as a positional message
         argument. Keep that contract explicit instead of relying on stdin
-        behavior that is not documented for JSON mode.
+        behavior that is not documented for JSON mode. When the installed Pi
+        supports them, ``--append-system-prompt`` and ``--tools`` carry the
+        system prompt and the tool allow-list as native runtime parameters
+        instead of prompt text.
         """
         command = [self._cli_path, "--mode", "json"]
 
@@ -194,6 +250,13 @@ class PiRuntime:
             if not _SAFE_SESSION_ID_PATTERN.match(resume_session_id):
                 raise ValueError(f"Invalid resume_session_id: {resume_session_id!r}")
             command.extend(["--session", resume_session_id])
+
+        if self._supports_native_param_flags():
+            if system_prompt:
+                command.extend(["--append-system-prompt", system_prompt])
+            if tools:
+                pi_names = ",".join(_PI_TOOL_FLAG_NAMES.get(tool, tool) for tool in tools)
+                command.extend(["--tools", pi_names])
 
         command.append(prompt)
         return command
@@ -426,10 +489,11 @@ class PiRuntime:
             current_handle.native_session_id if current_handle is not None else resume_session_id
         )
 
+        native_params = self._supports_native_param_flags()
         composed_parts = []
-        if system_prompt:
+        if system_prompt and not native_params:
             composed_parts.append(f"## System Instructions\n{system_prompt}")
-        if tools:
+        if tools and not native_params:
             tool_list = "\n".join(f"- {t}" for t in tools)
             composed_parts.append(f"## Tooling Guidance\nPrefer these tools:\n{tool_list}")
         composed_parts.append(prompt)
@@ -437,7 +501,10 @@ class PiRuntime:
 
         try:
             command = self._build_command(
-                prompt=composed_prompt, resume_session_id=attempted_resume
+                prompt=composed_prompt,
+                resume_session_id=attempted_resume,
+                system_prompt=system_prompt,
+                tools=tools,
             )
         except Exception as e:
             yield AgentMessage(

--- a/tests/unit/orchestrator/test_pi_runtime.py
+++ b/tests/unit/orchestrator/test_pi_runtime.py
@@ -80,7 +80,7 @@ def test_build_command_uses_documented_json_prompt_argument() -> None:
 
 def test_build_command_passes_native_system_prompt_and_tools_when_supported() -> None:
     runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
-    runtime._native_param_flags = True
+    runtime._native_param_flags = (True, True)
 
     command = runtime._build_command(
         prompt="Do the task",
@@ -102,7 +102,7 @@ def test_build_command_passes_native_system_prompt_and_tools_when_supported() ->
 
 def test_build_command_skips_native_flags_when_unsupported() -> None:
     runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
-    runtime._native_param_flags = False
+    runtime._native_param_flags = (False, False)
 
     command = runtime._build_command(
         prompt="Do the task",
@@ -115,9 +115,9 @@ def test_build_command_skips_native_flags_when_unsupported() -> None:
 
 def test_capabilities_follow_probed_native_param_support() -> None:
     native = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
-    native._native_param_flags = True
+    native._native_param_flags = (True, True)
     legacy = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
-    legacy._native_param_flags = False
+    legacy._native_param_flags = (False, False)
 
     assert native.capabilities.system_prompt_support == ParamSupport.NATIVE
     assert native.capabilities.tool_restriction_support == ParamSupport.NATIVE
@@ -365,7 +365,7 @@ async def test_execute_task_passes_params_natively_when_supported() -> None:
         returncode=0,
     )
     runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
-    runtime._native_param_flags = True
+    runtime._native_param_flags = (True, True)
 
     with patch("asyncio.create_subprocess_exec", return_value=process) as mock_exec:
         _ = [
@@ -402,7 +402,7 @@ async def test_execute_task_composes_params_into_prompt_when_unsupported() -> No
         returncode=0,
     )
     runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
-    runtime._native_param_flags = False
+    runtime._native_param_flags = (False, False)
 
     with patch("asyncio.create_subprocess_exec", return_value=process) as mock_exec:
         _ = [
@@ -564,3 +564,149 @@ def test_runtime_handle_accepts_pi_backend() -> None:
     handle = RuntimeHandle(backend="pi_cli", native_session_id="session-1")
 
     assert handle.backend == "pi"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for PR #2203 review blockers
+# ---------------------------------------------------------------------------
+
+
+def test_build_command_emits_no_tools_for_explicit_empty_list() -> None:
+    """Blocker 1: tools=[] must emit --no-tools, not be silently dropped."""
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = (True, True)
+
+    command = runtime._build_command(prompt="Do the task", tools=[])
+
+    assert "--no-tools" in command
+    assert "--tools" not in command
+    assert command == ["/tmp/pi", "--mode", "json", "--no-tools", "Do the task"]
+
+
+def test_build_command_omits_tools_flag_for_none() -> None:
+    """tools=None means 'use defaults'; neither --tools nor --no-tools should appear."""
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = (True, True)
+
+    command = runtime._build_command(prompt="Do the task", tools=None)
+
+    assert "--tools" not in command
+    assert "--no-tools" not in command
+    assert command == ["/tmp/pi", "--mode", "json", "Do the task"]
+
+
+def test_build_command_empty_tools_without_no_tools_support() -> None:
+    """When Pi lacks --no-tools, tools=[] falls through without error."""
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = (True, False)  # has --tools but not --no-tools
+
+    command = runtime._build_command(prompt="Do the task", tools=[])
+
+    assert "--tools" not in command
+    assert "--no-tools" not in command
+    assert command == ["/tmp/pi", "--mode", "json", "Do the task"]
+
+
+def test_glob_maps_to_pi_find_builtin() -> None:
+    """Blocker 2: Glob must map to Pi's 'find', not nonexistent 'glob'."""
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = (True, True)
+
+    command = runtime._build_command(prompt="Do it", tools=["Glob"])
+
+    assert command == ["/tmp/pi", "--mode", "json", "--tools", "find", "Do it"]
+
+
+def test_command_and_execute_map_to_pi_bash_builtin() -> None:
+    """Command and Execute must map to Pi's 'bash' built-in."""
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = (True, True)
+
+    command = runtime._build_command(prompt="Do it", tools=["Command", "Execute"])
+
+    assert command == ["/tmp/pi", "--mode", "json", "--tools", "bash,bash", "Do it"]
+
+
+def test_all_known_ouroboros_builtins_map_to_valid_pi_tools() -> None:
+    """Every known Ouroboros built-in must map to a documented Pi tool name."""
+    from ouroboros.orchestrator.pi_runtime import _PI_TOOL_FLAG_NAMES
+
+    # Pi's documented built-in tools
+    pi_builtins = {"read", "write", "edit", "bash", "grep", "find", "ls"}
+
+    for ouroboros_name, pi_name in _PI_TOOL_FLAG_NAMES.items():
+        assert pi_name in pi_builtins, (
+            f"Ouroboros tool {ouroboros_name!r} maps to {pi_name!r} "
+            f"which is not a documented Pi built-in: {pi_builtins}"
+        )
+
+
+def test_ls_maps_to_pi_ls_builtin() -> None:
+    """LS/Ls must map to Pi's 'ls' built-in."""
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = (True, True)
+
+    command_upper = runtime._build_command(prompt="Do it", tools=["LS"])
+    command_title = runtime._build_command(prompt="Do it", tools=["Ls"])
+
+    assert "--tools" in command_upper
+    assert command_upper[command_upper.index("--tools") + 1] == "ls"
+    assert command_title[command_title.index("--tools") + 1] == "ls"
+
+
+@pytest.mark.asyncio
+async def test_execute_task_emits_no_tools_for_empty_list() -> None:
+    """End-to-end: execute_task with tools=[] should emit --no-tools natively."""
+    process = _FakeProcess(
+        stdout_lines=[
+            _jsonl_event({"type": "session", "id": "session-1"}),
+            _jsonl_event(
+                {
+                    "type": "agent_end",
+                    "messages": [
+                        {"role": "assistant", "content": [{"type": "text", "text": "Done."}]}
+                    ],
+                }
+            ),
+        ],
+        stderr_lines=[],
+        returncode=0,
+    )
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = (True, True)
+
+    with patch("asyncio.create_subprocess_exec", return_value=process) as mock_exec:
+        _ = [msg async for msg in runtime.execute_task("Do it", tools=[])]
+
+    args = mock_exec.call_args.args
+    assert "--no-tools" in args
+    assert "--tools" not in args
+
+
+@pytest.mark.asyncio
+async def test_execute_task_tools_none_omits_all_tool_flags() -> None:
+    """End-to-end: execute_task with tools=None should omit --tools and --no-tools."""
+    process = _FakeProcess(
+        stdout_lines=[
+            _jsonl_event({"type": "session", "id": "session-1"}),
+            _jsonl_event(
+                {
+                    "type": "agent_end",
+                    "messages": [
+                        {"role": "assistant", "content": [{"type": "text", "text": "Done."}]}
+                    ],
+                }
+            ),
+        ],
+        stderr_lines=[],
+        returncode=0,
+    )
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = (True, True)
+
+    with patch("asyncio.create_subprocess_exec", return_value=process) as mock_exec:
+        _ = [msg async for msg in runtime.execute_task("Do it", tools=None)]
+
+    args = mock_exec.call_args.args
+    assert "--no-tools" not in args
+    assert "--tools" not in args

--- a/tests/unit/orchestrator/test_pi_runtime.py
+++ b/tests/unit/orchestrator/test_pi_runtime.py
@@ -78,6 +78,56 @@ def test_build_command_uses_documented_json_prompt_argument() -> None:
     ]
 
 
+def test_build_command_passes_native_system_prompt_and_tools_when_supported() -> None:
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = True
+
+    command = runtime._build_command(
+        prompt="Do the task",
+        system_prompt="Be a careful test runner.",
+        tools=["Read", "Edit", "Bash", "custom_tool"],
+    )
+
+    assert command == [
+        "/tmp/pi",
+        "--mode",
+        "json",
+        "--append-system-prompt",
+        "Be a careful test runner.",
+        "--tools",
+        "read,edit,bash,custom_tool",
+        "Do the task",
+    ]
+
+
+def test_build_command_skips_native_flags_when_unsupported() -> None:
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = False
+
+    command = runtime._build_command(
+        prompt="Do the task",
+        system_prompt="Be a careful test runner.",
+        tools=["Read"],
+    )
+
+    assert command == ["/tmp/pi", "--mode", "json", "Do the task"]
+
+
+def test_capabilities_follow_probed_native_param_support() -> None:
+    native = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    native._native_param_flags = True
+    legacy = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    legacy._native_param_flags = False
+
+    assert native.capabilities.system_prompt_support == ParamSupport.NATIVE
+    assert native.capabilities.tool_restriction_support == ParamSupport.NATIVE
+    assert legacy.capabilities.system_prompt_support == ParamSupport.TRANSLATED
+    assert legacy.capabilities.tool_restriction_support == ParamSupport.TRANSLATED
+    # Pi has no approval gate: permission mode stays ignored either way.
+    assert native.capabilities.permission_mode_support == ParamSupport.IGNORED
+    assert legacy.capabilities.permission_mode_support == ParamSupport.IGNORED
+
+
 def test_tracks_requested_permission_mode_and_declares_ignored_support() -> None:
     default_runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
     requested_runtime = PiRuntime(
@@ -295,6 +345,76 @@ async def test_execute_task_streams_delta_and_final_result() -> None:
     assert result.data == {"subtype": "success", "returncode": 0}
     assert result.resume_handle is not None
     assert result.resume_handle.native_session_id == "session-1"
+
+
+@pytest.mark.asyncio
+async def test_execute_task_passes_params_natively_when_supported() -> None:
+    process = _FakeProcess(
+        stdout_lines=[
+            _jsonl_event({"type": "session", "id": "session-1"}),
+            _jsonl_event(
+                {
+                    "type": "agent_end",
+                    "messages": [
+                        {"role": "assistant", "content": [{"type": "text", "text": "Hello"}]}
+                    ],
+                }
+            ),
+        ],
+        stderr_lines=[],
+        returncode=0,
+    )
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = True
+
+    with patch("asyncio.create_subprocess_exec", return_value=process) as mock_exec:
+        _ = [
+            msg async for msg in runtime.execute_task("Do it", tools=["Read"], system_prompt="Sys")
+        ]
+
+    assert mock_exec.call_args.args == (
+        "/tmp/pi",
+        "--mode",
+        "json",
+        "--append-system-prompt",
+        "Sys",
+        "--tools",
+        "read",
+        "Do it",
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_task_composes_params_into_prompt_when_unsupported() -> None:
+    process = _FakeProcess(
+        stdout_lines=[
+            _jsonl_event({"type": "session", "id": "session-1"}),
+            _jsonl_event(
+                {
+                    "type": "agent_end",
+                    "messages": [
+                        {"role": "assistant", "content": [{"type": "text", "text": "Hello"}]}
+                    ],
+                }
+            ),
+        ],
+        stderr_lines=[],
+        returncode=0,
+    )
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = False
+
+    with patch("asyncio.create_subprocess_exec", return_value=process) as mock_exec:
+        _ = [
+            msg async for msg in runtime.execute_task("Do it", tools=["Read"], system_prompt="Sys")
+        ]
+
+    assert mock_exec.call_args.args == (
+        "/tmp/pi",
+        "--mode",
+        "json",
+        "## System Instructions\nSys\n\n## Tooling Guidance\nPrefer these tools:\n- Read\n\nDo it",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_pi_runtime.py
+++ b/tests/unit/orchestrator/test_pi_runtime.py
@@ -128,6 +128,22 @@ def test_capabilities_follow_probed_native_param_support() -> None:
     assert legacy.capabilities.permission_mode_support == ParamSupport.IGNORED
 
 
+def test_capabilities_partial_support_has_tools_but_no_no_tools() -> None:
+    """PR #2203 blocker: partial Pi (has --tools, lacks --no-tools) must NOT
+    report NATIVE for tool_restriction_support. It can restrict to a set but
+    cannot disable all tools — reporting NATIVE would silently widen tools=[]
+    to unrestricted."""
+    partial = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    partial._native_param_flags = (True, False)  # has --tools but not --no-tools
+
+    caps = partial.capabilities
+    # system_prompt is still native (only needs --append-system-prompt)
+    assert caps.system_prompt_support == ParamSupport.NATIVE
+    # tool restriction is TRANSLATED because empty-list cannot be enforced
+    assert caps.tool_restriction_support == ParamSupport.TRANSLATED
+    assert caps.permission_mode_support == ParamSupport.IGNORED
+
+
 def test_tracks_requested_permission_mode_and_declares_ignored_support() -> None:
     default_runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
     requested_runtime = PiRuntime(
@@ -710,3 +726,196 @@ async def test_execute_task_tools_none_omits_all_tool_flags() -> None:
     args = mock_exec.call_args.args
     assert "--no-tools" not in args
     assert "--tools" not in args
+
+
+# ---------------------------------------------------------------------------
+# PR #2203 Round 2: Partial support negotiation + fail-closed regressions
+# ---------------------------------------------------------------------------
+
+
+def test_negotiation_partial_pi_tools_empty_reports_ignored() -> None:
+    """When Pi has --tools but not --no-tools, requesting tools=[] must surface
+    as IGNORED through the parameter negotiation layer — never silently widen."""
+    from ouroboros.orchestrator.runtime_param_negotiation import (
+        negotiate_execution_params,
+    )
+
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = (True, False)  # partial support
+
+    degradations = negotiate_execution_params(
+        runtime.capabilities,
+        system_prompt=None,
+        tools=[],
+        permission_mode=None,
+    )
+
+    assert len(degradations) == 1
+    d = degradations[0]
+    assert d.parameter == "tools"
+    assert d.support == ParamSupport.IGNORED
+    assert "silently dropped" in d.detail
+
+
+def test_negotiation_partial_pi_tools_nonempty_reports_translated() -> None:
+    """Partial Pi with a non-empty tools list: TRANSLATED (can restrict, but lossily)."""
+    from ouroboros.orchestrator.runtime_param_negotiation import (
+        negotiate_execution_params,
+    )
+
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = (True, False)
+
+    degradations = negotiate_execution_params(
+        runtime.capabilities,
+        system_prompt=None,
+        tools=["Read", "Edit"],
+        permission_mode=None,
+    )
+
+    assert len(degradations) == 1
+    d = degradations[0]
+    assert d.parameter == "tools"
+    assert d.support == ParamSupport.TRANSLATED
+
+
+def test_negotiation_full_pi_tools_empty_no_degradation() -> None:
+    """Full Pi support (has --tools AND --no-tools): tools=[] is NATIVE, no degradation."""
+    from ouroboros.orchestrator.runtime_param_negotiation import (
+        negotiate_execution_params,
+    )
+
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = (True, True)
+
+    degradations = negotiate_execution_params(
+        runtime.capabilities,
+        system_prompt=None,
+        tools=[],
+        permission_mode=None,
+    )
+
+    assert len(degradations) == 0
+
+
+@pytest.mark.asyncio
+async def test_execute_task_fails_closed_tools_empty_partial_support() -> None:
+    """PR #2203 critical regression: tools=[] on partial Pi (has --tools, lacks
+    --no-tools) must fail closed with ToolRestrictionUnenforced error, never
+    silently widen to unrestricted tool access."""
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = (True, False)
+
+    with patch("asyncio.create_subprocess_exec") as mock_exec:
+        messages = [msg async for msg in runtime.execute_task("Do it", tools=[])]
+
+    # Must NOT have spawned a process — fail closed means no execution.
+    mock_exec.assert_not_called()
+
+    # Must emit exactly one error result.
+    assert len(messages) == 1
+    result = messages[0]
+    assert result.type == "result"
+    assert result.is_error is True
+    assert "ToolRestrictionUnenforced" in (result.data or {}).get("error_type", "")
+    assert "cannot enforce tools=[]" in result.content
+    assert (result.data or {}).get("requested") == []
+    assert (result.data or {}).get("effective") == "unrestricted"
+
+
+@pytest.mark.asyncio
+async def test_execute_task_succeeds_tools_empty_full_support() -> None:
+    """Full Pi (has --no-tools): tools=[] must succeed with --no-tools in command."""
+    process = _FakeProcess(
+        stdout_lines=[
+            _jsonl_event({"type": "session", "id": "session-1"}),
+            _jsonl_event(
+                {
+                    "type": "agent_end",
+                    "messages": [
+                        {"role": "assistant", "content": [{"type": "text", "text": "Done."}]}
+                    ],
+                }
+            ),
+        ],
+        stderr_lines=[],
+        returncode=0,
+    )
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = (True, True)
+
+    with patch("asyncio.create_subprocess_exec", return_value=process) as mock_exec:
+        messages = [msg async for msg in runtime.execute_task("Do it", tools=[])]
+
+    # Process WAS spawned with --no-tools
+    mock_exec.assert_called_once()
+    args = mock_exec.call_args.args
+    assert "--no-tools" in args
+    # Last message should be successful result
+    result = [m for m in messages if m.type == "result"][-1]
+    assert result.is_error is not True
+
+
+@pytest.mark.asyncio
+async def test_execute_task_tools_nonempty_partial_support_proceeds() -> None:
+    """Partial Pi with a non-empty tools list should proceed (--tools works)."""
+    process = _FakeProcess(
+        stdout_lines=[
+            _jsonl_event({"type": "session", "id": "session-1"}),
+            _jsonl_event(
+                {
+                    "type": "agent_end",
+                    "messages": [
+                        {"role": "assistant", "content": [{"type": "text", "text": "Done."}]}
+                    ],
+                }
+            ),
+        ],
+        stderr_lines=[],
+        returncode=0,
+    )
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = (True, False)
+
+    with patch("asyncio.create_subprocess_exec", return_value=process) as mock_exec:
+        messages = [msg async for msg in runtime.execute_task("Do it", tools=["Read"])]
+
+    # Process WAS spawned with --tools (non-empty list works even without --no-tools)
+    mock_exec.assert_called_once()
+    args = mock_exec.call_args.args
+    assert "--tools" in args
+    assert "read" in args[args.index("--tools") + 1]
+    result = [m for m in messages if m.type == "result"][-1]
+    assert result.is_error is not True
+
+
+@pytest.mark.asyncio
+async def test_execute_task_tools_none_partial_support_proceeds() -> None:
+    """Partial Pi with tools=None (default tools) should proceed without any flag."""
+    process = _FakeProcess(
+        stdout_lines=[
+            _jsonl_event({"type": "session", "id": "session-1"}),
+            _jsonl_event(
+                {
+                    "type": "agent_end",
+                    "messages": [
+                        {"role": "assistant", "content": [{"type": "text", "text": "Done."}]}
+                    ],
+                }
+            ),
+        ],
+        stderr_lines=[],
+        returncode=0,
+    )
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    runtime._native_param_flags = (True, False)
+
+    with patch("asyncio.create_subprocess_exec", return_value=process) as mock_exec:
+        messages = [msg async for msg in runtime.execute_task("Do it", tools=None)]
+
+    mock_exec.assert_called_once()
+    args = mock_exec.call_args.args
+    assert "--tools" not in args
+    assert "--no-tools" not in args
+    result = [m for m in messages if m.type == "result"][-1]
+    assert result.is_error is not True


### PR DESCRIPTION
## Summary

The Pi adapter declared `system_prompt` and `tools` as `TRANSLATED` and composed them into the user message (`## System Instructions` / `## Tooling Guidance`), but Pi's CLI ships native flags for both parameters. This PR delivers them natively, matching the forwarding intent already spelled out in the original Pi runtime epic #1307 ("system prompt … forwarded to pi request", "tool policy … translated from Ouroboros execute_task tools argument").

## Changes

| Parameter | Before | After |
|-----------|--------|-------|
| `system_prompt` | composed into user message as text | `--append-system-prompt <text>` (appends to Pi's base coding prompt, preserving its tool documentation) |
| `tools` allow-list | "Prefer these tools" prompt guidance | `--tools <csv>` — Pi's real allow-list; enforcement instead of a request |
| `permission_mode` | `IGNORED` | unchanged — Pi has no approval gate and no flag to translate onto |

Details:

- **Capability probe with fallback**: the runtime probes `pi --help` once (cached) for both flags. Pi binaries without them keep the previous user-message composition and report `TRANSLATED`, so older installations are unaffected.
- **Tool name mapping**: Ouroboros speaks a Claude-style capitalized vocabulary (`Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`) while Pi's built-ins are lowercase. Known names are mapped (`Read → read`, …); unknown names pass through unchanged so extension/custom tool names keep working. Unmatched allow-list entries are inert for Pi.
- **Honest capabilities**: `system_prompt_support` / `tool_restriction_support` now follow the probe result (`NATIVE` when supported, `TRANSLATED` on fallback). This also upgrades project execution-guidance delivery for Pi runs.
- **Docs**: runtime contract updated in `docs/runtime-guides/pi.md`; the parameter-handling table and its note in `docs/runtime-capability-matrix.md` now show Pi as `native*` with the fallback footnote.

## Testing

- 5 new unit tests: native command building (incl. name mapping and passthrough), fallback path, capabilities for both probe outcomes, and `execute_task`-level assertions for native vs composed delivery.
- `tests/unit/orchestrator/test_pi_runtime.py` + `test_runtime_factory.py`: 70 passed.
- Full `tests/unit/orchestrator/` suite with this change: 4035 passed. One failure (`test_routing_contract_resume.py::test_resume_restores_persisted_custom_frontier_router`) reproduces on a clean `main` checkout (environment-dependent project-identity path issue) and is unrelated to this change.
- `ruff check` and `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)