### PR TITLE
feat(pi): complete /ooo arguments in the interactive bridge

### DIFF
--- a/docs/runtime-guides/pi.md
+++ b/docs/runtime-guides/pi.md
@@ -171,6 +171,13 @@ to Pi with a deterministic unsupported-dispatch exit code so the normal Pi
 session can continue handling the input instead of receiving a hard bridge
 failure.
 
+The registered `/ooo` command also provides TAB argument completion through Pi's
+native `getArgumentCompletions` surface: `/ooo <TAB>` lists the dispatchable
+subcommands with one-line descriptions, and `ooo run <TAB>` lists Seed files
+from `~/.ouroboros/seeds/`. Completion is deterministic and offline — the
+subcommand list mirrors the packaged skills that declare `mcp_tool` frontmatter
+and a unit test keeps the two in sync.
+
 For `ooo auto`, the dispatcher owns the background job lifecycle. After
 `ouroboros_start_auto` returns a `job_id`, the dispatch process polls
 `ouroboros_job_wait` and fetches `ouroboros_job_result` when the job reaches a

--- a/docs/runtime-guides/pi.md
+++ b/docs/runtime-guides/pi.md
@@ -174,9 +174,13 @@ failure.
 The registered `/ooo` command also provides TAB argument completion through Pi's
 native `getArgumentCompletions` surface: `/ooo <TAB>` lists the dispatchable
 subcommands with one-line descriptions, and `ooo run <TAB>` lists Seed files
-from `~/.ouroboros/seeds/`. Completion is deterministic and offline — the
-subcommand list mirrors the packaged skills that declare `mcp_tool` frontmatter
-and a unit test keeps the two in sync.
+from `~/.ouroboros/seeds/` as absolute store paths, so the completed value
+executes regardless of the Pi session directory (relative seed paths resolve
+against the session cwd). Completion is deterministic and offline — the
+subcommand list mirrors the skills the dispatcher itself deems eligible, and a
+unit test derives that set through `resolve_skill_dispatch` so the two cannot
+drift. Seed names containing whitespace are skipped because the dispatcher
+tokenizes the dispatched command on whitespace.
 
 For `ooo auto`, the dispatcher owns the background job lifecycle. After
 `ouroboros_start_auto` returns a `job_id`, the dispatch process polls

--- a/src/ouroboros/cli/commands/pi_bridge.py
+++ b/src/ouroboros/cli/commands/pi_bridge.py
@@ -63,26 +63,33 @@ function seedFileCompletions(prefix: string): CompletionItem[] | null {{
   }} catch {{
     return null;
   }}
-  // Completion values carry the absolute store path: the `run` dispatcher
-  // resolves relative seed paths against the Pi session cwd, so a bare
-  // filename would only execute when the same file also exists there.
+  // Pi's CombinedAutocompleteProvider replaces the *entire* argument prefix
+  // with item.value — so the completed value must include the `run` subcommand
+  // to remain dispatchable.  The absolute path is POSIX single-argument
+  // quoted so every pathname character supported by shlex survives; embedded
+  // single quotes use the standard '\"'\"' sequence.
   // Names containing whitespace are skipped because the dispatcher
-  // tokenizes the dispatched command on whitespace.
+  // tokenizes the completion prefix on whitespace before this replacement.
   const items = names
     .filter((name) => name.endsWith(".yaml") || name.endsWith(".yml"))
     .filter((name) => !/\\s/.test(name) && matchesPrefix(name, prefix))
     .sort()
-    .map((name) => ({{
-      value: path.join(seedsDir, name),
-      label: name,
-      description: "Seed file",
-    }}));
+    .map((name) => {{
+      const abs = path.join(seedsDir, name);
+      const quoted = `'${{abs.replace(/'/g, `'\"'\"'`)}}'`;
+      return {{
+        value: `run ${{quoted}}`,
+        label: name,
+        description: "Seed file",
+      }};
+    }});
   return items.length > 0 ? items : null;
 }}
 
 // TAB completions for `/ooo <TAB>`: dispatchable subcommands for the first
-// argument, Seed files from `~/.ouroboros/seeds/` for `ooo run <TAB>`
-// (inserted as absolute paths so the value executes from any session cwd).
+// argument, Seed files from `~/.ouroboros/seeds/` for `ooo run <TAB>`.
+// Pi replaces the entire argument prefix with item.value, so Seed items
+// carry `run <quoted-absolute-path>` to remain dispatchable after selection.
 function argumentCompletions(argumentPrefix: string): CompletionItem[] | null {{
   const tokens = argumentPrefix.replace(/^\\s+/, "").split(/\\s+/);
   const completing = tokens[tokens.length - 1] ?? "";

--- a/src/ouroboros/cli/commands/pi_bridge.py
+++ b/src/ouroboros/cli/commands/pi_bridge.py
@@ -1,0 +1,165 @@
+"""Managed Pi bridge extension source for ``ooo`` frontdoor dispatch.
+
+``ouroboros setup --runtime pi`` renders the TypeScript below and installs it
+as ``~/.pi/agent/extensions/ouroboros-ooo-bridge.ts``. The template lives in
+this module so :mod:`ouroboros.cli.commands.setup` stays within its
+module-size budget; only pure rendering lives here, while install-site and
+launcher decisions stay in setup.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def pi_ooo_bridge_source_text(*, command: str, args: list[str]) -> str:
+    """Render the managed Pi ``ooo`` bridge extension TypeScript source.
+
+    ``command``/``args`` name the Ouroboros launcher the rendered bridge
+    should dispatch through; setup decides that launcher from the install
+    context (:func:`_detect_pi_bridge_dispatch_entry` in
+    :mod:`ouroboros.cli.commands.setup`) so this module stays a pure
+    renderer with no setup dependencies.
+    """
+    default_command = json.dumps(command)
+    default_args = json.dumps(args)
+    return f"""/**
+ * Ouroboros ooo bridge for Pi.
+ *
+ * Managed by `ouroboros setup --runtime pi`.
+ * Routes exact-prefix `ooo ...` inputs from interactive Pi into Ouroboros'
+ * shared skill dispatcher instead of sending them to the model as chat.
+ * The registered `/ooo` command also provides TAB argument completion for
+ * dispatchable subcommands and Seed files.
+ */
+import {{ readdirSync }} from "node:fs";
+import {{ homedir }} from "node:os";
+import * as path from "node:path";
+import type {{ ExtensionAPI, ExtensionContext }} from "@earendil-works/pi-coding-agent";
+
+type CompletionItem = {{ value: string; label: string; description?: string }};
+
+// Dispatchable `ooo` subcommands: the packaged skills whose SKILL.md declares
+// `mcp_tool` frontmatter, i.e. the commands the shared dispatcher can execute
+// as one deterministic MCP call. Kept in sync by a unit test.
+const DISPATCHABLE_COMMANDS: Array<{{ cmd: string; description: string }}> = [
+  {{ cmd: "auto", description: "Interview, Seed generation, and run handoff" }},
+  {{ cmd: "interview", description: "Socratic interview to clarify requirements" }},
+  {{ cmd: "run", description: "Execute a Seed specification" }},
+  {{ cmd: "seed", description: "Generate a Seed from an interview session" }},
+  {{ cmd: "status", description: "Session status and drift check" }},
+  {{ cmd: "ralph", description: "Evolutionary loop until QA passes" }},
+];
+
+function matchesPrefix(value: string, prefix: string): boolean {{
+  return value.toLowerCase().startsWith(prefix.toLowerCase());
+}}
+
+function seedFileCompletions(prefix: string): CompletionItem[] | null {{
+  const seedsDir = path.join(homedir(), ".ouroboros", "seeds");
+  let names: string[];
+  try {{
+    names = readdirSync(seedsDir);
+  }} catch {{
+    return null;
+  }}
+  // Completion values carry the absolute store path: the `run` dispatcher
+  // resolves relative seed paths against the Pi session cwd, so a bare
+  // filename would only execute when the same file also exists there.
+  // Names containing whitespace are skipped because the dispatcher
+  // tokenizes the dispatched command on whitespace.
+  const items = names
+    .filter((name) => name.endsWith(".yaml") || name.endsWith(".yml"))
+    .filter((name) => !/\\s/.test(name) && matchesPrefix(name, prefix))
+    .sort()
+    .map((name) => ({{
+      value: path.join(seedsDir, name),
+      label: name,
+      description: "Seed file",
+    }}));
+  return items.length > 0 ? items : null;
+}}
+
+// TAB completions for `/ooo <TAB>`: dispatchable subcommands for the first
+// argument, Seed files from `~/.ouroboros/seeds/` for `ooo run <TAB>`
+// (inserted as absolute paths so the value executes from any session cwd).
+function argumentCompletions(argumentPrefix: string): CompletionItem[] | null {{
+  const tokens = argumentPrefix.replace(/^\\s+/, "").split(/\\s+/);
+  const completing = tokens[tokens.length - 1] ?? "";
+  if (tokens.length <= 1) {{
+    const items = DISPATCHABLE_COMMANDS.filter((entry) =>
+      matchesPrefix(entry.cmd, completing),
+    ).map((entry) => ({{ value: entry.cmd, label: entry.cmd, description: entry.description }}));
+    return items.length > 0 ? items : null;
+  }}
+  if (tokens[0].toLowerCase() === "run" && tokens.length === 2) {{
+    return seedFileCompletions(completing);
+  }}
+  return null;
+}}
+
+const COMMAND_RE = /^\\s*ooo(?:\\s+|$)/i;
+const UNSUPPORTED_DISPATCH_EXIT_CODE = 78;
+const TIMEOUT_MS = Number(process.env.OUROBOROS_PI_BRIDGE_TIMEOUT_MS || 6 * 60 * 60 * 1000);
+const DEFAULT_COMMAND = {default_command};
+const DEFAULT_ARGS = {default_args};
+
+function ouroborosEntry(): {{ command: string; args: string[] }} {{
+  if (process.env.OUROBOROS_CLI) return {{ command: process.env.OUROBOROS_CLI, args: [] }};
+  return {{ command: DEFAULT_COMMAND, args: DEFAULT_ARGS }};
+}}
+
+function outputText(stdout: string, stderr: string): string {{
+  const out = stdout.trim();
+  const err = stderr.trim();
+  if (out && err) return `${{out}}\\n\\n${{err}}`;
+  return out || err || "(no output)";
+}}
+
+async function dispatch(pi: ExtensionAPI, text: string, ctx: ExtensionContext): Promise<boolean> {{
+  ctx.ui.notify(`Ouroboros dispatch: ${{text}}`, "info");
+  const entry = ouroborosEntry();
+  const result = await pi.exec(
+    entry.command,
+    [...entry.args, "dispatch", "--runtime", "pi", "--cwd", ctx.cwd, text],
+    {{ cwd: ctx.cwd, timeout: TIMEOUT_MS }},
+  );
+  if (result.code === UNSUPPORTED_DISPATCH_EXIT_CODE) {{
+    ctx.ui.notify(`Ouroboros did not claim command; continuing in Pi`, "info");
+    return false;
+  }}
+  const body = outputText(result.stdout || "", result.stderr || "");
+  pi.sendMessage({{
+    customType: "ouroboros",
+    content: body,
+    display: true,
+    details: {{ command: text, exitCode: result.code }},
+  }});
+  if (result.code !== 0) {{
+    ctx.ui.notify(`Ouroboros dispatch failed (${{result.code ?? "unknown"}})`, "error");
+  }}
+  return true;
+}}
+
+export default function ouroborosBridge(pi: ExtensionAPI) {{
+  pi.registerCommand("ooo", {{
+    description: "Dispatch an Ouroboros ooo command",
+    getArgumentCompletions: argumentCompletions,
+    handler: async (args, ctx) => {{
+      const text = `ooo ${{args}}`.trim();
+      await dispatch(pi, text, ctx);
+    }},
+  }});
+
+  pi.on("input", async (event, ctx) => {{
+    if (event.source === "extension") {{
+      return {{ action: "continue" }};
+    }}
+    if (!COMMAND_RE.test(event.text)) {{
+      return {{ action: "continue" }};
+    }}
+    const handled = await dispatch(pi, event.text.trim(), ctx);
+    return {{ action: handled ? "handled" : "continue" }};
+  }});
+}}
+"""

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -46,6 +46,7 @@ from ouroboros.cli.commands.claude_setup import (
 from ouroboros.cli.commands.claude_setup import (
     setup_claude_sdk as _setup_claude_sdk,
 )
+from ouroboros.cli.commands.pi_bridge import pi_ooo_bridge_source_text
 from ouroboros.cli.commands.setup_atomic_restore import restore_hermes, restore_hermes_receipt
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import (
@@ -3604,148 +3605,7 @@ def _detect_pi_bridge_dispatch_entry() -> tuple[str, list[str]]:
 def _pi_ooo_bridge_source_text() -> str:
     """Return the managed Pi extension source for ``ooo`` frontdoor dispatch."""
     command, args = _detect_pi_bridge_dispatch_entry()
-    default_command = json.dumps(command)
-    default_args = json.dumps(args)
-    return f"""/**
- * Ouroboros ooo bridge for Pi.
- *
- * Managed by `ouroboros setup --runtime pi`.
- * Routes exact-prefix `ooo ...` inputs from interactive Pi into Ouroboros'
- * shared skill dispatcher instead of sending them to the model as chat.
- * The registered `/ooo` command also provides TAB argument completion for
- * dispatchable subcommands and Seed files.
- */
-import {{ readdirSync }} from "node:fs";
-import {{ homedir }} from "node:os";
-import * as path from "node:path";
-import type {{ ExtensionAPI, ExtensionContext }} from "@earendil-works/pi-coding-agent";
-
-type CompletionItem = {{ value: string; label: string; description?: string }};
-
-// Dispatchable `ooo` subcommands: the packaged skills whose SKILL.md declares
-// `mcp_tool` frontmatter, i.e. the commands the shared dispatcher can execute
-// as one deterministic MCP call. Kept in sync by a unit test.
-const DISPATCHABLE_COMMANDS: Array<{{ cmd: string; description: string }}> = [
-  {{ cmd: "auto", description: "Interview, Seed generation, and run handoff" }},
-  {{ cmd: "interview", description: "Socratic interview to clarify requirements" }},
-  {{ cmd: "run", description: "Execute a Seed specification" }},
-  {{ cmd: "seed", description: "Generate a Seed from an interview session" }},
-  {{ cmd: "status", description: "Session status and drift check" }},
-  {{ cmd: "ralph", description: "Evolutionary loop until QA passes" }},
-];
-
-function matchesPrefix(value: string, prefix: string): boolean {{
-  return value.toLowerCase().startsWith(prefix.toLowerCase());
-}}
-
-function seedFileCompletions(prefix: string): CompletionItem[] | null {{
-  const seedsDir = path.join(homedir(), ".ouroboros", "seeds");
-  let names: string[];
-  try {{
-    names = readdirSync(seedsDir);
-  }} catch {{
-    return null;
-  }}
-  // Completion values carry the absolute store path: the `run` dispatcher
-  // resolves relative seed paths against the Pi session cwd, so a bare
-  // filename would only execute when the same file also exists there.
-  // Names containing whitespace are skipped because the dispatcher
-  // tokenizes the dispatched command on whitespace.
-  const items = names
-    .filter((name) => name.endsWith(".yaml") || name.endsWith(".yml"))
-    .filter((name) => !/\\s/.test(name) && matchesPrefix(name, prefix))
-    .sort()
-    .map((name) => ({{
-      value: path.join(seedsDir, name),
-      label: name,
-      description: "Seed file",
-    }}));
-  return items.length > 0 ? items : null;
-}}
-
-// TAB completions for `/ooo <TAB>`: dispatchable subcommands for the first
-// argument, Seed files from `~/.ouroboros/seeds/` for `ooo run <TAB>`
-// (inserted as absolute paths so the value executes from any session cwd).
-function argumentCompletions(argumentPrefix: string): CompletionItem[] | null {{
-  const tokens = argumentPrefix.replace(/^\\s+/, "").split(/\\s+/);
-  const completing = tokens[tokens.length - 1] ?? "";
-  if (tokens.length <= 1) {{
-    const items = DISPATCHABLE_COMMANDS.filter((entry) =>
-      matchesPrefix(entry.cmd, completing),
-    ).map((entry) => ({{ value: entry.cmd, label: entry.cmd, description: entry.description }}));
-    return items.length > 0 ? items : null;
-  }}
-  if (tokens[0].toLowerCase() === "run" && tokens.length === 2) {{
-    return seedFileCompletions(completing);
-  }}
-  return null;
-}}
-
-const COMMAND_RE = /^\\s*ooo(?:\\s+|$)/i;
-const UNSUPPORTED_DISPATCH_EXIT_CODE = 78;
-const TIMEOUT_MS = Number(process.env.OUROBOROS_PI_BRIDGE_TIMEOUT_MS || 6 * 60 * 60 * 1000);
-const DEFAULT_COMMAND = {default_command};
-const DEFAULT_ARGS = {default_args};
-
-function ouroborosEntry(): {{ command: string; args: string[] }} {{
-  if (process.env.OUROBOROS_CLI) return {{ command: process.env.OUROBOROS_CLI, args: [] }};
-  return {{ command: DEFAULT_COMMAND, args: DEFAULT_ARGS }};
-}}
-
-function outputText(stdout: string, stderr: string): string {{
-  const out = stdout.trim();
-  const err = stderr.trim();
-  if (out && err) return `${{out}}\\n\\n${{err}}`;
-  return out || err || "(no output)";
-}}
-
-async function dispatch(pi: ExtensionAPI, text: string, ctx: ExtensionContext): Promise<boolean> {{
-  ctx.ui.notify(`Ouroboros dispatch: ${{text}}`, "info");
-  const entry = ouroborosEntry();
-  const result = await pi.exec(
-    entry.command,
-    [...entry.args, "dispatch", "--runtime", "pi", "--cwd", ctx.cwd, text],
-    {{ cwd: ctx.cwd, timeout: TIMEOUT_MS }},
-  );
-  if (result.code === UNSUPPORTED_DISPATCH_EXIT_CODE) {{
-    ctx.ui.notify(`Ouroboros did not claim command; continuing in Pi`, "info");
-    return false;
-  }}
-  const body = outputText(result.stdout || "", result.stderr || "");
-  pi.sendMessage({{
-    customType: "ouroboros",
-    content: body,
-    display: true,
-    details: {{ command: text, exitCode: result.code }},
-  }});
-  if (result.code !== 0) {{
-    ctx.ui.notify(`Ouroboros dispatch failed (${{result.code ?? "unknown"}})`, "error");
-  }}
-  return true;
-}}
-
-export default function ouroborosBridge(pi: ExtensionAPI) {{
-  pi.registerCommand("ooo", {{
-    description: "Dispatch an Ouroboros ooo command",
-    getArgumentCompletions: argumentCompletions,
-    handler: async (args, ctx) => {{
-      const text = `ooo ${{args}}`.trim();
-      await dispatch(pi, text, ctx);
-    }},
-  }});
-
-  pi.on("input", async (event, ctx) => {{
-    if (event.source === "extension") {{
-      return {{ action: "continue" }};
-    }}
-    if (!COMMAND_RE.test(event.text)) {{
-      return {{ action: "continue" }};
-    }}
-    const handled = await dispatch(pi, event.text.trim(), ctx);
-    return {{ action: handled ? "handled" : "continue" }};
-  }});
-}}
-"""
+    return pi_ooo_bridge_source_text(command=command, args=args)
 
 
 def _install_pi_ooo_bridge() -> bool:

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -3612,8 +3612,64 @@ def _pi_ooo_bridge_source_text() -> str:
  * Managed by `ouroboros setup --runtime pi`.
  * Routes exact-prefix `ooo ...` inputs from interactive Pi into Ouroboros'
  * shared skill dispatcher instead of sending them to the model as chat.
+ * The registered `/ooo` command also provides TAB argument completion for
+ * dispatchable subcommands and Seed files.
  */
+import {{ readdirSync }} from "node:fs";
+import {{ homedir }} from "node:os";
+import * as path from "node:path";
 import type {{ ExtensionAPI, ExtensionContext }} from "@earendil-works/pi-coding-agent";
+
+type CompletionItem = {{ value: string; label: string; description?: string }};
+
+// Dispatchable `ooo` subcommands: the packaged skills whose SKILL.md declares
+// `mcp_tool` frontmatter, i.e. the commands the shared dispatcher can execute
+// as one deterministic MCP call. Kept in sync by a unit test.
+const DISPATCHABLE_COMMANDS: Array<{{ cmd: string; description: string }}> = [
+  {{ cmd: "auto", description: "Interview, Seed generation, and run handoff" }},
+  {{ cmd: "interview", description: "Socratic interview to clarify requirements" }},
+  {{ cmd: "run", description: "Execute a Seed specification" }},
+  {{ cmd: "seed", description: "Generate a Seed from an interview session" }},
+  {{ cmd: "status", description: "Session status and drift check" }},
+  {{ cmd: "ralph", description: "Evolutionary loop until QA passes" }},
+];
+
+function matchesPrefix(value: string, prefix: string): boolean {{
+  return value.toLowerCase().startsWith(prefix.toLowerCase());
+}}
+
+function seedFileCompletions(prefix: string): CompletionItem[] | null {{
+  let names: string[];
+  try {{
+    names = readdirSync(path.join(homedir(), ".ouroboros", "seeds"));
+  }} catch {{
+    return null;
+  }}
+  const items = names
+    .filter(
+      (name) =>
+        (name.endsWith(".yaml") || name.endsWith(".yml")) && matchesPrefix(name, prefix),
+    )
+    .map((name) => ({{ value: name, label: name, description: "Seed file" }}));
+  return items.length > 0 ? items : null;
+}}
+
+// TAB completions for `/ooo <TAB>`: dispatchable subcommands for the first
+// argument, Seed files from `~/.ouroboros/seeds/` for `ooo run <TAB>`.
+function argumentCompletions(argumentPrefix: string): CompletionItem[] | null {{
+  const tokens = argumentPrefix.replace(/^\\s+/, "").split(/\\s+/);
+  const completing = tokens[tokens.length - 1] ?? "";
+  if (tokens.length <= 1) {{
+    const items = DISPATCHABLE_COMMANDS.filter((entry) =>
+      matchesPrefix(entry.cmd, completing),
+    ).map((entry) => ({{ value: entry.cmd, label: entry.cmd, description: entry.description }}));
+    return items.length > 0 ? items : null;
+  }}
+  if (tokens[0].toLowerCase() === "run" && tokens.length === 2) {{
+    return seedFileCompletions(completing);
+  }}
+  return null;
+}}
 
 const COMMAND_RE = /^\\s*ooo(?:\\s+|$)/i;
 const UNSUPPORTED_DISPATCH_EXIT_CODE = 78;
@@ -3661,6 +3717,7 @@ async function dispatch(pi: ExtensionAPI, text: string, ctx: ExtensionContext): 
 export default function ouroborosBridge(pi: ExtensionAPI) {{
   pi.registerCommand("ooo", {{
     description: "Dispatch an Ouroboros ooo command",
+    getArgumentCompletions: argumentCompletions,
     handler: async (args, ctx) => {{
       const text = `ooo ${{args}}`.trim();
       await dispatch(pi, text, ctx);

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -3639,23 +3639,33 @@ function matchesPrefix(value: string, prefix: string): boolean {{
 }}
 
 function seedFileCompletions(prefix: string): CompletionItem[] | null {{
+  const seedsDir = path.join(homedir(), ".ouroboros", "seeds");
   let names: string[];
   try {{
-    names = readdirSync(path.join(homedir(), ".ouroboros", "seeds"));
+    names = readdirSync(seedsDir);
   }} catch {{
     return null;
   }}
+  // Completion values carry the absolute store path: the `run` dispatcher
+  // resolves relative seed paths against the Pi session cwd, so a bare
+  // filename would only execute when the same file also exists there.
+  // Names containing whitespace are skipped because the dispatcher
+  // tokenizes the dispatched command on whitespace.
   const items = names
-    .filter(
-      (name) =>
-        (name.endsWith(".yaml") || name.endsWith(".yml")) && matchesPrefix(name, prefix),
-    )
-    .map((name) => ({{ value: name, label: name, description: "Seed file" }}));
+    .filter((name) => name.endsWith(".yaml") || name.endsWith(".yml"))
+    .filter((name) => !/\\s/.test(name) && matchesPrefix(name, prefix))
+    .sort()
+    .map((name) => ({{
+      value: path.join(seedsDir, name),
+      label: name,
+      description: "Seed file",
+    }}));
   return items.length > 0 ? items : null;
 }}
 
 // TAB completions for `/ooo <TAB>`: dispatchable subcommands for the first
-// argument, Seed files from `~/.ouroboros/seeds/` for `ooo run <TAB>`.
+// argument, Seed files from `~/.ouroboros/seeds/` for `ooo run <TAB>`
+// (inserted as absolute paths so the value executes from any session cwd).
 function argumentCompletions(argumentPrefix: string): CompletionItem[] | null {{
   const tokens = argumentPrefix.replace(/^\\s+/, "").split(/\\s+/);
   const completing = tokens[tokens.length - 1] ?? "";

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -7,6 +7,7 @@ import json
 import os
 from pathlib import Path
 import re
+import shlex
 import stat
 import subprocess
 import sys
@@ -10625,7 +10626,8 @@ class TestCopilotSetup:
         """The managed bridge should TAB-complete `/ooo` arguments.
 
         `/ooo <TAB>` lists the dispatchable subcommands and `ooo run <TAB>`
-        lists Seed files from `~/.ouroboros/seeds/` as absolute paths so the
+        lists Seed files from `~/.ouroboros/seeds/` as `run <quoted-absolute-path>`
+        so Pi's full-prefix replacement preserves the subcommand and the
         completed value executes regardless of the Pi session cwd.
         """
         bridge_source = setup_cmd._pi_ooo_bridge_source_text()
@@ -10633,7 +10635,9 @@ class TestCopilotSetup:
         assert "getArgumentCompletions: argumentCompletions" in bridge_source
         assert "function argumentCompletions(argumentPrefix: string)" in bridge_source
         assert 'path.join(homedir(), ".ouroboros", "seeds")' in bridge_source
-        assert "value: path.join(seedsDir, name)" in bridge_source
+        # Seed completion values carry `run <quoted path>` — Pi replaces the
+        # entire argument prefix with the value, so `run` must be part of it.
+        assert "value: `run ${quoted}`" in bridge_source
         assert ".sort()" in bridge_source
         assert 'tokens[0].toLowerCase() === "run"' in bridge_source
 
@@ -10671,27 +10675,31 @@ class TestCopilotSetup:
 
         The `run` dispatcher forwards ``seed_path`` unchanged and the seed
         resolver treats relative paths as session-cwd-relative, degrading a
-        missing file to inline YAML. Completion therefore advertises absolute
-        store paths; this test pins that contract from the completed value
-        through router resolution to seed loading.
+        missing file to inline YAML. Completion therefore advertises
+        ``run <quoted-absolute-path>``; this test pins that contract from the
+        completed value through router resolution to seed loading.
         """
         seeds_dir = tmp_path / ".ouroboros" / "seeds"
         seeds_dir.mkdir(parents=True)
         (seeds_dir / "demo.yaml").write_text("goal: demo\n", encoding="utf-8")
-        completed_value = str(seeds_dir / "demo.yaml")
+        absolute_path = str(seeds_dir / "demo.yaml")
         session_cwd = tmp_path / "session"
         session_cwd.mkdir()
 
+        # The completion value now carries `run <path>` — the full replacement
+        # that Pi will substitute for the argument prefix.
+        completed_value = f"run {absolute_path}"
+
         resolved = resolve_skill_dispatch(
-            ResolveRequest(prompt=f"ooo run {completed_value}", cwd=session_cwd)
+            ResolveRequest(prompt=f"ooo {completed_value}", cwd=session_cwd)
         )
         assert isinstance(resolved, Resolved)
         assert resolved.mcp_tool == "ouroboros_execute_seed"
-        assert resolved.mcp_args["seed_path"] == completed_value
+        assert resolved.mcp_args["seed_path"] == absolute_path
 
         with patch("pathlib.Path.home", return_value=tmp_path):
             loaded = await ExecuteSeedHandler._resolve_seed_content(
-                arguments={"seed_path": completed_value},
+                arguments={"seed_path": absolute_path},
                 resolved_cwd=session_cwd,
                 tool_name="ouroboros_execute_seed",
             )
@@ -10707,6 +10715,95 @@ class TestCopilotSetup:
         # store from a session cwd and degrades to inline YAML.
         assert bare_name.is_ok
         assert bare_name.value == "demo.yaml"
+
+    def test_pi_completion_value_survives_combined_autocomplete_provider_replacement(
+        self, tmp_path: Path
+    ) -> None:
+        """Seed completion values remain dispatchable after Pi's full-prefix replacement.
+
+        Pi's ``CombinedAutocompleteProvider.applyCompletion`` replaces the
+        entire argument prefix with ``item.value``. For example, when a user
+        types ``/ooo run de<TAB>`` and selects a Seed completion, the argument
+        text ``run de`` is replaced wholesale with the item's ``value``.
+
+        Before the fix, ``value`` was just the absolute path, so the result
+        was ``/ooo /path/to/demo.yaml`` — which the shared dispatcher could
+        not recognize (no ``run`` subcommand). This regression test verifies
+        that the completed value, when applied as Pi does, produces a
+        dispatchable command.
+        """
+        seeds_dir = tmp_path / ".ouroboros" / "seeds"
+        seeds_dir.mkdir(parents=True)
+        (seeds_dir / "demo.yaml").write_text("goal: demo\n", encoding="utf-8")
+        session_cwd = tmp_path / "session"
+        session_cwd.mkdir()
+
+        absolute_path = str(seeds_dir / "demo.yaml")
+
+        # --- Simulate Pi's CombinedAutocompleteProvider semantics ---
+        # The user types: /ooo run de
+        # argumentPrefix passed to getArgumentCompletions: "run de"
+        # The rendered bridge returns: { value: "run <absolute-path>", ... }
+        # Pi applies the completion: replaces "run de" with item.value.
+        # The final command dispatched: /ooo <item.value>
+
+        # The completion value as the bridge would render it (without
+        # shell-quoting since this path has no special chars):
+        completed_item_value = f"run {absolute_path}"
+
+        # Pi replaces the full argument prefix with item.value, making the
+        # dispatched command: `ooo <completed_item_value>`
+        dispatched_text = f"ooo {completed_item_value}"
+
+        resolved = resolve_skill_dispatch(ResolveRequest(prompt=dispatched_text, cwd=session_cwd))
+        assert isinstance(resolved, Resolved), (
+            f"Pi full-prefix replacement produced undispatchable command: "
+            f"{dispatched_text!r} -> {resolved!r}"
+        )
+        assert resolved.mcp_tool == "ouroboros_execute_seed"
+        assert resolved.mcp_args["seed_path"] == absolute_path
+
+        # --- Verify the OLD (broken) behavior would fail ---
+        # Before the fix, value was just the absolute path (no 'run' prefix).
+        broken_item_value = absolute_path
+        broken_dispatched = f"ooo {broken_item_value}"
+        broken_result = resolve_skill_dispatch(
+            ResolveRequest(prompt=broken_dispatched, cwd=session_cwd)
+        )
+        # The absolute path alone is not a recognized skill subcommand
+        assert not isinstance(broken_result, Resolved), (
+            "Bare absolute path should NOT dispatch — it means Pi's replacement "
+            "lost the 'run' subcommand"
+        )
+
+    def test_pi_completion_value_with_quoted_path_survives_replacement(
+        self, tmp_path: Path
+    ) -> None:
+        """Every shlex-supported pathname character survives Pi replacement.
+
+        The rendered bridge uses POSIX single-argument quoting, including the
+        standard quote break for an embedded single quote. The dispatcher's
+        ``shlex.split`` must recover the exact original path without expanding
+        dollar signs or backticks or retaining escape characters.
+        """
+        seeds_dir = tmp_path / "my $projects`archive'\\data" / ".ouroboros" / "seeds"
+        seeds_dir.mkdir(parents=True)
+        (seeds_dir / "demo.yaml").write_text("goal: quoted\n", encoding="utf-8")
+        session_cwd = tmp_path / "session"
+        session_cwd.mkdir()
+
+        absolute_path = str(seeds_dir / "demo.yaml")
+        quoted_path = shlex.quote(absolute_path)
+        completed_item_value = f"run {quoted_path}"
+
+        dispatched_text = f"ooo {completed_item_value}"
+        resolved = resolve_skill_dispatch(ResolveRequest(prompt=dispatched_text, cwd=session_cwd))
+        assert isinstance(resolved, Resolved), (
+            f"Quoted-path completion produced undispatchable command: "
+            f"{dispatched_text!r} -> {resolved!r}"
+        )
+        assert resolved.mcp_tool == "ouroboros_execute_seed"
+        assert resolved.mcp_args["seed_path"] == absolute_path
 
 
 class TestRuntimeFlagDispatch:

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager, suppress
 import json
 import os
 from pathlib import Path
+import re
 import stat
 import subprocess
 import sys
@@ -43,6 +44,7 @@ from ouroboros.config.models import (
 )
 from ouroboros.providers.base import CompletionConfig
 from ouroboros.providers.profiles import resolve_completion_profile
+from ouroboros.skills.artifacts import resolve_packaged_skills_dir
 
 
 def _terminate_and_reap_test_process(process: subprocess.Popen[str] | None) -> None:
@@ -10616,6 +10618,44 @@ class TestCopilotSetup:
             assert setup_cmd._install_pi_ooo_bridge() is True
 
         assert bridge_path.stat().st_mtime_ns == first_mtime
+
+    def test_pi_bridge_registers_argument_completions(self) -> None:
+        """The managed bridge should TAB-complete `/ooo` arguments.
+
+        `/ooo <TAB>` lists the dispatchable subcommands and `ooo run <TAB>`
+        lists Seed files from `~/.ouroboros/seeds/`.
+        """
+        bridge_source = setup_cmd._pi_ooo_bridge_source_text()
+
+        assert "getArgumentCompletions: argumentCompletions" in bridge_source
+        assert "function argumentCompletions(argumentPrefix: string)" in bridge_source
+        assert 'path.join(homedir(), ".ouroboros", "seeds")' in bridge_source
+        assert 'tokens[0].toLowerCase() === "run"' in bridge_source
+
+    def test_pi_bridge_completions_mirror_dispatchable_skills(self) -> None:
+        """Completion subcommands must mirror skills with `mcp_tool` frontmatter.
+
+        The bridge hardcodes the dispatchable subcommand list so completion
+        stays deterministic and offline. This test fails whenever a packaged
+        skill gains or loses `mcp_tool` frontmatter, so the hardcoded list
+        cannot drift silently.
+        """
+        bridge_source = setup_cmd._pi_ooo_bridge_source_text()
+        completed = set(re.findall(r'cmd: "([a-z0-9][a-z0-9_-]*)"', bridge_source))
+
+        with resolve_packaged_skills_dir(anchor_file=Path(__file__)) as skills_dir:
+            dispatchable = {
+                skill_dir.name
+                for skill_dir in skills_dir.iterdir()
+                if (skill_dir / "SKILL.md").is_file()
+                and re.search(
+                    r"^mcp_tool:",
+                    (skill_dir / "SKILL.md").read_text(encoding="utf-8"),
+                    re.MULTILINE,
+                )
+            }
+
+        assert completed == dispatchable
 
 
 class TestRuntimeFlagDispatch:

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -42,8 +42,10 @@ from ouroboros.config.models import (
     get_default_config,
     get_default_credentials,
 )
+from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler
 from ouroboros.providers.base import CompletionConfig
 from ouroboros.providers.profiles import resolve_completion_profile
+from ouroboros.router import Resolved, ResolveRequest, resolve_skill_dispatch
 from ouroboros.skills.artifacts import resolve_packaged_skills_dir
 
 
@@ -10623,22 +10625,26 @@ class TestCopilotSetup:
         """The managed bridge should TAB-complete `/ooo` arguments.
 
         `/ooo <TAB>` lists the dispatchable subcommands and `ooo run <TAB>`
-        lists Seed files from `~/.ouroboros/seeds/`.
+        lists Seed files from `~/.ouroboros/seeds/` as absolute paths so the
+        completed value executes regardless of the Pi session cwd.
         """
         bridge_source = setup_cmd._pi_ooo_bridge_source_text()
 
         assert "getArgumentCompletions: argumentCompletions" in bridge_source
         assert "function argumentCompletions(argumentPrefix: string)" in bridge_source
         assert 'path.join(homedir(), ".ouroboros", "seeds")' in bridge_source
+        assert "value: path.join(seedsDir, name)" in bridge_source
+        assert ".sort()" in bridge_source
         assert 'tokens[0].toLowerCase() === "run"' in bridge_source
 
     def test_pi_bridge_completions_mirror_dispatchable_skills(self) -> None:
-        """Completion subcommands must mirror skills with `mcp_tool` frontmatter.
+        """Completion subcommands must mirror dispatcher-eligible skills.
 
-        The bridge hardcodes the dispatchable subcommand list so completion
-        stays deterministic and offline. This test fails whenever a packaged
-        skill gains or loses `mcp_tool` frontmatter, so the hardcoded list
-        cannot drift silently.
+        Eligibility is derived through ``resolve_skill_dispatch`` itself —
+        frontmatter loading, ``normalize_mcp_frontmatter`` validation, and
+        template resolution — instead of a textual ``mcp_tool:`` grep, so a
+        body example or an invalid/missing ``mcp_args`` mapping cannot make
+        an undispatchable skill look dispatchable.
         """
         bridge_source = setup_cmd._pi_ooo_bridge_source_text()
         completed = set(re.findall(r'cmd: "([a-z0-9][a-z0-9_-]*)"', bridge_source))
@@ -10648,14 +10654,59 @@ class TestCopilotSetup:
                 skill_dir.name
                 for skill_dir in skills_dir.iterdir()
                 if (skill_dir / "SKILL.md").is_file()
-                and re.search(
-                    r"^mcp_tool:",
-                    (skill_dir / "SKILL.md").read_text(encoding="utf-8"),
-                    re.MULTILINE,
+                and isinstance(
+                    resolve_skill_dispatch(
+                        ResolveRequest(prompt=f"ooo {skill_dir.name}", cwd=Path.cwd())
+                    ),
+                    Resolved,
                 )
             }
 
         assert completed == dispatchable
+
+    async def test_pi_bridge_run_completion_value_round_trips_to_global_seed(
+        self, tmp_path: Path
+    ) -> None:
+        """Absolute Seed completion values must stay executable end to end.
+
+        The `run` dispatcher forwards ``seed_path`` unchanged and the seed
+        resolver treats relative paths as session-cwd-relative, degrading a
+        missing file to inline YAML. Completion therefore advertises absolute
+        store paths; this test pins that contract from the completed value
+        through router resolution to seed loading.
+        """
+        seeds_dir = tmp_path / ".ouroboros" / "seeds"
+        seeds_dir.mkdir(parents=True)
+        (seeds_dir / "demo.yaml").write_text("goal: demo\n", encoding="utf-8")
+        completed_value = str(seeds_dir / "demo.yaml")
+        session_cwd = tmp_path / "session"
+        session_cwd.mkdir()
+
+        resolved = resolve_skill_dispatch(
+            ResolveRequest(prompt=f"ooo run {completed_value}", cwd=session_cwd)
+        )
+        assert isinstance(resolved, Resolved)
+        assert resolved.mcp_tool == "ouroboros_execute_seed"
+        assert resolved.mcp_args["seed_path"] == completed_value
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            loaded = await ExecuteSeedHandler._resolve_seed_content(
+                arguments={"seed_path": completed_value},
+                resolved_cwd=session_cwd,
+                tool_name="ouroboros_execute_seed",
+            )
+            bare_name = await ExecuteSeedHandler._resolve_seed_content(
+                arguments={"seed_path": "demo.yaml"},
+                resolved_cwd=session_cwd,
+                tool_name="ouroboros_execute_seed",
+            )
+
+        assert loaded.is_ok
+        assert loaded.value == "goal: demo\n"
+        # The pre-fix completion shape: a bare name never reaches the global
+        # store from a session cwd and degrades to inline YAML.
+        assert bare_name.is_ok
+        assert bare_name.value == "demo.yaml"
 
 
 class TestRuntimeFlagDispatch:


### PR DESCRIPTION
Refs #1307 (Pi AgentRuntime epic this bridge work belongs to).

## Summary

The managed Pi bridge (`ouroboros setup --runtime pi`) registers the `/ooo` command but offers no argument completion. Interactive Pi users have to remember dispatch subcommand names and Seed filenames by hand.

This PR registers a `getArgumentCompletions` handler on the bridge command, using Pi's native completion surface (`RegisteredCommand.getArgumentCompletions` → `AutocompleteItem { value, label, description }`).

## What completes

| Input | Completion |
|-------|------------|
| `/ooo <TAB>` | dispatchable subcommands with one-line descriptions |
| `ooo run <TAB>` | Seed files (`*.yaml` / `*.yml`) from `~/.ouroboros/seeds/` |
| anything else | `null` — Pi falls back to its default behavior |

The subcommand list mirrors the packaged skills whose `SKILL.md` declares `mcp_tool` frontmatter — exactly the commands the shared dispatcher can execute, so completion never suggests a command that would end in the unsupported-dispatch exit code.

## Design notes

- **Deterministic and offline.** The completion path spawns no subprocess and reads only the local seeds directory; a missing directory degrades to no completion instead of an error.
- **Drift guard.** The bridge hardcodes the subcommand list so completion stays offline. A new unit test (`test_pi_bridge_completions_mirror_dispatchable_skills`) compares the rendered list against the packaged skills with `mcp_tool` frontmatter and fails whenever a skill gains or loses that frontmatter, so the hardcoded list cannot drift silently.
- **Typed structurally.** The extension declares a local `CompletionItem` type; `AutocompleteItem` is not re-exported from `@earendil-works/pi-coding-agent`, and the structural shape satisfies `getArgumentCompletions` without depending on `@earendil-works/pi-tui` directly.

## Docs

`docs/runtime-guides/pi.md` — the interactive bridge section now documents the `/ooo` TAB completion surface.

## Testing

- 2 new tests in `tests/unit/cli/test_setup.py`:
  - `test_pi_bridge_registers_argument_completions` — bridge source carries the completion wiring and the seeds-directory lookup.
  - `test_pi_bridge_completions_mirror_dispatchable_skills` — drift guard described above.
- `pytest tests/unit/cli/test_setup.py -k "pi"` → 76 passed, 1 skipped.
- `pytest tests/unit/cli` → 2031 passed, 7 skipped, 22 failed. The 22 failures are pre-existing on a clean `upstream/main` checkout in this environment (Codex setup/registration tests; identical set before and after this change, verified by re-running with the change stashed).
- The rendered TypeScript loads cleanly under Node `--experimental-strip-types`, and the completion function was exercised on the edge cases (`""`, `"ru"`, `"run "`, `"run <prefix>"`, `"run a b"`, unknown prefixes → `null`).
- `ruff format` + `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
