### PR TITLE
fix(mcp): require auth for localhost.localdomain

### DIFF
--- a/src/ouroboros/mcp/server/auth.py
+++ b/src/ouroboros/mcp/server/auth.py
@@ -72,8 +72,9 @@ def is_loopback_host(host: str) -> bool:
         False: refusing to guess is the safe direction, since the caller uses
         this to decide whether credentials are mandatory.
     """
-    candidate = host.strip().strip("[]").lower().removesuffix(".")
-    if candidate in _LOOPBACK_HOSTNAMES:
+    candidate = host.strip().strip("[]").lower()
+    hostname_candidate = candidate.removesuffix(".")
+    if hostname_candidate in _LOOPBACK_HOSTNAMES:
         return True
     try:
         return ipaddress.ip_address(candidate).is_loopback

--- a/src/ouroboros/mcp/server/auth.py
+++ b/src/ouroboros/mcp/server/auth.py
@@ -46,9 +46,10 @@ NETWORK_TRANSPORTS = ("sse", "streamable-http")
 # bare unless settings are passed explicitly.
 _SDK_AUTOPROTECTED_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 
-# Hostnames that always resolve to this machine. ``""`` is deliberately absent:
-# an empty bind host means "every interface" to uvicorn, not loopback.
-_LOOPBACK_HOSTNAMES = frozenset({"localhost", "localhost.localdomain"})
+# DNS names guaranteed local by the supported resolver contract. ``localhost``
+# is RFC 6761 special-use; ``localhost.localdomain`` is only a conventional
+# hosts-file alias and can resolve to a routable address on other systems.
+_LOOPBACK_HOSTNAMES = frozenset({"localhost"})
 
 #: Scope minted for every accepted credential. Ouroboros authorizes per tool
 #: through ``SecurityLayer``, so the SDK layer only needs one opaque scope to
@@ -71,7 +72,7 @@ def is_loopback_host(host: str) -> bool:
         False: refusing to guess is the safe direction, since the caller uses
         this to decide whether credentials are mandatory.
     """
-    candidate = host.strip().strip("[]").lower()
+    candidate = host.strip().strip("[]").lower().removesuffix(".")
     if candidate in _LOOPBACK_HOSTNAMES:
         return True
     try:

--- a/tests/unit/mcp/server/test_network_security.py
+++ b/tests/unit/mcp/server/test_network_security.py
@@ -68,7 +68,17 @@ class TestHostClassification:
 
     @pytest.mark.parametrize(
         "host",
-        ["127.0.0.1", "localhost", "LOCALHOST", "::1", "[::1]", "127.0.0.2", " 127.0.0.1 "],
+        [
+            "127.0.0.1",
+            "localhost",
+            "LOCALHOST",
+            "localhost.",
+            "LOCALHOST.",
+            "::1",
+            "[::1]",
+            "127.0.0.2",
+            " 127.0.0.1 ",
+        ],
     )
     def test_loopback_hosts_recognized(self, host: str) -> None:
         """Every spelling that only this machine can reach counts as loopback."""
@@ -76,7 +86,16 @@ class TestHostClassification:
 
     @pytest.mark.parametrize(
         "host",
-        ["0.0.0.0", "::", "", "192.168.1.10", "example.com", "build-box.internal"],
+        [
+            "0.0.0.0",
+            "::",
+            "",
+            "192.168.1.10",
+            "example.com",
+            "build-box.internal",
+            "localhost.localdomain",
+            "LOCALHOST.LOCALDOMAIN.",
+        ],
     )
     def test_routable_hosts_are_not_loopback(self, host: str) -> None:
         """Anything reachable from elsewhere -- including unresolvable names."""
@@ -96,7 +115,9 @@ class TestServeRefusesUnauthenticatedExposure:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("transport", ["sse", "streamable-http"])
-    @pytest.mark.parametrize("host", ["0.0.0.0", "192.168.1.10", "example.com"])
+    @pytest.mark.parametrize(
+        "host", ["0.0.0.0", "192.168.1.10", "example.com", "localhost.localdomain"]
+    )
     async def test_non_loopback_without_auth_is_refused(self, transport: str, host: str) -> None:
         """A routable bind with no credentials never reaches the SDK."""
         adapter = MCPServerAdapter()

--- a/tests/unit/mcp/server/test_network_security.py
+++ b/tests/unit/mcp/server/test_network_security.py
@@ -95,6 +95,8 @@ class TestHostClassification:
             "build-box.internal",
             "localhost.localdomain",
             "LOCALHOST.LOCALDOMAIN.",
+            "127.0.0.1.",
+            "127.0.0.2.",
         ],
     )
     def test_routable_hosts_are_not_loopback(self, host: str) -> None:


### PR DESCRIPTION
## Summary

- Remove `localhost.localdomain` from the credential-free hostname set because it is a conventional alias, not a protocol-guaranteed loopback name.
- Continue accepting exact/case/root-dot `localhost` and literal loopback IP addresses without credentials.
- Route `localhost.localdomain` through the same fail-closed authentication decision used by other DNS names for both SSE and streamable HTTP.

## Verification

- `uv run pytest -q tests/unit/mcp/server/test_network_security.py` — 83 passed
- Ruff, format, and diagnostics pass
- Adapter regression proves an unauthenticated `localhost.localdomain` bind is rejected before SDK construction.

Closes #2049