### PR TITLE
fix(seed): reject masked verify commands

### DIFF
--- a/src/ouroboros/agents/seed-architect.md
+++ b/src/ouroboros/agents/seed-architect.md
@@ -58,6 +58,8 @@ Multi-artifact example: `[{"description":"Build outputs exist","verify":"NONE","
 
 `verify` / `verify_command` semantics:
 - Use exactly one single-line shell command.
+- The command must verify the criterion directly and exit 0 on success without masking a failure. NEVER append unconditional fallbacks such as `|| true` or `|| :`; if a criterion cannot be checked by one command, use `verify: NONE` and provide exact artifacts instead.
+- Keep the command portable across the supported host shells. NEVER rely on POSIX-only fallback commands or shell-control syntax that changes the exit contract on Windows.
 - NEVER use heredoc or multiline shell syntax such as `<<`, `<<'PY'`, `cat <<EOF`, line-continuation scripts, or an unterminated command block. The AC contract format is one line, so multiline command bodies will be lost.
 - For Python snippets, use `python -c "..."` / `python3 -c "..."`; for longer checks, require a pytest-discoverable test artifact and use `python -m pytest -q`.
 

--- a/src/ouroboros/agents/seed-architect.md
+++ b/src/ouroboros/agents/seed-architect.md
@@ -58,8 +58,8 @@ Multi-artifact example: `[{"description":"Build outputs exist","verify":"NONE","
 
 `verify` / `verify_command` semantics:
 - Use exactly one single-line shell command.
-- The command must verify the criterion directly and exit 0 on success without masking a failure. NEVER append unconditional fallbacks such as `|| true` or `|| :`; if a criterion cannot be checked by one command, use `verify: NONE` and provide exact artifacts instead.
-- Keep the command portable across the supported host shells. NEVER rely on POSIX-only fallback commands or shell-control syntax that changes the exit contract on Windows.
+- The command must verify the criterion directly and exit 0 on success without masking a failure. NEVER append an unconditional success fallback such as `|| true`, `|| :`, or an equivalent known-success command; if a criterion cannot be checked by one command, use `verify: NONE` and provide exact artifacts instead.
+- Keep the command portable across supported Bash installations. Do not rely on host-specific shell features that the verifier cannot execute.
 - NEVER use heredoc or multiline shell syntax such as `<<`, `<<'PY'`, `cat <<EOF`, line-continuation scripts, or an unterminated command block. The AC contract format is one line, so multiline command bodies will be lost.
 - For Python snippets, use `python -c "..."` / `python3 -c "..."`; for longer checks, require a pytest-discoverable test artifact and use `python -m pytest -q`.
 

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -1394,68 +1394,147 @@ def _unsupported_verify_command_reason(command: str) -> str | None:
 
 _SHELL_COMMANDS = frozenset({"bash", "dash", "ksh", "sh", "zsh"})
 _ALWAYS_SUCCESS_COMMANDS = frozenset({"echo", "printf", "true", ":"})
+_ALWAYS_FAIL_COMMANDS = frozenset({"false"})
+_SHELL_OPTIONS_WITH_VALUES = frozenset({"--init-file", "--rcfile", "-O"})
+_SHELL_CONTROL_TOKENS = frozenset({"&&", "||", "|", ";", ")", "}"})
 
 
-def _success_command_end(tokens: list[str], start: int) -> int | None:
-    """Return the end of a known-success command after ``||``."""
-    index = start
-    while index < len(tokens) and (
-        re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", tokens[index])
-        or tokens[index] in {"command", "exec", "builtin", "nohup"}
+def _mask_command_substitutions(command: str) -> str:
+    """Hide nested substitutions whose exit status does not decide the outer list."""
+    pieces: list[str] = []
+    index = 0
+    while index < len(command):
+        if command.startswith("$(", index) or command.startswith("${", index):
+            end = _posix_expansion_end(command, index)
+            if end is not None:
+                pieces.append("SUBSTITUTION")
+                index = end
+                continue
+        if command[index] == "`":
+            end = _posix_backtick_substitution_end(command, index)
+            if end is not None:
+                pieces.append("SUBSTITUTION")
+                index = end
+                continue
+        pieces.append(command[index])
+        index += 1
+    return "".join(pieces)
+
+
+def _simple_command_status(tokens: list[str], index: int) -> tuple[frozenset[int], bool, int]:
+    """Parse one simple/group command into possible statuses and fallback evidence."""
+    if index < len(tokens) and tokens[index] in {"(", "{"}:
+        close = ")" if tokens[index] == "(" else "}"
+        statuses, masked, index = _shell_sequence_status(tokens, index + 1, stop=close)
+        return (
+            statuses,
+            masked,
+            index + 1 if index < len(tokens) and tokens[index] == close else index,
+        )
+    segment: list[str] = []
+    while index < len(tokens) and tokens[index] not in _SHELL_CONTROL_TOKENS:
+        segment.append(tokens[index])
+        index += 1
+    command_index = 0
+    while command_index < len(segment) and (
+        re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", segment[command_index])
+        or segment[command_index] in {"command", "exec", "builtin", "nohup"}
     ):
-        index += 1
-    if index < len(tokens) and tokens[index] == "env":
-        index += 1
-        while (
-            index < len(tokens)
-            and "=" in tokens[index]
-            and not tokens[index].startswith(("-", "/"))
+        command_index += 1
+    if command_index < len(segment) and segment[command_index] == "env":
+        command_index += 1
+        while command_index < len(segment) and re.fullmatch(
+            r"[A-Za-z_][A-Za-z0-9_]*=.*", segment[command_index]
         ):
-            index += 1
-    if index >= len(tokens):
-        return None
-    if tokens[index] in {"{", "("}:
-        close = "}" if tokens[index] == "{" else ")"
-        close_index = tokens.index(close, index + 1) if close in tokens[index + 1 :] else -1
-        inner = tokens[index + 1 : close_index]
-        return close_index + 1 if inner and _success_command_end(inner, 0) == len(inner) else None
-    if tokens[index] not in _ALWAYS_SUCCESS_COMMANDS:
-        return None
-    index += 1
-    while index < len(tokens) and tokens[index] not in {"||", "&&", "|", ";"}:
-        index += 1
-    return index
+            command_index += 1
+    executable = (
+        segment[command_index].rsplit("/", 1)[-1] if command_index < len(segment) else "true"
+    )
+    if executable in _ALWAYS_SUCCESS_COMMANDS:
+        return frozenset({0}), False, index
+    if executable in _ALWAYS_FAIL_COMMANDS:
+        return frozenset({1}), False, index
+    return frozenset({0, 1}), False, index
+
+
+def _shell_pipeline_status(tokens: list[str], index: int) -> tuple[frozenset[int], bool, int]:
+    statuses, masked, index = _simple_command_status(tokens, index)
+    while index < len(tokens) and tokens[index] == "|":
+        right, right_masked, index = _simple_command_status(tokens, index + 1)
+        statuses, masked = right, masked or right_masked
+    return statuses, masked, index
+
+
+def _shell_and_or_status(tokens: list[str], index: int) -> tuple[frozenset[int], bool, int]:
+    statuses, masked, index = _shell_pipeline_status(tokens, index)
+    while index < len(tokens) and tokens[index] in {"&&", "||"}:
+        operator = tokens[index]
+        right, right_masked, index = _shell_pipeline_status(tokens, index + 1)
+        if operator == "&&":
+            statuses = frozenset(
+                ({1} if 1 in statuses else set()) | (set(right) if 0 in statuses else set())
+            )
+        else:
+            masked = masked or (1 in statuses and right == frozenset({0}))
+            statuses = frozenset(
+                ({0} if 0 in statuses else set()) | (set(right) if 1 in statuses else set())
+            )
+        masked = masked or right_masked
+    return statuses, masked, index
+
+
+def _shell_sequence_status(
+    tokens: list[str], index: int = 0, *, stop: str | None = None
+) -> tuple[frozenset[int], bool, int]:
+    statuses, masked, index = _shell_and_or_status(tokens, index)
+    while index < len(tokens) and tokens[index] == ";":
+        if stop is not None and index + 1 < len(tokens) and tokens[index + 1] == stop:
+            return statuses, masked, index + 1
+        statuses, right_masked, index = _shell_and_or_status(tokens, index + 1)
+        masked = masked or right_masked
+    return statuses, masked, index
+
+
+def _wrapped_shell_bodies(tokens: list[str]) -> tuple[str, ...]:
+    bodies: list[str] = []
+    for index, token in enumerate(tokens):
+        if token.rsplit("/", 1)[-1] not in _SHELL_COMMANDS:
+            continue
+        option_index = index + 1
+        while option_index < len(tokens):
+            option = tokens[option_index]
+            if option == "--" or not option.startswith("-"):
+                break
+            if option == "-c" or (not option.startswith("--") and "c" in option[1:]):
+                body_index = option_index + 1
+                if body_index < len(tokens) and tokens[body_index] == "--":
+                    body_index += 1
+                if body_index < len(tokens):
+                    bodies.append(tokens[body_index])
+                break
+            option_index += 2 if option in _SHELL_OPTIONS_WITH_VALUES else 1
+    return tuple(bodies)
 
 
 def _contains_unconditional_success_fallback(command: str) -> bool:
-    """Reject a known-success ``||`` branch when it supplies the final status."""
+    """Reject Bash lists whose known-success fallback determines final exit 0."""
     try:
-        lexer = shlex.shlex(command, posix=True, punctuation_chars="|&;<>()")
+        lexer = shlex.shlex(
+            _mask_command_substitutions(command),
+            posix=True,
+            punctuation_chars="|&;<>(){}",
+        )
         lexer.whitespace_split = True
         lexer.commenters = ""
         tokens = list(lexer)
     except ValueError:
         return False
-    for index, token in enumerate(tokens):
-        if token == "||":
-            end = _success_command_end(tokens, index + 1)
-            if end is not None and end < len(tokens) and tokens[end] in {"&&", "||", "|", ";"}:
-                continue
-            if end is not None:
-                return True
-        if token.rsplit("/", 1)[-1] not in _SHELL_COMMANDS or index + 2 >= len(tokens):
-            continue
-        options_index = index + 1
-        options = tokens[options_index]
-        if options.startswith("-") and "c" in options[1:]:
-            body_index = options_index + 1
-            if body_index < len(tokens) and tokens[body_index] == "--":
-                body_index += 1
-            if body_index < len(tokens) and _contains_unconditional_success_fallback(
-                tokens[body_index]
-            ):
-                return True
-    return False
+    if any(
+        _contains_unconditional_success_fallback(body) for body in _wrapped_shell_bodies(tokens)
+    ):
+        return True
+    statuses, masked, _index = _shell_sequence_status(tokens)
+    return masked and statuses == frozenset({0})
 
 
 def _contains_posix_heredoc_operator(command: str) -> bool:

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -16,6 +16,7 @@ import json
 import math
 from pathlib import Path
 import re
+import shlex
 from typing import Any
 
 from pydantic import ValidationError as PydanticValidationError
@@ -1386,7 +1387,33 @@ def _unsupported_verify_command_reason(command: str) -> str | None:
         return "verify_command must be a single-line command"
     if _contains_posix_heredoc_operator(command):
         return "verify_command uses heredoc/multiline shell syntax; use python -c or pytest instead"
+    if _contains_unconditional_success_fallback(command):
+        return "verify_command masks failure with an unconditional success fallback"
     return None
+
+
+_SHELL_COMMANDS = frozenset({"bash", "dash", "ksh", "sh", "zsh"})
+
+
+def _contains_unconditional_success_fallback(command: str) -> bool:
+    """Reject ``|| true``/``|| :`` without matching quoted data literals."""
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars="|&;<>")
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
+    except ValueError:
+        return False
+    for index, token in enumerate(tokens):
+        if token == "||" and index + 1 < len(tokens) and tokens[index + 1] in {"true", ":"}:
+            return True
+        if token.rsplit("/", 1)[-1] not in _SHELL_COMMANDS or index + 2 >= len(tokens):
+            continue
+        options = tokens[index + 1]
+        if options.startswith("-") and "c" in options[1:]:
+            if _contains_unconditional_success_fallback(tokens[index + 2]):
+                return True
+    return False
 
 
 def _contains_posix_heredoc_operator(command: str) -> bool:

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -1393,25 +1393,67 @@ def _unsupported_verify_command_reason(command: str) -> str | None:
 
 
 _SHELL_COMMANDS = frozenset({"bash", "dash", "ksh", "sh", "zsh"})
+_ALWAYS_SUCCESS_COMMANDS = frozenset({"echo", "printf", "true", ":"})
+
+
+def _success_command_end(tokens: list[str], start: int) -> int | None:
+    """Return the end of a known-success command after ``||``."""
+    index = start
+    while index < len(tokens) and (
+        re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", tokens[index])
+        or tokens[index] in {"command", "exec", "builtin", "nohup"}
+    ):
+        index += 1
+    if index < len(tokens) and tokens[index] == "env":
+        index += 1
+        while (
+            index < len(tokens)
+            and "=" in tokens[index]
+            and not tokens[index].startswith(("-", "/"))
+        ):
+            index += 1
+    if index >= len(tokens):
+        return None
+    if tokens[index] in {"{", "("}:
+        close = "}" if tokens[index] == "{" else ")"
+        close_index = tokens.index(close, index + 1) if close in tokens[index + 1 :] else -1
+        inner = tokens[index + 1 : close_index]
+        return close_index + 1 if inner and _success_command_end(inner, 0) == len(inner) else None
+    if tokens[index] not in _ALWAYS_SUCCESS_COMMANDS:
+        return None
+    index += 1
+    while index < len(tokens) and tokens[index] not in {"||", "&&", "|", ";"}:
+        index += 1
+    return index
 
 
 def _contains_unconditional_success_fallback(command: str) -> bool:
-    """Reject ``|| true``/``|| :`` without matching quoted data literals."""
+    """Reject a known-success ``||`` branch when it supplies the final status."""
     try:
-        lexer = shlex.shlex(command, posix=True, punctuation_chars="|&;<>")
+        lexer = shlex.shlex(command, posix=True, punctuation_chars="|&;<>()")
         lexer.whitespace_split = True
         lexer.commenters = ""
         tokens = list(lexer)
     except ValueError:
         return False
     for index, token in enumerate(tokens):
-        if token == "||" and index + 1 < len(tokens) and tokens[index + 1] in {"true", ":"}:
-            return True
+        if token == "||":
+            end = _success_command_end(tokens, index + 1)
+            if end is not None and end < len(tokens) and tokens[end] in {"&&", "||", "|", ";"}:
+                continue
+            if end is not None:
+                return True
         if token.rsplit("/", 1)[-1] not in _SHELL_COMMANDS or index + 2 >= len(tokens):
             continue
-        options = tokens[index + 1]
+        options_index = index + 1
+        options = tokens[options_index]
         if options.startswith("-") and "c" in options[1:]:
-            if _contains_unconditional_success_fallback(tokens[index + 2]):
+            body_index = options_index + 1
+            if body_index < len(tokens) and tokens[body_index] == "--":
+                body_index += 1
+            if body_index < len(tokens) and _contains_unconditional_success_fallback(
+                tokens[body_index]
+            ):
                 return True
     return False
 

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -2399,6 +2399,30 @@ class TestSeedGeneratorExtraction:
             "verify_command masks failure with an unconditional success fallback"
         )
 
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "bash --noprofile -c 'false || true'",
+            "false || { true; }",
+            "false || true && true",
+        ),
+    )
+    def test_verify_command_rejects_wrapped_and_compound_masks(self, command: str) -> None:
+        assert _unsupported_verify_command_reason(command) == (
+            "verify_command masks failure with an unconditional success fallback"
+        )
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "x=$(false || true); false",
+            "false || true && false",
+            "false || true | false",
+        ),
+    )
+    def test_verify_command_preserves_truthful_final_failure(self, command: str) -> None:
+        assert _unsupported_verify_command_reason(command) is None
+
     def test_verify_command_allows_fallback_text_inside_python_literal(self) -> None:
         command = '''python -c "print('document `|| true` as unsupported')"'''
 

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -32,6 +32,7 @@ from ouroboros.bigbang.seed_generator import (
     _parse_extracted_acceptance_criteria,
     _parse_ontology_fields,
     _parse_string_array_values,
+    _unsupported_verify_command_reason,
     load_seed,
     save_seed_sync,
 )
@@ -2369,7 +2370,79 @@ class TestSeedGeneratorExtraction:
             assert isinstance(second, AcceptanceCriterionSpec)
             assert second.output_assertion == "5 passed"
 
+    @pytest.mark.parametrize(
+        "command",
+        (
+            'python -c "raise SystemExit(1)" 2>&1 || true',
+            'python -c "raise SystemExit(1)" || :',
+            "bash -lc 'python -m pytest -q || true'",
+        ),
+    )
+    def test_verify_command_rejects_unconditional_success_fallback(self, command: str) -> None:
+        assert _unsupported_verify_command_reason(command) == (
+            "verify_command masks failure with an unconditional success fallback"
+        )
+
+    def test_verify_command_allows_fallback_text_inside_python_literal(self) -> None:
+        command = '''python -c "print('document `|| true` as unsupported')"'''
+
+        assert _unsupported_verify_command_reason(command) is None
+
     @pytest.mark.asyncio
+    async def test_generate_retries_when_verify_command_masks_failure(self) -> None:
+        mock_adapter = AsyncMock()
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+        bad_command = (
+            'python -c "import subprocess; '
+            "subprocess.run(['python', '-m', 'http.server', '8000'], timeout=1)\" "
+            "2>&1 || true"
+        )
+        bad_response = create_valid_extraction_response(
+            acceptance_criteria=json.dumps(
+                [
+                    {
+                        "description": "Widget persists after refresh",
+                        "verify": bad_command,
+                        "artifacts": ["app/widgets/weekly-review.js"],
+                        "expect": "NONE",
+                    }
+                ]
+            )
+        )
+        repaired_response = create_valid_extraction_response(
+            acceptance_criteria=json.dumps(
+                [
+                    {
+                        "description": "Widget implementation exists",
+                        "verify": "NONE",
+                        "artifacts": ["app/widgets/weekly-review.js"],
+                        "expect": "NONE",
+                    }
+                ]
+            )
+        )
+        mock_adapter.complete = AsyncMock(
+            side_effect=[
+                Result.ok(create_mock_completion_response(bad_response)),
+                Result.ok(create_mock_completion_response(repaired_response)),
+            ]
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+            result = await generator.generate(state, low_ambiguity)
+
+        assert result.is_ok
+        assert mock_adapter.complete.await_count == 2
+        (criterion,) = result.value.acceptance_criteria
+        assert isinstance(criterion, AcceptanceCriterionSpec)
+        assert criterion.verify_command is None
+        assert criterion.expected_artifacts == ("app/widgets/weekly-review.js",)
+
     @pytest.mark.parametrize(
         "heredoc_command",
         (

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -2383,6 +2383,22 @@ class TestSeedGeneratorExtraction:
             "verify_command masks failure with an unconditional success fallback"
         )
 
+    def test_verify_command_allows_later_failure_to_determine_status(self) -> None:
+        assert _unsupported_verify_command_reason("false || true && false") is None
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "false || env X=1 true",
+            "false || VAR=x command true",
+            "bash -c -- 'false || true'",
+        ),
+    )
+    def test_verify_command_rejects_equivalent_success_fallbacks(self, command: str) -> None:
+        assert _unsupported_verify_command_reason(command) == (
+            "verify_command masks failure with an unconditional success fallback"
+        )
+
     def test_verify_command_allows_fallback_text_inside_python_literal(self) -> None:
         command = '''python -c "print('document `|| true` as unsupported')"'''
 


### PR DESCRIPTION
## Summary

- Reject generated `verify_command` values that mask a failing check with `|| true` or `|| :`, including fallbacks inside explicit `sh -c` / `bash -lc` wrappers.
- Keep quoted literals and existing valid single-line commands unchanged.
- Tell the Seed architect to use exact artifacts rather than inventing a proxy command when one shell line cannot verify the criterion.

## Verification

- `uv run pytest -q tests/unit/bigbang/test_seed_generator.py` — 359 passed
- Ruff and diagnostics pass
- Regression covers the reported `http.server` timeout followed by `2>&1 || true` and proves generation retries to an artifact contract.

Closes #2155