### PR TITLE
fix(setup): accept Windows file mode semantics

### DIFF
--- a/src/ouroboros/cli/runtime_activation.py
+++ b/src/ouroboros/cli/runtime_activation.py
@@ -365,6 +365,26 @@ def _snapshot_from_stat(contents: bytes, result: os.stat_result) -> _FileSnapsho
     )
 
 
+def _validate_prepared_mode(
+    path: Path,
+    prepared_mode: int,
+    *,
+    requested_mode: int,
+    preserve_exact_mode: bool,
+) -> None:
+    """Validate POSIX mode bits where the platform reports them reliably."""
+    if os.name == "nt":
+        # NTFS security is enforced by ACLs; CPython reports writable files as
+        # 0o666 regardless of the requested mode because POSIX group/other
+        # bits do not exist. Treating those synthetic bits as a violation
+        # makes every Windows activation fail before publication.
+        return
+    if preserve_exact_mode and prepared_mode != requested_mode:
+        raise OSError(f"Could not preserve file mode for {path}")
+    if prepared_mode & ~requested_mode:
+        raise OSError(f"Prepared file mode exceeds the secure default for {path}")
+
+
 def _prepare_file(
     path: Path,
     contents: bytes,
@@ -400,12 +420,14 @@ def _prepare_file(
         prepared = os.fstat(descriptor)
         if not stat.S_ISREG(prepared.st_mode) or prepared.st_nlink != 1:
             raise OSError(f"Could not prepare regular replacement for {path}")
-        if preserve_exact_mode and stat.S_IMODE(prepared.st_mode) != requested_mode:
-            raise OSError(f"Could not preserve file mode for {path}")
+        _validate_prepared_mode(
+            path,
+            stat.S_IMODE(prepared.st_mode),
+            requested_mode=requested_mode,
+            preserve_exact_mode=preserve_exact_mode,
+        )
         if requested_owner is not None and (prepared.st_uid, prepared.st_gid) != requested_owner:
             raise OSError(f"Could not preserve file ownership for {path}")
-        if stat.S_IMODE(prepared.st_mode) & ~requested_mode:
-            raise OSError(f"Prepared file mode exceeds the secure default for {path}")
         return _PreparedFile(path, _snapshot_from_stat(contents, prepared))
     except BaseException:
         failed_prepared: _PreparedFile | None = None

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -4473,6 +4473,31 @@ class TestCodexSetup:
 class TestClaudeSetup:
     """Tests for Claude-specific setup behavior."""
 
+    def test_windows_prepared_file_ignores_synthetic_posix_mode(self, tmp_path: Path) -> None:
+        path = tmp_path / "credentials.yaml"
+
+        with patch.object(runtime_activation.os, "name", "nt"):
+            runtime_activation._validate_prepared_mode(
+                path,
+                0o666,
+                requested_mode=0o600,
+                preserve_exact_mode=False,
+            )
+
+    def test_posix_prepared_file_still_rejects_broader_mode(self, tmp_path: Path) -> None:
+        path = tmp_path / "credentials.yaml"
+
+        with (
+            patch.object(runtime_activation.os, "name", "posix"),
+            pytest.raises(OSError, match="Prepared file mode exceeds"),
+        ):
+            runtime_activation._validate_prepared_mode(
+                path,
+                0o666,
+                requested_mode=0o600,
+                preserve_exact_mode=False,
+            )
+
     @pytest.mark.parametrize(
         ("persisted", "profile"),
         [("claude_mcp", "claude-cli"), ("claude", "claude")],


### PR DESCRIPTION
## Summary

- Stop applying POSIX permission-bit assertions to staged runtime activation files on native Windows.
- Keep regular-file, link-count, identity, ownership, durability, rollback, and every POSIX mode check unchanged.
- Add regressions for Windows `st_mode == 0o666` and the retained POSIX rejection.

## Verification

- `uv run pytest -q tests/unit/cli/test_setup.py -k "prepared_file or setup_claude_fresh_modes"` — 4 passed
- Ruff check and format pass on both changed files
- LSP diagnostics: clean

Closes #2116