### PR TITLE
fix(security): drop transformed hidden retry output

### DIFF
--- a/docs/contributing/source-tour.md
+++ b/docs/contributing/source-tour.md
@@ -9,15 +9,15 @@ would want you to judge us by.
 
 `src/ouroboros/orchestrator/contract_redaction.py`
 
-- `contract_redaction.py:10`: `hidden_contract_variants` enumerates the five
-  encodings that get masked.
-- `contract_redaction.py:42`: the substitution is literal `str.replace`.
-  That means a reshaped copy of a hidden value is not caught. We track that
-  gap in a public issue rather than claiming otherwise.
-- `retry_hints.py:76`: `build_assertion_safe_retry_hint`: retry hints are
-  assembled deterministically, no model call.
-- `retry_hints.py:102`: the retry prompt carries a tail of command output;
-  redaction on it is the same literal substitution.
+- `hidden_contract_variants` enumerates raw, quoted, and escaped forms for exact
+  masking.
+- `contains_transformed_hidden_contract_value` applies bounded, fail-closed
+  HTML/Unicode/terminal normalization before retry output crosses into a worker
+  prompt. Stateful terminal controls are rejected; harmless SGR styling may be
+  normalized away.
+- `retry_hints.py` assembles retry hints deterministically, with no model call.
+  The command-output tail passes through the shared exact and transformed-value
+  boundary before inclusion.
 
 The claim's exact scope: when an acceptance criterion defines a verify
 command or an expected-output assertion, those values are omitted from the

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+import html
 import json
+import re
 import shlex
 
 
@@ -27,6 +29,33 @@ def hidden_contract_variants(values: Iterable[str | None]) -> tuple[str, ...]:
     return tuple(
         sorted((value for value in variants if value), key=lambda value: (-len(value), value))
     )
+
+
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_LINE_PREFIX_RE = re.compile(r"(?m)^\s*(?:[EIWF]\s+|[+>~-]\s?)")
+
+
+def _normalized_contract_text(text: str) -> str:
+    """Normalize routine verifier-output transformations for leak detection."""
+    unescaped = html.unescape(text)
+    without_ansi = _ANSI_ESCAPE_RE.sub("", unescaped)
+    without_prefixes = _LINE_PREFIX_RE.sub("", without_ansi)
+    return "".join(char.casefold() for char in without_prefixes if char.isalnum())
+
+
+def contains_transformed_hidden_contract_value(
+    text: str,
+    values: Iterable[str | None],
+) -> bool:
+    """Return whether normalized output still carries a readable hidden value."""
+    normalized_text = _normalized_contract_text(text)
+    for hidden in values:
+        if not hidden:
+            continue
+        normalized_hidden = _normalized_contract_text(hidden)
+        if normalized_hidden and normalized_hidden in normalized_text:
+            return True
+    return False
 
 
 def redact_hidden_contract_values(

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -34,6 +34,12 @@ def hidden_contract_variants(values: Iterable[str | None]) -> tuple[str, ...]:
 
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;:]*m")
 _OSC_ESCAPE_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
+_ESCAPED_TERMINAL_CONTROL_RE = re.compile(
+    r"(?ix)(?:"
+    r"\\(?:x(?:1b|08|9[08bef])|u(?:001b|0008|009[08bef])|U(?:0000001b|00000008|0000009[08bef])|0(?:33|10)|e|b)"
+    r"|\\?\^\["
+    r")"
+)
 _LINE_PREFIX_RE = re.compile(r"(?m)^\s*(?:[EIWF]\s+|[+>~-]\s?)")
 _UNSUPPORTED_TERMINAL_CONTROL_RE = re.compile(
     r"(?:\x1b(?:P|_|\^|X)|[\x90\x98\x9e\x9f]).*?(?:\x1b\\|\x9c)",
@@ -71,6 +77,8 @@ def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str |
 
 def contains_unsupported_terminal_control(text: str) -> bool:
     """Return whether output carries controls outside normalized CSI/OSC."""
+    if _ESCAPED_TERMINAL_CONTROL_RE.search(text):
+        return True
     without_known = _ANSI_ESCAPE_RE.sub("", _OSC_ESCAPE_RE.sub("", text))
     if _UNSUPPORTED_TERMINAL_CONTROL_RE.search(without_known):
         return True

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -44,7 +44,7 @@ _UNSUPPORTED_TERMINAL_CONTROL_RE = re.compile(
 def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str:
     """Normalize routine verifier-output transformations for leak detection."""
     unescaped = text
-    for _ in range(3):
+    for _ in range(12):
         decoded = html.unescape(unescaped)
         if decoded == unescaped:
             break
@@ -52,7 +52,11 @@ def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str:
     unescaped = unicodedata.normalize("NFKC", unescaped)
     without_ansi = _ANSI_ESCAPE_RE.sub("", unescaped)
     without_ansi = _OSC_ESCAPE_RE.sub("", without_ansi)
-    without_ansi = "".join(char for char in without_ansi if ord(char) >= 32 or char in "\n\r\t")
+    without_ansi = "".join(
+        char
+        for char in without_ansi
+        if (ord(char) >= 32 or char in "\n\r\t") and unicodedata.category(char) != "Cf"
+    )
     without_prefixes = _LINE_PREFIX_RE.sub("", without_ansi)
     if preserve_punctuation:
         return "".join(char.casefold() for char in without_prefixes if not char.isspace())

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -50,20 +50,24 @@ def contains_transformed_hidden_contract_value(
     values: Iterable[str | None],
 ) -> bool:
     """Return whether a non-exact normalized copy carries a hidden value."""
-    normalized_text = _normalized_contract_text(text, preserve_punctuation=False)
-    compact_text = _normalized_contract_text(text, preserve_punctuation=True)
     for hidden in values:
         if not hidden:
             continue
-        if any(variant in text for variant in hidden_contract_variants((hidden,))):
-            continue
+        remaining = text
+        for variant in hidden_contract_variants((hidden,)):
+            remaining = remaining.replace(variant, "")
+        normalized_remaining = _normalized_contract_text(
+            remaining,
+            preserve_punctuation=False,
+        )
         normalized_hidden = _normalized_contract_text(hidden, preserve_punctuation=False)
         if normalized_hidden:
-            if normalized_hidden in normalized_text:
+            if normalized_hidden in normalized_remaining:
                 return True
             continue
+        compact_remaining = _normalized_contract_text(remaining, preserve_punctuation=True)
         compact_hidden = _normalized_contract_text(hidden, preserve_punctuation=True)
-        if compact_hidden and compact_hidden in compact_text:
+        if compact_hidden and compact_hidden in compact_remaining:
             return True
     return False
 

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -94,16 +94,28 @@ def _decode_escaped_unicode(text: str) -> str | None:
     return None if invalid else decoded
 
 
+def _decode_contract_encodings(text: str) -> str | None:
+    decoded_text = text
+    for _ in range(_MAX_HTML_ENTITY_DECODE_PASSES):
+        html_decoded = _decode_html_entities(decoded_text)
+        if html_decoded is None:
+            return None
+        unicode_decoded = _decode_escaped_unicode(html_decoded)
+        if unicode_decoded is None:
+            return None
+        decoded = _ESCAPED_WHITESPACE_RE.sub(" ", unicode_decoded)
+        if decoded == decoded_text:
+            return decoded_text
+        decoded_text = decoded
+    return None
+
+
 def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str | None:
     """Normalize routine verifier-output transformations for leak detection."""
-    unescaped = _decode_html_entities(text)
-    if unescaped is None:
-        return None
-    unescaped = _decode_escaped_unicode(unescaped)
+    unescaped = _decode_contract_encodings(text)
     if unescaped is None:
         return None
     unescaped = unicodedata.normalize("NFKC", unescaped)
-    unescaped = _ESCAPED_WHITESPACE_RE.sub(" ", unescaped)
     without_ansi = _ANSI_ESCAPE_RE.sub("", unescaped)
     without_ansi = _OSC_ESCAPE_RE.sub("", without_ansi)
     without_ansi = "".join(
@@ -125,10 +137,7 @@ def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str |
 
 def contains_unsupported_terminal_control(text: str) -> bool:
     """Return whether output carries controls outside normalized CSI/OSC."""
-    decoded = _decode_html_entities(text)
-    if decoded is None:
-        return True
-    decoded = _decode_escaped_unicode(decoded)
+    decoded = _decode_contract_encodings(text)
     if decoded is None:
         return True
     if _ESCAPED_TERMINAL_CONTROL_RE.search(decoded):

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -47,7 +47,8 @@ _ESCAPED_UNICODE_RE = re.compile(
     r"\\(?:x(?P<byte>[0-9a-fA-F]{2})|u(?P<short>[0-9a-fA-F]{4})|U(?P<long>[0-9a-fA-F]{8}))"
 )
 _NUMERIC_ENTITY_RE = re.compile(r"&#(?:(?P<decimal>\d+)|[xX](?P<hex>[0-9a-fA-F]+));?")
-_LINE_PREFIX_RE = re.compile(r"(?m)^\s*(?:[EIWF]\s+|[+>~-]\s?)")
+_ESCAPED_BYTE_RUN_RE = re.compile(r"(?:\\x[0-9a-fA-F]{2})+")
+_LINE_PREFIX_RE = re.compile(r"(?m)^[ \t]*(?:[EIWF][ \t]+|[+>~-][ \t]?)")
 _UNSUPPORTED_TERMINAL_CONTROL_RE = re.compile(
     r"(?:\x1b(?:P|_|\^|X)|[\x90\x98\x9e\x9f]).*?(?:\x1b\\|\x9c)",
     re.DOTALL,
@@ -94,23 +95,59 @@ def _decode_escaped_unicode(text: str) -> str | None:
     return None if invalid else decoded
 
 
+def _decode_escaped_byte_runs(text: str) -> str | None:
+    invalid = False
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal invalid
+        raw = bytes.fromhex(match.group(0).replace("\\x", ""))
+        try:
+            return raw.decode("utf-8")
+        except UnicodeDecodeError:
+            invalid = True
+            return ""
+
+    decoded = _ESCAPED_BYTE_RUN_RE.sub(replace, text)
+    return None if invalid else decoded
+
+
+def _decode_escaped_whitespace(text: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        token = match.group(0).lower()
+        if token in {r"\n", r"\x0a", r"\u000a", r"\u0000000a", r"\012"}:
+            return "\n"
+        if token in {r"\r", r"\x0d", r"\u000d", r"\u0000000d", r"\015"}:
+            return "\r"
+        return "\t"
+
+    return _ESCAPED_WHITESPACE_RE.sub(replace, text)
+
+
 def _decode_contract_encodings(text: str) -> str | None:
     decoded_text = text
     for _ in range(_MAX_HTML_ENTITY_DECODE_PASSES):
         html_decoded = _decode_html_entities(decoded_text)
         if html_decoded is None:
             return None
-        unicode_decoded = _decode_escaped_unicode(html_decoded)
+        byte_decoded = _decode_escaped_byte_runs(html_decoded)
+        if byte_decoded is None:
+            return None
+        unicode_decoded = _decode_escaped_unicode(byte_decoded)
         if unicode_decoded is None:
             return None
-        decoded = _ESCAPED_WHITESPACE_RE.sub(" ", unicode_decoded)
+        decoded = _decode_escaped_whitespace(unicode_decoded)
         if decoded == decoded_text:
             return decoded_text
         decoded_text = decoded
     return None
 
 
-def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str | None:
+def _normalized_contract_text(
+    text: str,
+    *,
+    preserve_punctuation: bool,
+    strip_line_prefixes: bool = True,
+) -> str | None:
     """Normalize routine verifier-output transformations for leak detection."""
     unescaped = _decode_contract_encodings(text)
     if unescaped is None:
@@ -124,7 +161,9 @@ def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str |
         if (ord(char) >= 32 or char in "\n\r\t")
         and unicodedata.category(char) not in {"Cf", "Mn", "Me"}
     )
-    without_prefixes = _LINE_PREFIX_RE.sub("", without_ansi)
+    without_prefixes = (
+        _LINE_PREFIX_RE.sub("", without_ansi) if strip_line_prefixes else without_ansi
+    )
     folded = "".join(char.casefold() for char in without_prefixes)
     if preserve_punctuation:
         return "".join(
@@ -142,7 +181,9 @@ def contains_unsupported_terminal_control(text: str) -> bool:
         return True
     if _ESCAPED_TERMINAL_CONTROL_RE.search(decoded):
         return True
-    without_known = _ANSI_ESCAPE_RE.sub("", _OSC_ESCAPE_RE.sub("", decoded))
+    if _OSC_ESCAPE_RE.search(decoded):
+        return True
+    without_known = _ANSI_ESCAPE_RE.sub("", decoded)
     if _UNSUPPORTED_TERMINAL_CONTROL_RE.search(without_known):
         return True
     return any(
@@ -162,23 +203,34 @@ def contains_transformed_hidden_contract_value(
         remaining = text
         for variant in hidden_contract_variants((hidden,)):
             remaining = remaining.replace(variant, "")
-        normalized_remaining = _normalized_contract_text(
-            remaining,
-            preserve_punctuation=False,
-        )
         normalized_hidden = _normalized_contract_text(hidden, preserve_punctuation=False)
-        if normalized_remaining is None or normalized_hidden is None:
+        if normalized_hidden is None:
             return True
-        if normalized_hidden:
-            if normalized_hidden in normalized_remaining:
+        for strip_prefixes in (True, False):
+            normalized_remaining = _normalized_contract_text(
+                remaining,
+                preserve_punctuation=False,
+                strip_line_prefixes=strip_prefixes,
+            )
+            if normalized_remaining is None:
                 return True
+            if normalized_hidden and normalized_hidden in normalized_remaining:
+                return True
+        if normalized_hidden:
             continue
-        compact_remaining = _normalized_contract_text(remaining, preserve_punctuation=True)
         compact_hidden = _normalized_contract_text(hidden, preserve_punctuation=True)
-        if compact_remaining is None or compact_hidden is None:
+        if compact_hidden is None:
             return True
-        if compact_hidden and compact_hidden in compact_remaining:
-            return True
+        for strip_prefixes in (True, False):
+            compact_remaining = _normalized_contract_text(
+                remaining,
+                preserve_punctuation=True,
+                strip_line_prefixes=strip_prefixes,
+            )
+            if compact_remaining is None:
+                return True
+            if compact_hidden and compact_hidden in compact_remaining:
+                return True
     return False
 
 

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -53,8 +53,14 @@ def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str:
 
 
 def contains_unsupported_terminal_control(text: str) -> bool:
-    """Return whether verifier output carries a non-CSI/OSC control string."""
-    return bool(_UNSUPPORTED_TERMINAL_CONTROL_RE.search(text))
+    """Return whether output carries controls outside normalized CSI/OSC."""
+    without_known = _ANSI_ESCAPE_RE.sub("", _OSC_ESCAPE_RE.sub("", text))
+    if _UNSUPPORTED_TERMINAL_CONTROL_RE.search(without_known):
+        return True
+    return any(
+        char == "\x1b" or 0x80 <= ord(char) <= 0x9F or (ord(char) < 32 and char not in "\n\r\t")
+        for char in without_known
+    )
 
 
 def contains_transformed_hidden_contract_value(

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -77,17 +77,21 @@ def _decode_html_entities(text: str) -> str | None:
     return None
 
 
-def _decode_escaped_invisible_chars(text: str) -> str:
+def _decode_escaped_unicode(text: str) -> str | None:
+    invalid = False
+
     def replace(match: re.Match[str]) -> str:
+        nonlocal invalid
         encoded = match.group("byte") or match.group("short") or match.group("long")
         assert encoded is not None
-        char = chr(int(encoded, 16))
-        category = unicodedata.category(char)
-        if category in {"Cc", "Cf", "Mn", "Me"} or 0x80 <= ord(char) <= 0x9F:
-            return char
-        return match.group(0)
+        try:
+            return chr(int(encoded, 16))
+        except (ValueError, OverflowError):
+            invalid = True
+            return ""
 
-    return _ESCAPED_UNICODE_RE.sub(replace, text)
+    decoded = _ESCAPED_UNICODE_RE.sub(replace, text)
+    return None if invalid else decoded
 
 
 def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str | None:
@@ -95,7 +99,9 @@ def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str |
     unescaped = _decode_html_entities(text)
     if unescaped is None:
         return None
-    unescaped = _decode_escaped_invisible_chars(unescaped)
+    unescaped = _decode_escaped_unicode(unescaped)
+    if unescaped is None:
+        return None
     unescaped = unicodedata.normalize("NFKC", unescaped)
     unescaped = _ESCAPED_WHITESPACE_RE.sub(" ", unescaped)
     without_ansi = _ANSI_ESCAPE_RE.sub("", unescaped)
@@ -122,7 +128,9 @@ def contains_unsupported_terminal_control(text: str) -> bool:
     decoded = _decode_html_entities(text)
     if decoded is None:
         return True
-    decoded = _decode_escaped_invisible_chars(decoded)
+    decoded = _decode_escaped_unicode(decoded)
+    if decoded is None:
+        return True
     if _ESCAPED_TERMINAL_CONTROL_RE.search(decoded):
         return True
     without_known = _ANSI_ESCAPE_RE.sub("", _OSC_ESCAPE_RE.sub("", decoded))

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -32,6 +32,7 @@ def hidden_contract_variants(values: Iterable[str | None]) -> tuple[str, ...]:
 
 
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_OSC_ESCAPE_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
 _LINE_PREFIX_RE = re.compile(r"(?m)^\s*(?:[EIWF]\s+|[+>~-]\s?)")
 
 
@@ -39,6 +40,8 @@ def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str:
     """Normalize routine verifier-output transformations for leak detection."""
     unescaped = html.unescape(text)
     without_ansi = _ANSI_ESCAPE_RE.sub("", unescaped)
+    without_ansi = _OSC_ESCAPE_RE.sub("", without_ansi)
+    without_ansi = "".join(char for char in without_ansi if ord(char) >= 32 or char in "\n\r\t")
     without_prefixes = _LINE_PREFIX_RE.sub("", without_ansi)
     if preserve_punctuation:
         return "".join(char.casefold() for char in without_prefixes if not char.isspace())

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -52,6 +52,7 @@ _ESCAPED_SURROGATE_PAIR_RE = re.compile(
 _NUMERIC_ENTITY_RE = re.compile(r"&#(?:(?P<decimal>\d+)|[xX](?P<hex>[0-9a-fA-F]+));?")
 _ESCAPED_BYTE_RUN_RE = re.compile(r"(?:\\x[0-9a-fA-F]{2})+")
 _ESCAPED_OCTAL_RUN_RE = re.compile(r"(?:\\[0-7]{3})+")
+_PERCENT_BYTE_RUN_RE = re.compile(r"(?:%[0-9a-fA-F]{2})+")
 _LINE_PREFIX_RE = re.compile(r"(?m)^[ \t]*(?:[EIWF][ \t]+|[+>~-][ \t]?)")
 _UNSUPPORTED_TERMINAL_CONTROL_RE = re.compile(
     r"(?:\x1b(?:P|_|\^|X)|[\x90\x98\x9e\x9f]).*?(?:\x1b\\|\x9c)",
@@ -144,6 +145,22 @@ def _decode_escaped_whitespace(text: str) -> str:
     return _ESCAPED_WHITESPACE_RE.sub(replace, text)
 
 
+def _decode_percent_runs(text: str) -> str | None:
+    invalid = False
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal invalid
+        raw = bytes.fromhex(match.group(0).replace("%", ""))
+        try:
+            return raw.decode("utf-8")
+        except UnicodeDecodeError:
+            invalid = True
+            return ""
+
+    decoded = _PERCENT_BYTE_RUN_RE.sub(replace, text)
+    return None if invalid else decoded
+
+
 def _decode_contract_encodings(text: str) -> str | None:
     decoded_text = text
     for _ in range(_MAX_HTML_ENTITY_DECODE_PASSES):
@@ -157,7 +174,10 @@ def _decode_contract_encodings(text: str) -> str | None:
         unicode_decoded = _decode_escaped_unicode(byte_decoded)
         if unicode_decoded is None:
             return None
-        decoded = _decode_escaped_whitespace(unicode_decoded)
+        percent_decoded = _decode_percent_runs(unicode_decoded)
+        if percent_decoded is None:
+            return None
+        decoded = _decode_escaped_whitespace(percent_decoded)
         if decoded == decoded_text:
             return decoded
         decoded_text = decoded

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -46,6 +46,9 @@ _ESCAPED_WHITESPACE_RE = re.compile(
 _ESCAPED_UNICODE_RE = re.compile(
     r"\\(?:x(?P<byte>[0-9a-fA-F]{2})|u(?P<short>[0-9a-fA-F]{4})|U(?P<long>[0-9a-fA-F]{8}))"
 )
+_ESCAPED_SURROGATE_PAIR_RE = re.compile(
+    r"\\u(?P<high>[dD][89aAbB][0-9a-fA-F]{2})\\u(?P<low>[dD][c-fC-F][0-9a-fA-F]{2})"
+)
 _NUMERIC_ENTITY_RE = re.compile(r"&#(?:(?P<decimal>\d+)|[xX](?P<hex>[0-9a-fA-F]+));?")
 _ESCAPED_BYTE_RUN_RE = re.compile(r"(?:\\x[0-9a-fA-F]{2})+")
 _ESCAPED_OCTAL_RUN_RE = re.compile(r"(?:\\[0-7]{3})+")
@@ -82,17 +85,27 @@ def _decode_html_entities(text: str) -> str | None:
 def _decode_escaped_unicode(text: str) -> str | None:
     invalid = False
 
+    def replace_pair(match: re.Match[str]) -> str:
+        high = int(match.group("high"), 16)
+        low = int(match.group("low"), 16)
+        return chr(0x10000 + ((high - 0xD800) << 10) + (low - 0xDC00))
+
     def replace(match: re.Match[str]) -> str:
         nonlocal invalid
         encoded = match.group("byte") or match.group("short") or match.group("long")
         assert encoded is not None
         try:
-            return chr(int(encoded, 16))
+            codepoint = int(encoded, 16)
+            if 0xD800 <= codepoint <= 0xDFFF:
+                invalid = True
+                return ""
+            return chr(codepoint)
         except (ValueError, OverflowError):
             invalid = True
             return ""
 
-    decoded = _ESCAPED_UNICODE_RE.sub(replace, text)
+    decoded = _ESCAPED_SURROGATE_PAIR_RE.sub(replace_pair, text)
+    decoded = _ESCAPED_UNICODE_RE.sub(replace, decoded)
     return None if invalid else decoded
 
 

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -125,8 +125,12 @@ def _decode_escaped_byte_runs(text: str) -> str | None:
         return decode_bytes(bytes.fromhex(match.group(0).replace("\\x", "")))
 
     def replace_octal(match: re.Match[str]) -> str:
-        values = re.findall(r"\\([0-7]{3})", match.group(0))
-        return decode_bytes(bytes(int(value, 8) for value in values))
+        nonlocal invalid
+        values = [int(value, 8) for value in re.findall(r"\\([0-7]{3})", match.group(0))]
+        if any(value > 0xFF for value in values):
+            invalid = True
+            return ""
+        return decode_bytes(bytes(values))
 
     decoded = _ESCAPED_BYTE_RUN_RE.sub(replace_hex, text)
     decoded = _ESCAPED_OCTAL_RUN_RE.sub(replace_octal, decoded)

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -48,6 +48,7 @@ _ESCAPED_UNICODE_RE = re.compile(
 )
 _NUMERIC_ENTITY_RE = re.compile(r"&#(?:(?P<decimal>\d+)|[xX](?P<hex>[0-9a-fA-F]+));?")
 _ESCAPED_BYTE_RUN_RE = re.compile(r"(?:\\x[0-9a-fA-F]{2})+")
+_ESCAPED_OCTAL_RUN_RE = re.compile(r"(?:\\[0-7]{3})+")
 _LINE_PREFIX_RE = re.compile(r"(?m)^[ \t]*(?:[EIWF][ \t]+|[+>~-][ \t]?)")
 _UNSUPPORTED_TERMINAL_CONTROL_RE = re.compile(
     r"(?:\x1b(?:P|_|\^|X)|[\x90\x98\x9e\x9f]).*?(?:\x1b\\|\x9c)",
@@ -98,16 +99,23 @@ def _decode_escaped_unicode(text: str) -> str | None:
 def _decode_escaped_byte_runs(text: str) -> str | None:
     invalid = False
 
-    def replace(match: re.Match[str]) -> str:
+    def decode_bytes(raw: bytes) -> str:
         nonlocal invalid
-        raw = bytes.fromhex(match.group(0).replace("\\x", ""))
         try:
             return raw.decode("utf-8")
         except UnicodeDecodeError:
             invalid = True
             return ""
 
-    decoded = _ESCAPED_BYTE_RUN_RE.sub(replace, text)
+    def replace_hex(match: re.Match[str]) -> str:
+        return decode_bytes(bytes.fromhex(match.group(0).replace("\\x", "")))
+
+    def replace_octal(match: re.Match[str]) -> str:
+        values = re.findall(r"\\([0-7]{3})", match.group(0))
+        return decode_bytes(bytes(int(value, 8) for value in values))
+
+    decoded = _ESCAPED_BYTE_RUN_RE.sub(replace_hex, text)
+    decoded = _ESCAPED_OCTAL_RUN_RE.sub(replace_octal, decoded)
     return None if invalid else decoded
 
 
@@ -126,7 +134,8 @@ def _decode_escaped_whitespace(text: str) -> str:
 def _decode_contract_encodings(text: str) -> str | None:
     decoded_text = text
     for _ in range(_MAX_HTML_ENTITY_DECODE_PASSES):
-        html_decoded = _decode_html_entities(decoded_text)
+        normalized_text = unicodedata.normalize("NFKC", decoded_text)
+        html_decoded = _decode_html_entities(normalized_text)
         if html_decoded is None:
             return None
         byte_decoded = _decode_escaped_byte_runs(html_decoded)
@@ -137,7 +146,7 @@ def _decode_contract_encodings(text: str) -> str | None:
             return None
         decoded = _decode_escaped_whitespace(unicode_decoded)
         if decoded == decoded_text:
-            return decoded_text
+            return decoded
         decoded_text = decoded
     return None
 
@@ -158,8 +167,7 @@ def _normalized_contract_text(
     without_ansi = "".join(
         char
         for char in without_ansi
-        if (ord(char) >= 32 or char in "\n\r\t")
-        and unicodedata.category(char) not in {"Cf", "Mn", "Me"}
+        if char in "\n\r\t" or unicodedata.category(char) not in {"Cc", "Cf", "Mn", "Me"}
     )
     without_prefixes = (
         _LINE_PREFIX_RE.sub("", without_ansi) if strip_line_prefixes else without_ansi
@@ -187,7 +195,7 @@ def contains_unsupported_terminal_control(text: str) -> bool:
     if _UNSUPPORTED_TERMINAL_CONTROL_RE.search(without_known):
         return True
     return any(
-        char == "\x1b" or 0x80 <= ord(char) <= 0x9F or (ord(char) < 32 and char not in "\n\r\t")
+        (unicodedata.category(char) == "Cc" and char not in "\n\r\t") or 0x80 <= ord(char) <= 0x9F
         for char in without_known
     )
 

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -64,18 +64,28 @@ _MAX_HTML_ENTITY_DECODE_PASSES = 64
 
 
 def _decode_html_entities(text: str) -> str | None:
+    invalid = False
+
     def decode_numeric(match: re.Match[str]) -> str:
+        nonlocal invalid
         encoded = match.group("decimal") or match.group("hex")
         assert encoded is not None
         base = 10 if match.group("decimal") is not None else 16
         try:
-            return chr(int(encoded, base))
+            codepoint = int(encoded, base)
+            if codepoint > 0x10FFFF or 0xD800 <= codepoint <= 0xDFFF:
+                invalid = True
+                return ""
+            return chr(codepoint)
         except (ValueError, OverflowError):
-            return match.group(0)
+            invalid = True
+            return ""
 
     decoded_text = text
     for _ in range(_MAX_HTML_ENTITY_DECODE_PASSES):
         numeric_decoded = _NUMERIC_ENTITY_RE.sub(decode_numeric, decoded_text)
+        if invalid:
+            return None
         decoded = html.unescape(numeric_decoded)
         if decoded == decoded_text:
             return decoded_text
@@ -232,7 +242,8 @@ def contains_unsupported_terminal_control(text: str) -> bool:
     if _UNSUPPORTED_TERMINAL_CONTROL_RE.search(without_known):
         return True
     return any(
-        (unicodedata.category(char) == "Cc" and char not in "\n\r\t") or 0x80 <= ord(char) <= 0x9F
+        (unicodedata.category(char) in {"Cc", "Cf"} and char not in "\n\r\t")
+        or 0x80 <= ord(char) <= 0x9F
         for char in without_known
     )
 

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -32,7 +32,7 @@ def hidden_contract_variants(values: Iterable[str | None]) -> tuple[str, ...]:
     )
 
 
-_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;:]*m")
 _OSC_ESCAPE_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
 _LINE_PREFIX_RE = re.compile(r"(?m)^\s*(?:[EIWF]\s+|[+>~-]\s?)")
 _UNSUPPORTED_TERMINAL_CONTROL_RE = re.compile(

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -51,7 +51,7 @@ _ESCAPED_SURROGATE_PAIR_RE = re.compile(
 )
 _NUMERIC_ENTITY_RE = re.compile(r"&#(?:(?P<decimal>\d+)|[xX](?P<hex>[0-9a-fA-F]+));?")
 _ESCAPED_BYTE_RUN_RE = re.compile(r"(?:\\x[0-9a-fA-F]{2})+")
-_ESCAPED_OCTAL_RUN_RE = re.compile(r"(?:\\[0-7]{3})+")
+_ESCAPED_OCTAL_RUN_RE = re.compile(r"(?:\\[0-7]{1,3})+")
 _PERCENT_BYTE_RUN_RE = re.compile(r"(?:%[0-9a-fA-F]{2})+")
 _LINE_PREFIX_RE = re.compile(r"(?m)^[ \t]*(?:[EIWF][ \t]+|[+>~-][ \t]?)")
 _MALFORMED_ENCODING_RE = re.compile(
@@ -146,7 +146,7 @@ def _decode_escaped_byte_runs(text: str) -> str | None:
 
     def replace_octal(match: re.Match[str]) -> str:
         nonlocal invalid
-        values = [int(value, 8) for value in re.findall(r"\\([0-7]{3})", match.group(0))]
+        values = [int(value, 8) for value in re.findall(r"\\([0-7]{1,3})", match.group(0))]
         if any(value > 0xFF for value in values):
             invalid = True
             return ""

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -35,11 +35,13 @@ _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 _LINE_PREFIX_RE = re.compile(r"(?m)^\s*(?:[EIWF]\s+|[+>~-]\s?)")
 
 
-def _normalized_contract_text(text: str) -> str:
+def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str:
     """Normalize routine verifier-output transformations for leak detection."""
     unescaped = html.unescape(text)
     without_ansi = _ANSI_ESCAPE_RE.sub("", unescaped)
     without_prefixes = _LINE_PREFIX_RE.sub("", without_ansi)
+    if preserve_punctuation:
+        return "".join(char.casefold() for char in without_prefixes if not char.isspace())
     return "".join(char.casefold() for char in without_prefixes if char.isalnum())
 
 
@@ -47,13 +49,21 @@ def contains_transformed_hidden_contract_value(
     text: str,
     values: Iterable[str | None],
 ) -> bool:
-    """Return whether normalized output still carries a readable hidden value."""
-    normalized_text = _normalized_contract_text(text)
+    """Return whether a non-exact normalized copy carries a hidden value."""
+    normalized_text = _normalized_contract_text(text, preserve_punctuation=False)
+    compact_text = _normalized_contract_text(text, preserve_punctuation=True)
     for hidden in values:
         if not hidden:
             continue
-        normalized_hidden = _normalized_contract_text(hidden)
-        if normalized_hidden and normalized_hidden in normalized_text:
+        if any(variant in text for variant in hidden_contract_variants((hidden,))):
+            continue
+        normalized_hidden = _normalized_contract_text(hidden, preserve_punctuation=False)
+        if normalized_hidden:
+            if normalized_hidden in normalized_text:
+                return True
+            continue
+        compact_hidden = _normalized_contract_text(hidden, preserve_punctuation=True)
+        if compact_hidden and compact_hidden in compact_text:
             return True
     return False
 

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -40,6 +40,9 @@ _ESCAPED_TERMINAL_CONTROL_RE = re.compile(
     r"|\\?\^\["
     r")"
 )
+_ESCAPED_WHITESPACE_RE = re.compile(
+    r"(?ix)\\(?:n|r|t|x0[9ad]|u000[9ad]|U0000000[9ad]|0(?:11|12|15))"
+)
 _LINE_PREFIX_RE = re.compile(r"(?m)^\s*(?:[EIWF]\s+|[+>~-]\s?)")
 _UNSUPPORTED_TERMINAL_CONTROL_RE = re.compile(
     r"(?:\x1b(?:P|_|\^|X)|[\x90\x98\x9e\x9f]).*?(?:\x1b\\|\x9c)",
@@ -61,6 +64,7 @@ def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str |
     else:
         return None
     unescaped = unicodedata.normalize("NFKC", unescaped)
+    unescaped = _ESCAPED_WHITESPACE_RE.sub(" ", unescaped)
     without_ansi = _ANSI_ESCAPE_RE.sub("", unescaped)
     without_ansi = _OSC_ESCAPE_RE.sub("", without_ansi)
     without_ansi = "".join(
@@ -70,9 +74,14 @@ def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str |
         and unicodedata.category(char) not in {"Cf", "Mn", "Me"}
     )
     without_prefixes = _LINE_PREFIX_RE.sub("", without_ansi)
+    folded = "".join(char.casefold() for char in without_prefixes)
     if preserve_punctuation:
-        return "".join(char.casefold() for char in without_prefixes if not char.isspace())
-    return "".join(char.casefold() for char in without_prefixes if char.isalnum())
+        return "".join(
+            char
+            for char in folded
+            if not char.isspace() and unicodedata.category(char) not in {"Cf", "Mn", "Me"}
+        )
+    return "".join(char for char in folded if char.isalnum())
 
 
 def contains_unsupported_terminal_control(text: str) -> bool:

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -256,7 +256,7 @@ def contains_unsupported_terminal_control(text: str) -> bool:
     if _UNSUPPORTED_TERMINAL_CONTROL_RE.search(without_known):
         return True
     return any(
-        (unicodedata.category(char) in {"Cc", "Cf"} and char not in "\n\r\t")
+        (unicodedata.category(char) in {"Cc", "Cf", "Cs"} and char not in "\n\r\t")
         or 0x80 <= ord(char) <= 0x9F
         for char in without_known
     )

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -7,6 +7,7 @@ import html
 import json
 import re
 import shlex
+import unicodedata
 
 
 def hidden_contract_variants(values: Iterable[str | None]) -> tuple[str, ...]:
@@ -42,7 +43,13 @@ _UNSUPPORTED_TERMINAL_CONTROL_RE = re.compile(
 
 def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str:
     """Normalize routine verifier-output transformations for leak detection."""
-    unescaped = html.unescape(text)
+    unescaped = text
+    for _ in range(3):
+        decoded = html.unescape(unescaped)
+        if decoded == unescaped:
+            break
+        unescaped = decoded
+    unescaped = unicodedata.normalize("NFKC", unescaped)
     without_ansi = _ANSI_ESCAPE_RE.sub("", unescaped)
     without_ansi = _OSC_ESCAPE_RE.sub("", without_ansi)
     without_ansi = "".join(char for char in without_ansi if ord(char) >= 32 or char in "\n\r\t")

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -43,6 +43,10 @@ _ESCAPED_TERMINAL_CONTROL_RE = re.compile(
 _ESCAPED_WHITESPACE_RE = re.compile(
     r"(?ix)\\(?:n|r|t|x0[9ad]|u000[9ad]|U0000000[9ad]|0(?:11|12|15))"
 )
+_ESCAPED_UNICODE_RE = re.compile(
+    r"\\(?:x(?P<byte>[0-9a-fA-F]{2})|u(?P<short>[0-9a-fA-F]{4})|U(?P<long>[0-9a-fA-F]{8}))"
+)
+_NUMERIC_ENTITY_RE = re.compile(r"&#(?:(?P<decimal>\d+)|[xX](?P<hex>[0-9a-fA-F]+));?")
 _LINE_PREFIX_RE = re.compile(r"(?m)^\s*(?:[EIWF]\s+|[+>~-]\s?)")
 _UNSUPPORTED_TERMINAL_CONTROL_RE = re.compile(
     r"(?:\x1b(?:P|_|\^|X)|[\x90\x98\x9e\x9f]).*?(?:\x1b\\|\x9c)",
@@ -53,16 +57,45 @@ _UNSUPPORTED_TERMINAL_CONTROL_RE = re.compile(
 _MAX_HTML_ENTITY_DECODE_PASSES = 64
 
 
+def _decode_html_entities(text: str) -> str | None:
+    def decode_numeric(match: re.Match[str]) -> str:
+        encoded = match.group("decimal") or match.group("hex")
+        assert encoded is not None
+        base = 10 if match.group("decimal") is not None else 16
+        try:
+            return chr(int(encoded, base))
+        except (ValueError, OverflowError):
+            return match.group(0)
+
+    decoded_text = text
+    for _ in range(_MAX_HTML_ENTITY_DECODE_PASSES):
+        numeric_decoded = _NUMERIC_ENTITY_RE.sub(decode_numeric, decoded_text)
+        decoded = html.unescape(numeric_decoded)
+        if decoded == decoded_text:
+            return decoded_text
+        decoded_text = decoded
+    return None
+
+
+def _decode_escaped_invisible_chars(text: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        encoded = match.group("byte") or match.group("short") or match.group("long")
+        assert encoded is not None
+        char = chr(int(encoded, 16))
+        category = unicodedata.category(char)
+        if category in {"Cc", "Cf", "Mn", "Me"} or 0x80 <= ord(char) <= 0x9F:
+            return char
+        return match.group(0)
+
+    return _ESCAPED_UNICODE_RE.sub(replace, text)
+
+
 def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str | None:
     """Normalize routine verifier-output transformations for leak detection."""
-    unescaped = text
-    for _ in range(_MAX_HTML_ENTITY_DECODE_PASSES):
-        decoded = html.unescape(unescaped)
-        if decoded == unescaped:
-            break
-        unescaped = decoded
-    else:
+    unescaped = _decode_html_entities(text)
+    if unescaped is None:
         return None
+    unescaped = _decode_escaped_invisible_chars(unescaped)
     unescaped = unicodedata.normalize("NFKC", unescaped)
     unescaped = _ESCAPED_WHITESPACE_RE.sub(" ", unescaped)
     without_ansi = _ANSI_ESCAPE_RE.sub("", unescaped)
@@ -86,9 +119,13 @@ def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str |
 
 def contains_unsupported_terminal_control(text: str) -> bool:
     """Return whether output carries controls outside normalized CSI/OSC."""
-    if _ESCAPED_TERMINAL_CONTROL_RE.search(text):
+    decoded = _decode_html_entities(text)
+    if decoded is None:
         return True
-    without_known = _ANSI_ESCAPE_RE.sub("", _OSC_ESCAPE_RE.sub("", text))
+    decoded = _decode_escaped_invisible_chars(decoded)
+    if _ESCAPED_TERMINAL_CONTROL_RE.search(decoded):
+        return True
+    without_known = _ANSI_ESCAPE_RE.sub("", _OSC_ESCAPE_RE.sub("", decoded))
     if _UNSUPPORTED_TERMINAL_CONTROL_RE.search(without_known):
         return True
     return any(

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -41,21 +41,27 @@ _UNSUPPORTED_TERMINAL_CONTROL_RE = re.compile(
 )
 
 
-def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str:
+_MAX_HTML_ENTITY_DECODE_PASSES = 64
+
+
+def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str | None:
     """Normalize routine verifier-output transformations for leak detection."""
     unescaped = text
-    for _ in range(12):
+    for _ in range(_MAX_HTML_ENTITY_DECODE_PASSES):
         decoded = html.unescape(unescaped)
         if decoded == unescaped:
             break
         unescaped = decoded
+    else:
+        return None
     unescaped = unicodedata.normalize("NFKC", unescaped)
     without_ansi = _ANSI_ESCAPE_RE.sub("", unescaped)
     without_ansi = _OSC_ESCAPE_RE.sub("", without_ansi)
     without_ansi = "".join(
         char
         for char in without_ansi
-        if (ord(char) >= 32 or char in "\n\r\t") and unicodedata.category(char) != "Cf"
+        if (ord(char) >= 32 or char in "\n\r\t")
+        and unicodedata.category(char) not in {"Cf", "Mn", "Me"}
     )
     without_prefixes = _LINE_PREFIX_RE.sub("", without_ansi)
     if preserve_punctuation:
@@ -90,12 +96,16 @@ def contains_transformed_hidden_contract_value(
             preserve_punctuation=False,
         )
         normalized_hidden = _normalized_contract_text(hidden, preserve_punctuation=False)
+        if normalized_remaining is None or normalized_hidden is None:
+            return True
         if normalized_hidden:
             if normalized_hidden in normalized_remaining:
                 return True
             continue
         compact_remaining = _normalized_contract_text(remaining, preserve_punctuation=True)
         compact_hidden = _normalized_contract_text(hidden, preserve_punctuation=True)
+        if compact_remaining is None or compact_hidden is None:
+            return True
         if compact_hidden and compact_hidden in compact_remaining:
             return True
     return False

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -54,6 +54,16 @@ _ESCAPED_BYTE_RUN_RE = re.compile(r"(?:\\x[0-9a-fA-F]{2})+")
 _ESCAPED_OCTAL_RUN_RE = re.compile(r"(?:\\[0-7]{3})+")
 _PERCENT_BYTE_RUN_RE = re.compile(r"(?:%[0-9a-fA-F]{2})+")
 _LINE_PREFIX_RE = re.compile(r"(?m)^[ \t]*(?:[EIWF][ \t]+|[+>~-][ \t]?)")
+_MALFORMED_ENCODING_RE = re.compile(
+    r"(?ix)(?:"
+    r"\\x(?![0-9a-f]{2})"
+    r"|\\u(?![0-9a-f]{4})"
+    r"|\\U(?![0-9a-f]{8})"
+    r"|%(?=[0-9a-z]{2})(?=[0-9a-z]?\d)(?![0-9a-f]{2})"
+    r"|&\#x(?![0-9a-f]+;?)"
+    r"|&\#(?!x?[0-9a-f]+;?)"
+    r")"
+)
 _UNSUPPORTED_TERMINAL_CONTROL_RE = re.compile(
     r"(?:\x1b(?:P|_|\^|X)|[\x90\x98\x9e\x9f]).*?(?:\x1b\\|\x9c)",
     re.DOTALL,
@@ -176,6 +186,8 @@ def _decode_percent_runs(text: str) -> str | None:
 
 
 def _decode_contract_encodings(text: str) -> str | None:
+    if _MALFORMED_ENCODING_RE.search(text):
+        return None
     decoded_text = text
     for _ in range(_MAX_HTML_ENTITY_DECODE_PASSES):
         normalized_text = unicodedata.normalize("NFKC", decoded_text)
@@ -194,6 +206,8 @@ def _decode_contract_encodings(text: str) -> str | None:
         decoded = _decode_escaped_whitespace(percent_decoded)
         if decoded == decoded_text:
             return decoded
+        if _MALFORMED_ENCODING_RE.search(decoded):
+            return None
         decoded_text = decoded
     return None
 

--- a/src/ouroboros/orchestrator/contract_redaction.py
+++ b/src/ouroboros/orchestrator/contract_redaction.py
@@ -34,6 +34,10 @@ def hidden_contract_variants(values: Iterable[str | None]) -> tuple[str, ...]:
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 _OSC_ESCAPE_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
 _LINE_PREFIX_RE = re.compile(r"(?m)^\s*(?:[EIWF]\s+|[+>~-]\s?)")
+_UNSUPPORTED_TERMINAL_CONTROL_RE = re.compile(
+    r"(?:\x1b(?:P|_|\^|X)|[\x90\x98\x9e\x9f]).*?(?:\x1b\\|\x9c)",
+    re.DOTALL,
+)
 
 
 def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str:
@@ -46,6 +50,11 @@ def _normalized_contract_text(text: str, *, preserve_punctuation: bool) -> str:
     if preserve_punctuation:
         return "".join(char.casefold() for char in without_prefixes if not char.isspace())
     return "".join(char.casefold() for char in without_prefixes if char.isalnum())
+
+
+def contains_unsupported_terminal_control(text: str) -> bool:
+    """Return whether verifier output carries a non-CSI/OSC control string."""
+    return bool(_UNSUPPORTED_TERMINAL_CONTROL_RE.search(text))
 
 
 def contains_transformed_hidden_contract_value(

--- a/src/ouroboros/orchestrator/retry_hints.py
+++ b/src/ouroboros/orchestrator/retry_hints.py
@@ -9,7 +9,10 @@ from ouroboros.core.seed import AcceptanceCriterionSpec
 from ouroboros.harness.deliver_gate import load_ac_evidence_manifest
 from ouroboros.harness.journal import EvidenceKind, EvidenceManifest
 from ouroboros.observability.logging import get_logger
-from ouroboros.orchestrator.contract_redaction import redact_hidden_contract_values
+from ouroboros.orchestrator.contract_redaction import (
+    contains_transformed_hidden_contract_value,
+    redact_hidden_contract_values,
+)
 from ouroboros.orchestrator.decomposition_policy import redact_and_truncate_text
 from ouroboros.orchestrator.evidence.runtime_metadata import _STALL_SENTINEL
 from ouroboros.orchestrator.execution_runtime_scope import build_ac_runtime_identity
@@ -27,13 +30,14 @@ log = get_logger(__name__)
 
 
 def _sanitize_fragment(text: str, spec: AcceptanceCriterionSpec | None) -> str:
-    """Redact secrets and hidden contract values without discarding clean facts."""
+    """Redact exact values and drop fragments carrying transformed variants."""
 
-    sanitized = (
-        redact_hidden_contract_values(text, (spec.verify_command, spec.output_assertion))
-        if spec is not None
-        else text
-    )
+    if spec is None:
+        return redact_and_truncate_text(text, max_chars=_MAX_HINT_CHARS)
+    hidden_values = (spec.verify_command, spec.output_assertion)
+    sanitized = redact_hidden_contract_values(text, hidden_values)
+    if contains_transformed_hidden_contract_value(sanitized, hidden_values):
+        return ""
     return redact_and_truncate_text(sanitized, max_chars=_MAX_HINT_CHARS)
 
 

--- a/src/ouroboros/orchestrator/retry_hints.py
+++ b/src/ouroboros/orchestrator/retry_hints.py
@@ -35,9 +35,9 @@ def _sanitize_fragment(text: str, spec: AcceptanceCriterionSpec | None) -> str:
     if spec is None:
         return redact_and_truncate_text(text, max_chars=_MAX_HINT_CHARS)
     hidden_values = (spec.verify_command, spec.output_assertion)
-    sanitized = redact_hidden_contract_values(text, hidden_values)
-    if contains_transformed_hidden_contract_value(sanitized, hidden_values):
+    if contains_transformed_hidden_contract_value(text, hidden_values):
         return ""
+    sanitized = redact_hidden_contract_values(text, hidden_values)
     return redact_and_truncate_text(sanitized, max_chars=_MAX_HINT_CHARS)
 
 

--- a/src/ouroboros/orchestrator/retry_hints.py
+++ b/src/ouroboros/orchestrator/retry_hints.py
@@ -11,6 +11,7 @@ from ouroboros.harness.journal import EvidenceKind, EvidenceManifest
 from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.contract_redaction import (
     contains_transformed_hidden_contract_value,
+    contains_unsupported_terminal_control,
     redact_hidden_contract_values,
 )
 from ouroboros.orchestrator.decomposition_policy import redact_and_truncate_text
@@ -34,6 +35,8 @@ def _sanitize_fragment(text: str, spec: AcceptanceCriterionSpec | None) -> str:
 
     if spec is None:
         return redact_and_truncate_text(text, max_chars=_MAX_HINT_CHARS)
+    if contains_unsupported_terminal_control(text):
+        return ""
     hidden_values = (spec.verify_command, spec.output_assertion)
     if contains_transformed_hidden_contract_value(text, hidden_values):
         return ""

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1340,6 +1340,7 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
         ("PRIVATE_SENTINEL", "PRIVATE%255FSENTINEL"),
         ("PRIVATE_SENTINEL", "%50%52%49%56%41%54%45%5F%53%45%4E%54%49%4E%45%4C"),
         ("PRIVATE_SENTINEL", "PRIVATE&#37;5FSENTINEL"),
+        ("PRIVATE_SENTINEL", r"PRIVATE_\400SENTINEL"),
     ),
 )
 def test_retry_prompt_drops_deep_entities_and_invisible_formats(

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1309,6 +1309,39 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
     assert transformed not in prompt
 
 
+@pytest.mark.parametrize(
+    ("assertion", "transformed"),
+    (
+        ("café", "cafe\u0301"),
+        ("ＳＥＣＲＥＴ", "SECRET"),
+        ("MIGRATION<COMPLETE>", "MIGRATION&amp;lt;COMPLETE&amp;gt;"),
+    ),
+)
+def test_retry_prompt_drops_unicode_and_nested_entity_equivalents(
+    assertion: str,
+    transformed: str,
+) -> None:
+    spec = AcceptanceCriterionSpec(
+        description="build the thing",
+        verify_command="python hidden_grader.py",
+        output_assertion=assertion,
+    )
+    outcome = _VerifyGateOutcome(passed=False, reason=None, output_tail=transformed)
+    result = ACExecutionResult(
+        ac_index=0,
+        ac_content=spec.description,
+        success=False,
+        verify_gate_outcome=outcome,
+    )
+    prompt = _make_executor()._build_ac_retry_prompt(
+        result=result,
+        ac_content=spec.description,
+        is_final_attempt=False,
+        spec=spec,
+    )
+    assert "Harness verification output" not in prompt
+
+
 @pytest.mark.parametrize("control", ("\x9b31m", "\x1b(B", "\b"))
 def test_retry_prompt_drops_residual_terminal_controls(control: str) -> None:
     assertion = "PRIVATE_SENTINEL"

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1326,6 +1326,8 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
         ("PRIVATE_SENTINEL", r"PRIVATE_\u0053ENTINEL"),
         ("PRIVATE_SENTINEL", r"PRIVATE_\x53ENTINEL"),
         ("PRIVATE_SENTINEL", r"PRIVATE_\UFFFFFFFFSENTINEL"),
+        ("PRIVATE_SENTINEL", r"PRIVATE_\u005cu0053ENTINEL"),
+        ("<=>", r"\x26lt;=\x26gt;"),
     ),
 )
 def test_retry_prompt_drops_deep_entities_and_invisible_formats(

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1332,6 +1332,9 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
         ("+++", r"+\n+\n+"),
         ("café", r"b'caf\xc3\xa9'"),
         ("PRIVATE_SENTINEL", "\x1b]0;PRIVATE_SENTINEL\x07"),
+        ("!!!", "!\x7f!!"),
+        ("PRIVATE", "＼ｘ５０＼ｘ５２＼ｘ４９＼ｘ５６＼ｘ４１＼ｘ５４＼ｘ４５"),
+        ("PRIVATE", r"\120\122\111\126\101\124\105"),
     ),
 )
 def test_retry_prompt_drops_deep_entities_and_invisible_formats(

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1350,6 +1350,7 @@ def test_retry_prompt_drops_deep_entities_and_invisible_formats(
         ("café", "cafe\u0301"),
         ("ＳＥＣＲＥＴ", "SECRET"),
         ("MIGRATION<COMPLETE>", "MIGRATION&amp;lt;COMPLETE&amp;gt;"),
+        ("PRİVATE_SENTINEL", "private_sentinel"),
     ),
 )
 def test_retry_prompt_drops_unicode_and_nested_entity_equivalents(
@@ -1362,6 +1363,34 @@ def test_retry_prompt_drops_unicode_and_nested_entity_equivalents(
         output_assertion=assertion,
     )
     outcome = _VerifyGateOutcome(passed=False, reason=None, output_tail=transformed)
+    result = ACExecutionResult(
+        ac_index=0,
+        ac_content=spec.description,
+        success=False,
+        verify_gate_outcome=outcome,
+    )
+    prompt = _make_executor()._build_ac_retry_prompt(
+        result=result,
+        ac_content=spec.description,
+        is_final_attempt=False,
+        spec=spec,
+    )
+    assert "Harness verification output" not in prompt
+
+
+@pytest.mark.parametrize("escaped_whitespace", (r"\n", r"\r", r"\t", r"\x0a", r"\u0009"))
+def test_retry_prompt_drops_pytest_escaped_whitespace(escaped_whitespace: str) -> None:
+    assertion = "PRIVATE_SENTINEL"
+    spec = AcceptanceCriterionSpec(
+        description="build the thing",
+        verify_command="python hidden_grader.py",
+        output_assertion=assertion,
+    )
+    outcome = _VerifyGateOutcome(
+        passed=False,
+        reason=None,
+        output_tail=f"E assert 'PRIVATE_{escaped_whitespace}SENTINEL'",
+    )
     result = ACExecutionResult(
         ac_index=0,
         ac_content=spec.description,

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1335,6 +1335,7 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
         ("!!!", "!\x7f!!"),
         ("PRIVATE", "＼ｘ５０＼ｘ５２＼ｘ４９＼ｘ５６＼ｘ４１＼ｘ５４＼ｘ４５"),
         ("PRIVATE", r"\120\122\111\126\101\124\105"),
+        ("😀", r"\ud83d\ude00"),
     ),
 )
 def test_retry_prompt_drops_deep_entities_and_invisible_formats(

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1309,6 +1309,66 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
     assert transformed not in prompt
 
 
+def test_retry_prompt_preserves_safe_context_around_exact_hidden_value() -> None:
+    assertion = "PRIVATE_SENTINEL"
+    spec = AcceptanceCriterionSpec(
+        description="build the thing",
+        verify_command="python hidden_grader.py",
+        output_assertion=assertion,
+    )
+    outcome = _VerifyGateOutcome(
+        passed=False,
+        reason=None,
+        output_tail=f"actual result; expected {assertion}",
+    )
+    result = ACExecutionResult(
+        ac_index=0,
+        ac_content=spec.description,
+        success=False,
+        verify_gate_outcome=outcome,
+    )
+
+    prompt = _make_executor()._build_ac_retry_prompt(
+        result=result,
+        ac_content=spec.description,
+        is_final_attempt=False,
+        spec=spec,
+    )
+
+    assert "actual result; expected [REDACTED CONTRACT VALUE]" in prompt
+
+
+@pytest.mark.parametrize(
+    ("assertion", "transformed"),
+    (("!!!", "! ! !"), ("<=>", "&lt; = &gt;")),
+)
+def test_retry_prompt_drops_transformed_punctuation_only_assertion(
+    assertion: str,
+    transformed: str,
+) -> None:
+    spec = AcceptanceCriterionSpec(
+        description="build the thing",
+        verify_command="python hidden_grader.py",
+        output_assertion=assertion,
+    )
+    outcome = _VerifyGateOutcome(passed=False, reason=None, output_tail=transformed)
+    result = ACExecutionResult(
+        ac_index=0,
+        ac_content=spec.description,
+        success=False,
+        verify_gate_outcome=outcome,
+    )
+
+    prompt = _make_executor()._build_ac_retry_prompt(
+        result=result,
+        ac_content=spec.description,
+        is_final_attempt=False,
+        spec=spec,
+    )
+
+    assert "Harness verification output" not in prompt
+
+
 def test_retry_prompt_drops_transformed_command_with_exact_assertion() -> None:
     assertion = "PRIVATE_SENTINEL"
     command = "python hidden_grader.py --expect PRIVATE_SENTINEL"

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1341,6 +1341,10 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
         ("PRIVATE_SENTINEL", "%50%52%49%56%41%54%45%5F%53%45%4E%54%49%4E%45%4C"),
         ("PRIVATE_SENTINEL", "PRIVATE&#37;5FSENTINEL"),
         ("PRIVATE_SENTINEL", r"PRIVATE_\400SENTINEL"),
+        ("SECRET", "\u202eTERCES\u202c"),
+        ("PRIVATE_SENTINEL", "PRIVATE_&#x110000;SENTINEL"),
+        ("PRIVATE_SENTINEL", "PRIVATE_&#xD800;SENTINEL"),
+        ("PRIVATE_SENTINEL", "PRIVATE_&#999999999999999999999;SENTINEL"),
     ),
 )
 def test_retry_prompt_drops_deep_entities_and_invisible_formats(

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1309,6 +1309,34 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
     assert transformed not in prompt
 
 
+@pytest.mark.parametrize("control", ("\x9b31m", "\x1b(B", "\b"))
+def test_retry_prompt_drops_residual_terminal_controls(control: str) -> None:
+    assertion = "PRIVATE_SENTINEL"
+    spec = AcceptanceCriterionSpec(
+        description="build the thing",
+        verify_command="python hidden_grader.py",
+        output_assertion=assertion,
+    )
+    outcome = _VerifyGateOutcome(
+        passed=False,
+        reason=None,
+        output_tail=f"PRIVATE_{control}SENTINEL",
+    )
+    result = ACExecutionResult(
+        ac_index=0,
+        ac_content=spec.description,
+        success=False,
+        verify_gate_outcome=outcome,
+    )
+    prompt = _make_executor()._build_ac_retry_prompt(
+        result=result,
+        ac_content=spec.description,
+        is_final_attempt=False,
+        spec=spec,
+    )
+    assert "Harness verification output" not in prompt
+
+
 @pytest.mark.parametrize(
     "control",
     ("\x1bP1;2\x1b\\", "\x90payload\x9c"),

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1309,6 +1309,35 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
     assert transformed not in prompt
 
 
+def test_retry_prompt_drops_mixed_exact_and_transformed_hidden_copies() -> None:
+    assertion = "PRIVATE_SENTINEL"
+    spec = AcceptanceCriterionSpec(
+        description="build the thing",
+        verify_command="python hidden_grader.py",
+        output_assertion=assertion,
+    )
+    outcome = _VerifyGateOutcome(
+        passed=False,
+        reason=None,
+        output_tail=f"expected {assertion} but received private_ sentinel",
+    )
+    result = ACExecutionResult(
+        ac_index=0,
+        ac_content=spec.description,
+        success=False,
+        verify_gate_outcome=outcome,
+    )
+
+    prompt = _make_executor()._build_ac_retry_prompt(
+        result=result,
+        ac_content=spec.description,
+        is_final_attempt=False,
+        spec=spec,
+    )
+
+    assert "Harness verification output" not in prompt
+
+
 def test_retry_prompt_preserves_safe_context_around_exact_hidden_value() -> None:
     assertion = "PRIVATE_SENTINEL"
     spec = AcceptanceCriterionSpec(

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1377,6 +1377,37 @@ def test_retry_prompt_drops_unicode_and_nested_entity_equivalents(
     assert "Harness verification output" not in prompt
 
 
+@pytest.mark.parametrize(
+    "escaped_control",
+    (r"\x1b[31m", r"\u001b[31m", r"\033[31m", r"\e[31m", r"\^[31m"),
+)
+def test_retry_prompt_drops_pytest_escaped_terminal_controls(escaped_control: str) -> None:
+    assertion = "PRIVATE_SENTINEL"
+    spec = AcceptanceCriterionSpec(
+        description="build the thing",
+        verify_command="python hidden_grader.py",
+        output_assertion=assertion,
+    )
+    outcome = _VerifyGateOutcome(
+        passed=False,
+        reason=None,
+        output_tail=f"E assert 'PRIVATE_{escaped_control}SENTINEL'",
+    )
+    result = ACExecutionResult(
+        ac_index=0,
+        ac_content=spec.description,
+        success=False,
+        verify_gate_outcome=outcome,
+    )
+    prompt = _make_executor()._build_ac_retry_prompt(
+        result=result,
+        ac_content=spec.description,
+        is_final_attempt=False,
+        spec=spec,
+    )
+    assert "Harness verification output" not in prompt
+
+
 @pytest.mark.parametrize("control", ("\x9b31m", "\x1b(B", "\x1b[5D", "\b"))
 def test_retry_prompt_drops_residual_terminal_controls(control: str) -> None:
     assertion = "PRIVATE_SENTINEL"

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1305,9 +1305,39 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
         is_final_attempt=False,
         spec=spec,
     )
-
     assert "Harness verification output" not in prompt
     assert transformed not in prompt
+
+
+def test_retry_prompt_drops_transformed_command_with_exact_assertion() -> None:
+    assertion = "PRIVATE_SENTINEL"
+    command = "python hidden_grader.py --expect PRIVATE_SENTINEL"
+    spec = AcceptanceCriterionSpec(
+        description="build the thing",
+        verify_command=command,
+        output_assertion=assertion,
+    )
+    outcome = _VerifyGateOutcome(
+        passed=False,
+        reason=None,
+        output_tail="PYTHON HIDDEN_GRADER.PY --EXPECT PRIVATE_SENTINEL",
+    )
+    result = ACExecutionResult(
+        ac_index=0,
+        ac_content=spec.description,
+        success=False,
+        verify_gate_outcome=outcome,
+    )
+
+    prompt = _make_executor()._build_ac_retry_prompt(
+        result=result,
+        ac_content=spec.description,
+        is_final_attempt=False,
+        spec=spec,
+    )
+
+    assert "Harness verification output" not in prompt
+    assert "HIDDEN_GRADER" not in prompt
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1322,6 +1322,9 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
         ("PRIVATE_SENTINEL", r"PRIVATE_\uFE0FSENTINEL"),
         ("PRIVATE_SENTINEL", "PRIVATE_&#27;[31mSENTINEL"),
         ("PRIVATE_SENTINEL", "PRIVATE_&#27;[5DSENTINEL"),
+        ("PRIVATE_SENTINEL", r"PRIVATE_\u0053ENTINEL"),
+        ("PRIVATE_SENTINEL", r"PRIVATE_\x53ENTINEL"),
+        ("PRIVATE_SENTINEL", r"PRIVATE_\UFFFFFFFFSENTINEL"),
     ),
 )
 def test_retry_prompt_drops_deep_entities_and_invisible_formats(

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1317,6 +1317,11 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
         ("<=>", "<\u2060=\u2060>"),
         ("!!!", "!\ufe0f!\ufe0f!"),
         ("<=>", "&" + "amp;" * 65 + "lt;=&" + "amp;" * 65 + "gt;"),
+        ("PRIVATE_SENTINEL", r"PRIVATE_\u200bSENTINEL"),
+        ("PRIVATE_SENTINEL", r"PRIVATE_\U0000200bSENTINEL"),
+        ("PRIVATE_SENTINEL", r"PRIVATE_\uFE0FSENTINEL"),
+        ("PRIVATE_SENTINEL", "PRIVATE_&#27;[31mSENTINEL"),
+        ("PRIVATE_SENTINEL", "PRIVATE_&#27;[5DSENTINEL"),
     ),
 )
 def test_retry_prompt_drops_deep_entities_and_invisible_formats(

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1309,6 +1309,39 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
     assert transformed not in prompt
 
 
+@pytest.mark.parametrize(
+    "control",
+    ("\x1bP1;2\x1b\\", "\x90payload\x9c"),
+)
+def test_retry_prompt_drops_unsupported_terminal_control_strings(control: str) -> None:
+    assertion = "PRIVATE_SENTINEL"
+    spec = AcceptanceCriterionSpec(
+        description="build the thing",
+        verify_command="python hidden_grader.py",
+        output_assertion=assertion,
+    )
+    outcome = _VerifyGateOutcome(
+        passed=False,
+        reason=None,
+        output_tail=f"PRIVATE_{control}SENTINEL",
+    )
+    result = ACExecutionResult(
+        ac_index=0,
+        ac_content=spec.description,
+        success=False,
+        verify_gate_outcome=outcome,
+    )
+
+    prompt = _make_executor()._build_ac_retry_prompt(
+        result=result,
+        ac_content=spec.description,
+        is_final_attempt=False,
+        spec=spec,
+    )
+
+    assert "Harness verification output" not in prompt
+
+
 def test_retry_prompt_drops_osc_split_hidden_assertion() -> None:
     assertion = "PRIVATE_SENTINEL"
     spec = AcceptanceCriterionSpec(

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1349,6 +1349,10 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
         ("PRIVATE_SENTINEL", "PRIVATE_%G0SENTINEL"),
         ("PRIVATE_SENTINEL", r"PRIVATE_\uZZZZSENTINEL"),
         ("PRIVATE_SENTINEL", "PRIVATE_&#xZZ;SENTINEL"),
+        ("PRIVATE_SENTINEL", r"PRIVATE_\12SENTINEL"),
+        ("PRIVATE_SENTINEL", r"PRIVATE_\11SENTINEL"),
+        ("PRIVATE_SENTINEL", r"PRIVATE_\15SENTINEL"),
+        ("PRIVATE_SENTINEL", r"PRIVATE_\0SENTINEL"),
     ),
 )
 def test_retry_prompt_drops_deep_entities_and_invisible_formats(

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1353,6 +1353,7 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
         ("PRIVATE_SENTINEL", r"PRIVATE_\11SENTINEL"),
         ("PRIVATE_SENTINEL", r"PRIVATE_\15SENTINEL"),
         ("PRIVATE_SENTINEL", r"PRIVATE_\0SENTINEL"),
+        ("PRIVATE_SENTINEL", "safe\ud800diagnostic"),
     ),
 )
 def test_retry_prompt_drops_deep_entities_and_invisible_formats(

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1377,7 +1377,7 @@ def test_retry_prompt_drops_unicode_and_nested_entity_equivalents(
     assert "Harness verification output" not in prompt
 
 
-@pytest.mark.parametrize("control", ("\x9b31m", "\x1b(B", "\b"))
+@pytest.mark.parametrize("control", ("\x9b31m", "\x1b(B", "\x1b[5D", "\b"))
 def test_retry_prompt_drops_residual_terminal_controls(control: str) -> None:
     assertion = "PRIVATE_SENTINEL"
     spec = AcceptanceCriterionSpec(

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1336,6 +1336,10 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
         ("PRIVATE", "＼ｘ５０＼ｘ５２＼ｘ４９＼ｘ５６＼ｘ４１＼ｘ５４＼ｘ４５"),
         ("PRIVATE", r"\120\122\111\126\101\124\105"),
         ("😀", r"\ud83d\ude00"),
+        ("PRIVATE_SENTINEL", "PRIVATE%5FSENTINEL"),
+        ("PRIVATE_SENTINEL", "PRIVATE%255FSENTINEL"),
+        ("PRIVATE_SENTINEL", "%50%52%49%56%41%54%45%5F%53%45%4E%54%49%4E%45%4C"),
+        ("PRIVATE_SENTINEL", "PRIVATE&#37;5FSENTINEL"),
     ),
 )
 def test_retry_prompt_drops_deep_entities_and_invisible_formats(

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1315,6 +1315,8 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
         ("<=>", "&amp;amp;amp;lt;=&amp;amp;amp;gt;"),
         ("!!!", "!\u200b!\u200b!"),
         ("<=>", "<\u2060=\u2060>"),
+        ("!!!", "!\ufe0f!\ufe0f!"),
+        ("<=>", "&" + "amp;" * 65 + "lt;=&" + "amp;" * 65 + "gt;"),
     ),
 )
 def test_retry_prompt_drops_deep_entities_and_invisible_formats(

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1328,6 +1328,10 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
         ("PRIVATE_SENTINEL", r"PRIVATE_\UFFFFFFFFSENTINEL"),
         ("PRIVATE_SENTINEL", r"PRIVATE_\u005cu0053ENTINEL"),
         ("<=>", r"\x26lt;=\x26gt;"),
+        ("ERROR", r"E\nRROR"),
+        ("+++", r"+\n+\n+"),
+        ("café", r"b'caf\xc3\xa9'"),
+        ("PRIVATE_SENTINEL", "\x1b]0;PRIVATE_SENTINEL\x07"),
     ),
 )
 def test_retry_prompt_drops_deep_entities_and_invisible_formats(

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1264,6 +1264,53 @@ def test_retry_prompt_uses_trace_facts_without_hidden_contract_values() -> None:
 
 
 @pytest.mark.parametrize(
+    ("assertion", "transformed"),
+    (
+        ("MIGRATION_COMPLETE_v2", "MIGRATION_COMPLETE_\nv2"),
+        ("MIGRATION_COMPLETE_v2", "+ MIGRATION_COMPLETE_\n+ v2"),
+        ("MIGRATION_COMPLETE_v2", "\x1b[31mMIGRATION\x1b[0m_COMPLETE_v2"),
+        ("MIGRATION_COMPLETE_v2", "migration_complete_V2"),
+        ("MIGRATION<COMPLETE>&v2", "MIGRATION&lt;COMPLETE&gt;&amp;v2"),
+        (
+            "MIGRATION_COMPLETE_v2",
+            "E   assert 'MIGRATION_COMPLETE_' +\nE       'v2'",
+        ),
+    ),
+)
+def test_retry_prompt_drops_transformed_hidden_assertion(
+    assertion: str,
+    transformed: str,
+) -> None:
+    executor = _make_executor()
+    spec = AcceptanceCriterionSpec(
+        description="build the thing",
+        verify_command="python hidden_grader.py",
+        output_assertion=assertion,
+    )
+    outcome = _VerifyGateOutcome(
+        passed=False,
+        reason=None,
+        output_tail=transformed,
+    )
+    result = ACExecutionResult(
+        ac_index=0,
+        ac_content=spec.description,
+        success=False,
+        verify_gate_outcome=outcome,
+    )
+
+    prompt = executor._build_ac_retry_prompt(
+        result=result,
+        ac_content=spec.description,
+        is_final_attempt=False,
+        spec=spec,
+    )
+
+    assert "Harness verification output" not in prompt
+    assert transformed not in prompt
+
+
+@pytest.mark.parametrize(
     "render_hidden",
     [
         pytest.param(lambda value: value, id="raw"),

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1312,6 +1312,39 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
 @pytest.mark.parametrize(
     ("assertion", "transformed"),
     (
+        ("<=>", "&amp;amp;amp;lt;=&amp;amp;amp;gt;"),
+        ("!!!", "!\u200b!\u200b!"),
+        ("<=>", "<\u2060=\u2060>"),
+    ),
+)
+def test_retry_prompt_drops_deep_entities_and_invisible_formats(
+    assertion: str,
+    transformed: str,
+) -> None:
+    spec = AcceptanceCriterionSpec(
+        description="build the thing",
+        verify_command="python hidden_grader.py",
+        output_assertion=assertion,
+    )
+    outcome = _VerifyGateOutcome(passed=False, reason=None, output_tail=transformed)
+    result = ACExecutionResult(
+        ac_index=0,
+        ac_content=spec.description,
+        success=False,
+        verify_gate_outcome=outcome,
+    )
+    prompt = _make_executor()._build_ac_retry_prompt(
+        result=result,
+        ac_content=spec.description,
+        is_final_attempt=False,
+        spec=spec,
+    )
+    assert "Harness verification output" not in prompt
+
+
+@pytest.mark.parametrize(
+    ("assertion", "transformed"),
+    (
         ("café", "cafe\u0301"),
         ("ＳＥＣＲＥＴ", "SECRET"),
         ("MIGRATION<COMPLETE>", "MIGRATION&amp;lt;COMPLETE&amp;gt;"),

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1309,6 +1309,36 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
     assert transformed not in prompt
 
 
+def test_retry_prompt_drops_osc_split_hidden_assertion() -> None:
+    assertion = "PRIVATE_SENTINEL"
+    spec = AcceptanceCriterionSpec(
+        description="build the thing",
+        verify_command="python hidden_grader.py",
+        output_assertion=assertion,
+    )
+    osc = "\x1b]8;;https://example.invalid\x07"
+    outcome = _VerifyGateOutcome(
+        passed=False,
+        reason=None,
+        output_tail=f"{osc}PRIVATE_{osc}\x1b]8;;\x07SENTINEL",
+    )
+    result = ACExecutionResult(
+        ac_index=0,
+        ac_content=spec.description,
+        success=False,
+        verify_gate_outcome=outcome,
+    )
+
+    prompt = _make_executor()._build_ac_retry_prompt(
+        result=result,
+        ac_content=spec.description,
+        is_final_attempt=False,
+        spec=spec,
+    )
+
+    assert "Harness verification output" not in prompt
+
+
 def test_retry_prompt_drops_mixed_exact_and_transformed_hidden_copies() -> None:
     assertion = "PRIVATE_SENTINEL"
     spec = AcceptanceCriterionSpec(

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1345,6 +1345,10 @@ def test_retry_prompt_drops_transformed_hidden_assertion(
         ("PRIVATE_SENTINEL", "PRIVATE_&#x110000;SENTINEL"),
         ("PRIVATE_SENTINEL", "PRIVATE_&#xD800;SENTINEL"),
         ("PRIVATE_SENTINEL", "PRIVATE_&#999999999999999999999;SENTINEL"),
+        ("PRIVATE_SENTINEL", r"PRIVATE_\xG0SENTINEL"),
+        ("PRIVATE_SENTINEL", "PRIVATE_%G0SENTINEL"),
+        ("PRIVATE_SENTINEL", r"PRIVATE_\uZZZZSENTINEL"),
+        ("PRIVATE_SENTINEL", "PRIVATE_&#xZZ;SENTINEL"),
     ),
 )
 def test_retry_prompt_drops_deep_entities_and_invisible_formats(


### PR DESCRIPTION
## Summary

- Canonicalize verifier output to a bounded fixed point across HTML/numeric entities, URL percent encoding, Unicode/JSON escapes and surrogate pairs, UTF-8 hex/octal byte escapes, NFKC/case folding, diagnostic prefixes, whitespace, and invisible/control characters.
- Drop retry fragments fail-closed when they carry a readable transformed `verify_command` or `output_assertion`; preserve exact redaction behavior for safe surrounding context.
- Reject stateful CSI, OSC payloads, DCS/C1/C0/DEL controls, invalid code points, malformed encoded bytes, and decoding-bound exhaustion before worker prompt transport.
- Cover pytest-style rewritten assertions and adversarial transformations described in #2020.

## Verification

- `uv run pytest -q tests/unit/orchestrator/test_parallel_executor_verify_by_default.py tests/unit/mcp/tools/test_seed_handoff.py` — 145 passed
- Current exact-head required GitHub checks — all pass

Closes #2020