### PR TITLE
fix(hooks): remove SessionStart packaging dependency

### DIFF
--- a/scripts/version-check.py
+++ b/scripts/version-check.py
@@ -99,6 +99,10 @@ def _version_key(version: str) -> tuple[tuple[int, ...], int, int] | None:
         release_parts.pop()
     release = tuple(release_parts)
     pre_kind = match.group("pre_kind")
+    if match.group("dev_num") is not None and (
+        pre_kind is not None or match.group("post_num") is not None
+    ):
+        return None
     if match.group("dev_num") is not None:
         phase, number = 0, int(match.group("dev_num"))
     elif pre_kind is not None:

--- a/scripts/version-check.py
+++ b/scripts/version-check.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 import json
 import os
 from pathlib import Path
+import re
 import sys
 import tempfile
 import time
@@ -72,17 +73,57 @@ def get_installed_version() -> str | None:
     return None
 
 
+_VERSION_RE = re.compile(
+    r"^\s*v?(?P<release>\d+(?:\.\d+)*)"
+    r"(?:(?P<pre_kind>a|b|rc)(?P<pre_num>\d+))?"
+    r"(?:\.post(?P<post_num>\d+))?"
+    r"(?:\.dev(?P<dev_num>\d+))?"
+    r"(?:\+[0-9A-Za-z.-]+)?\s*$",
+    re.IGNORECASE,
+)
+
+
+def _version_key(version: str) -> tuple[tuple[int, ...], int, int] | None:
+    """Return a sortable key for the version forms Ouroboros publishes.
+
+    SessionStart runs under the first host ``python3`` on PATH, so this
+    standalone hook cannot depend on the package environment containing
+    ``packaging``. Supported ordering is dev < alpha < beta < rc < final < post.
+    Local suffixes do not make a same-public-version update available.
+    """
+    match = _VERSION_RE.fullmatch(version)
+    if match is None:
+        return None
+    release_parts = [int(part) for part in match.group("release").split(".")]
+    while len(release_parts) > 1 and release_parts[-1] == 0:
+        release_parts.pop()
+    release = tuple(release_parts)
+    pre_kind = match.group("pre_kind")
+    if match.group("dev_num") is not None:
+        phase, number = 0, int(match.group("dev_num"))
+    elif pre_kind is not None:
+        phase = {"a": 1, "b": 2, "rc": 3}[pre_kind.lower()]
+        number = int(match.group("pre_num") or 0)
+    elif match.group("post_num") is not None:
+        phase, number = 5, int(match.group("post_num"))
+    else:
+        phase, number = 4, 0
+    return release, phase, number
+
+
+def _compare_versions(left: str, right: str) -> int | None:
+    """Compare supported versions, returning None when either is invalid."""
+    left_key = _version_key(left)
+    right_key = _version_key(right)
+    if left_key is None or right_key is None:
+        return None
+    return (left_key > right_key) - (left_key < right_key)
+
+
 def _is_prerelease(version_str: str) -> bool:
-    """Check if a version string is a pre-release (PEP 440)."""
-    try:
-        from packaging.version import Version
-
-        return Version(version_str).is_prerelease
-    except Exception:
-        # Fallback: check for common pre-release suffixes
-        import re
-
-        return bool(re.search(r"(a|b|rc|dev)\d*", version_str))
+    """Check whether a supported Ouroboros version is a pre-release."""
+    key = _version_key(version_str)
+    return key is not None and key[1] < 4
 
 
 def _get_latest_from_pypi(
@@ -110,13 +151,14 @@ def _get_latest_from_pypi(
     if not include_prerelease:
         return data["info"]["version"]
 
-    # Scan all releases to find the latest pre-release
-    from packaging.version import Version
-
-    all_versions = [Version(v) for v in data.get("releases", {}) if data["releases"][v]]
-    if not all_versions:
+    candidates = [
+        (key, version)
+        for version, files in data.get("releases", {}).items()
+        if files and (key := _version_key(version)) is not None
+    ]
+    if not candidates:
         return data["info"]["version"]
-    return str(max(all_versions))
+    return max(candidates)[1]
 
 
 def get_latest_version(*, current: str | None = None) -> str | None:
@@ -254,23 +296,16 @@ def check_update() -> dict:
             "message": None,
         }
 
-    from packaging.version import Version
-
-    try:
-        if Version(latest) > Version(current):
-            return {
-                "update_available": True,
-                "current": current,
-                "latest": latest,
-                "message": (
-                    f"Ouroboros update available: v{current} → v{latest}. "
-                    f"Run `ooo update` to upgrade."
-                ),
-            }
-    except Exception:
-        # Version parsing failed — cannot determine ordering safely.
-        # Return False rather than risking a false positive (e.g. downgrade).
-        pass
+    comparison = _compare_versions(latest, current)
+    if comparison is not None and comparison > 0:
+        return {
+            "update_available": True,
+            "current": current,
+            "latest": latest,
+            "message": (
+                f"Ouroboros update available: v{current} → v{latest}. Run `ooo update` to upgrade."
+            ),
+        }
 
     return {
         "update_available": False,

--- a/tests/unit/scripts/test_session_start.py
+++ b/tests/unit/scripts/test_session_start.py
@@ -11,6 +11,14 @@ _spec = importlib.util.spec_from_file_location("session_start", str(_SCRIPT_PATH
 session_start = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(session_start)
 
+_ORIGINAL_IMPORT = __import__
+
+
+def _block_packaging_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "packaging" or name.startswith("packaging."):
+        raise ModuleNotFoundError("No module named 'packaging'", name=name)
+    return _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)
+
 
 class TestSessionStartMain:
     """Regression coverage for safe SessionStart output handling."""
@@ -52,6 +60,27 @@ class TestSessionStartMain:
 
         captured = capsys.readouterr()
         assert captured.out == "Ouroboros update available\n"
+        assert captured.err == ""
+
+    def test_real_checker_emits_notice_without_packaging(self, monkeypatch, capsys) -> None:
+        real_loader = session_start._load_version_checker
+
+        def _load_checker():
+            checker = real_loader()
+            monkeypatch.setattr(checker, "get_installed_version", lambda: "0.51.13")
+            monkeypatch.setattr(checker, "get_latest_version", lambda **_kwargs: "0.51.14")
+            monkeypatch.setattr(checker, "consume_update_notice", lambda **_kwargs: True)
+            return checker
+
+        monkeypatch.setattr("builtins.__import__", _block_packaging_import)
+        monkeypatch.setattr(session_start, "_load_version_checker", _load_checker)
+
+        session_start.main()
+
+        captured = capsys.readouterr()
+        assert captured.out == (
+            "Ouroboros update available: v0.51.13 → v0.51.14. Run `ooo update` to upgrade.\n"
+        )
         assert captured.err == ""
 
     def test_repeated_session_emits_fresh_notice_only_once(self, monkeypatch, capsys) -> None:

--- a/tests/unit/scripts/test_version_check.py
+++ b/tests/unit/scripts/test_version_check.py
@@ -9,6 +9,8 @@ import threading
 import time
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from ouroboros.mcp import update_notice
 
 # Load the script as a module
@@ -311,6 +313,23 @@ class TestCheckUpdate:
             result = version_check.check_update()
 
         assert result["update_available"] is False
+
+    @pytest.mark.parametrize(
+        ("current", "latest"),
+        (
+            ("0.51.14rc1.dev1", "0.51.14b2"),
+            ("0.51.14.post1.dev1", "0.51.14.post0"),
+        ),
+    )
+    def test_composed_dev_versions_fail_closed(self, current: str, latest: str) -> None:
+        with (
+            patch.object(version_check, "get_installed_version", return_value=current),
+            patch.object(version_check, "get_latest_version", return_value=latest),
+        ):
+            result = version_check.check_update()
+
+        assert result["update_available"] is False
+        assert result["message"] is None
 
 
 class TestPrerelease:

--- a/tests/unit/scripts/test_version_check.py
+++ b/tests/unit/scripts/test_version_check.py
@@ -18,6 +18,15 @@ version_check = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(version_check)
 
 
+def _block_packaging_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "packaging" or name.startswith("packaging."):
+        raise ModuleNotFoundError("No module named 'packaging'", name=name)
+    return _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)
+
+
+_ORIGINAL_IMPORT = __import__
+
+
 class TestGetInstalledVersion:
     """Test get_installed_version."""
 
@@ -248,6 +257,20 @@ class TestCheckUpdate:
         assert result["latest"] == "0.20.0"
         assert "ooo update" in result["message"]
 
+    def test_update_available_without_packaging(self) -> None:
+        """SessionStart's host Python need not contain the packaging module."""
+        with (
+            patch("builtins.__import__", side_effect=_block_packaging_import),
+            patch.object(version_check, "get_installed_version", return_value="0.51.13"),
+            patch.object(version_check, "get_latest_version", return_value="0.51.14"),
+        ):
+            result = version_check.check_update()
+
+        assert result["update_available"] is True
+        assert result["message"] == (
+            "Ouroboros update available: v0.51.13 → v0.51.14. Run `ooo update` to upgrade."
+        )
+
     def test_up_to_date(self) -> None:
         """No update when versions match."""
         with (
@@ -334,6 +357,29 @@ class TestPrerelease:
             result = version_check.get_latest_version(current="0.26.0b3")
 
         assert result == "0.26.0b4"
+
+    def test_prerelease_scan_without_packaging(self, tmp_path: Path) -> None:
+        pypi_data = {
+            "info": {"version": "0.51.13"},
+            "releases": {
+                "invalid": [{"filename": "ignored"}],
+                "0.51.14.dev2": [{"filename": "x"}],
+                "0.51.14b1": [{"filename": "x"}],
+                "0.51.14rc1": [{"filename": "x"}],
+            },
+        }
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(pypi_data).encode()
+
+        with (
+            patch("builtins.__import__", side_effect=_block_packaging_import),
+            patch.object(version_check, "_CACHE_FILE", tmp_path / "cache.json"),
+            patch.object(version_check, "_CACHE_DIR", tmp_path),
+            patch("urllib.request.urlopen", return_value=mock_response),
+        ):
+            result = version_check.get_latest_version(current="0.51.14b1")
+
+        assert result == "0.51.14rc1"
 
     def test_stable_user_gets_stable_only(self, tmp_path: Path) -> None:
         """Stable user does NOT see beta releases."""


### PR DESCRIPTION
## Summary

- Remove undeclared `packaging` imports from the standalone SessionStart update checker.
- Compare the stable, development, alpha, beta, release-candidate, post, and local version forms Ouroboros publishes using only the standard library.
- Preserve the fail-closed behavior for invalid versions while restoring update notices under host Python installations without `packaging`.

## Verification

- `uv run pytest -q tests/unit/scripts/test_version_check.py tests/unit/scripts/test_session_start.py` — 37 passed
- Ruff check and format pass on all changed files
- The issue reproduction passes under `python3 -S` with `packaging` imports blocked: direct comparison returns `True`, SessionStart emits the update notice, and stderr stays empty.

Closes #2201