### PR TITLE
fix(executor): recognize option-bearing uv test runs

### DIFF
--- a/src/ouroboros/orchestrator/evidence/shell_parsing.py
+++ b/src/ouroboros/orchestrator/evidence/shell_parsing.py
@@ -141,19 +141,18 @@ def _shell_command_body_from_argv(argv: tuple[str, ...]) -> str | None:
 
 def _test_invocation_from_shell_body(body: str) -> str | None:
     """Return a test invocation after conservative shell setup preambles."""
-    for segment, pipefail_enabled in _segments_after_safe_shell_preamble_with_pipefail(body):
-        candidate = _strip_command_output_plumbing(segment)
-        if (
-            _has_trailing_output_filter_pipeline(segment)
-            and not pipefail_enabled
-            and _test_invocation_from_prefix(candidate) is not None
-        ):
-            candidate = segment
-        invocation = _test_invocation_from_prefix(candidate)
-        if invocation is not None:
-            return invocation
+    segments = tuple(_segments_after_safe_shell_preamble_with_pipefail(body))
+    if len(segments) != 1:
         return None
-    return None
+    segment, pipefail_enabled = segments[0]
+    candidate = _strip_command_output_plumbing(segment)
+    if (
+        _has_trailing_output_filter_pipeline(segment)
+        and not pipefail_enabled
+        and _test_invocation_from_prefix(candidate) is not None
+    ):
+        candidate = segment
+    return _test_invocation_from_prefix(candidate)
 
 
 def _single_command_after_safe_shell_preamble(command: str) -> str | None:

--- a/src/ouroboros/orchestrator/evidence/shell_parsing.py
+++ b/src/ouroboros/orchestrator/evidence/shell_parsing.py
@@ -360,6 +360,7 @@ _UV_VALUE_OPTIONS = frozenset(
         "--project",
         "--python",
         "--python-platform",
+        "--preview-features",
         "--refresh-package",
         "--reinstall-package",
         "--resolution",
@@ -431,7 +432,7 @@ def _uv_run_pytest_parts(parts: list[str]) -> list[str] | None:
             index += 1
             continue
         if token.startswith("--"):
-            option, separator, _attached = token.partition("=")
+            option, separator, attached = token.partition("=")
             if option in _UV_FLAG_OPTIONS:
                 if separator:
                     return None
@@ -440,7 +441,10 @@ def _uv_run_pytest_parts(parts: list[str]) -> list[str] | None:
             if option not in _UV_VALUE_OPTIONS:
                 return None
             index += 1
-            if not separator:
+            if separator:
+                if not attached:
+                    return None
+            else:
                 if index >= len(parts) or parts[index] == "--" or parts[index].startswith("-"):
                     return None
                 index += 1

--- a/src/ouroboros/orchestrator/evidence/shell_parsing.py
+++ b/src/ouroboros/orchestrator/evidence/shell_parsing.py
@@ -319,7 +319,7 @@ def _has_unquoted_status_masking_control(command: str) -> bool:
             previous = command[index - 1] if index > 0 else ""
             following = command[index + 1] if index + 1 < len(command) else ""
             if previous == "&" or following == "&":
-                continue
+                return True
             if previous not in {">", "<"} and following != ">":
                 return True
     return False
@@ -414,10 +414,10 @@ _UV_SHORT_VALUE_OPTIONS = frozenset({"C", "f", "i", "p", "P", "w"})
 _UV_SHORT_FLAG_OPTIONS = frozenset({"n", "q", "U", "v"})
 
 
-def _uv_run_pytest_operand(parts: list[str]) -> bool:
-    """Parse the uv option prefix and identify the selected program/module."""
+def _uv_run_pytest_parts(parts: list[str]) -> list[str] | None:
+    """Parse the uv option prefix and return selected pytest plus its arguments."""
     if len(parts) < 3 or parts[:2] != ["uv", "run"]:
-        return False
+        return None
     index = 2
     while index < len(parts):
         token = parts[index]
@@ -427,7 +427,7 @@ def _uv_run_pytest_operand(parts: list[str]) -> bool:
         if not token.startswith("-") or token == "-":
             break
         if token in {"--help", "-h", "--version", "-V", "--script", "-s", "--gui-script"}:
-            return False
+            return None
         if token in {"--module", "-m"}:
             index += 1
             continue
@@ -435,15 +435,15 @@ def _uv_run_pytest_operand(parts: list[str]) -> bool:
             option, separator, _attached = token.partition("=")
             if option in _UV_FLAG_OPTIONS:
                 if separator:
-                    return False
+                    return None
                 index += 1
                 continue
             if option not in _UV_VALUE_OPTIONS:
-                return False
+                return None
             index += 1
             if not separator:
                 if index >= len(parts) or parts[index] == "--" or parts[index].startswith("-"):
-                    return False
+                    return None
                 index += 1
             continue
         cluster = token[1:]
@@ -451,22 +451,21 @@ def _uv_run_pytest_operand(parts: list[str]) -> bool:
         while position < len(cluster):
             option = cluster[position]
             if option in {"h", "s"}:
-                return False
+                return None
             if option == "m" or option in _UV_SHORT_FLAG_OPTIONS:
                 position += 1
                 continue
             if option not in _UV_SHORT_VALUE_OPTIONS:
-                return False
+                return None
             if position + 1 == len(cluster):
                 index += 1
-                if index >= len(parts):
-                    return False
+                if index >= len(parts) or parts[index] == "--" or parts[index].startswith("-"):
+                    return None
             position = len(cluster)
         index += 1
-    if index >= len(parts):
-        return False
-    operand = parts[index]
-    return operand in {"pytest", "py.test"}
+    if index >= len(parts) or parts[index] not in {"pytest", "py.test"}:
+        return None
+    return parts[index:]
 
 
 def _test_invocation_from_prefix(command: str) -> str | None:
@@ -491,14 +490,17 @@ def _test_invocation_from_prefix(command: str) -> str | None:
         return None
     if any(part in {"|", "||", ";", "&"} for part in parts):
         return None
+    uv_pytest_parts = _uv_run_pytest_parts(parts)
+    if uv_pytest_parts is not None:
+        if _has_non_executing_test_mode(uv_pytest_parts):
+            return None
+        return _normalized_evidence_text(" ".join(parts))
     if _has_non_executing_test_mode(parts):
         return None
 
     if parts[0] in {"pytest", "py.test", "tox", "nox"}:
         return _normalized_evidence_text(" ".join(parts))
     if len(parts) >= 2 and parts[0] in {"npm", "pnpm", "yarn"} and parts[1] == "test":
-        return _normalized_evidence_text(" ".join(parts))
-    if _uv_run_pytest_operand(parts):
         return _normalized_evidence_text(" ".join(parts))
     if (
         len(parts) >= 3

--- a/src/ouroboros/orchestrator/evidence/shell_parsing.py
+++ b/src/ouroboros/orchestrator/evidence/shell_parsing.py
@@ -27,7 +27,7 @@ def _test_command_invocation(command: str) -> str | None:
     as ``| grep passed`` survives the strip and is rejected downstream by
     ``_test_invocation_from_prefix`` rather than being silently dropped.
     """
-    normalized = command.strip().lower()
+    normalized = command.strip()
     if not normalized:
         return None
 
@@ -54,7 +54,7 @@ def _test_command_invocation_allowing_output_plumbing(command: str) -> str | Non
     This must not be used as command proof. It exists only to classify rejected
     evidence forms for diagnostics while preserving the #1208 masking guard.
     """
-    normalized = command.strip().lower()
+    normalized = command.strip()
     if not normalized:
         return None
     direct = _test_invocation_from_prefix(_strip_command_output_plumbing(normalized))

--- a/src/ouroboros/orchestrator/evidence/shell_parsing.py
+++ b/src/ouroboros/orchestrator/evidence/shell_parsing.py
@@ -402,9 +402,12 @@ _UV_FLAG_OPTIONS = frozenset(
         "--no-sync",
         "--offline",
         "--only-dev",
+        "--quiet",
         "--refresh",
         "--reinstall",
+        "--system-certs",
         "--upgrade",
+        "--verbose",
     }
 )
 _UV_SHORT_VALUE_OPTIONS = frozenset({"C", "f", "i", "p", "P", "w"})
@@ -439,7 +442,7 @@ def _uv_run_pytest_operand(parts: list[str]) -> bool:
                 return False
             index += 1
             if not separator:
-                if index >= len(parts):
+                if index >= len(parts) or parts[index] == "--" or parts[index].startswith("-"):
                     return False
                 index += 1
             continue

--- a/src/ouroboros/orchestrator/evidence/shell_parsing.py
+++ b/src/ouroboros/orchestrator/evidence/shell_parsing.py
@@ -11,141 +11,6 @@ from ouroboros.orchestrator.evidence.common import (
     _normalized_evidence_text,
 )
 
-_UV_RUN_OPTIONS_WITH_VALUES = frozenset(
-    {
-        "--allow-insecure-host",
-        "--cache-dir",
-        "--color",
-        "--config-file",
-        "--config-setting",
-        "--config-settings-package",
-        "--default-index",
-        "--directory",
-        "--env-file",
-        "--exclude-newer",
-        "--exclude-newer-package",
-        "--extra",
-        "--extra-index-url",
-        "--find-links",
-        "--fork-strategy",
-        "--group",
-        "--index",
-        "--index-strategy",
-        "--index-url",
-        "--keyring-provider",
-        "--link-mode",
-        "--no-binary-package",
-        "--no-build-isolation-package",
-        "--no-build-package",
-        "--no-editable-package",
-        "--no-extra",
-        "--no-group",
-        "--only-group",
-        "--package",
-        "--prerelease",
-        "--project",
-        "--python",
-        "--python-platform",
-        "--refresh-package",
-        "--reinstall-package",
-        "--resolution",
-        "--upgrade-package",
-        "--with",
-        "--with-editable",
-        "--with-requirements",
-        "-C",
-        "-f",
-        "-i",
-        "-p",
-        "-P",
-        "-w",
-    }
-)
-_UV_RUN_FLAG_OPTIONS = frozenset(
-    {
-        "--active",
-        "--all-extras",
-        "--all-groups",
-        "--all-packages",
-        "--compile-bytecode",
-        "--exact",
-        "--frozen",
-        "--isolated",
-        "--locked",
-        "--managed-python",
-        "--native-tls",
-        "--no-config",
-        "--no-binary",
-        "--no-build-isolation",
-        "--no-default-groups",
-        "--no-build",
-        "--no-cache",
-        "--no-dev",
-        "--no-editable",
-        "--no-env-file",
-        "--no-index",
-        "--no-managed-python",
-        "--no-project",
-        "--no-progress",
-        "--no-python-downloads",
-        "--no-sources",
-        "--no-sync",
-        "--offline",
-        "--only-dev",
-        "--refresh",
-        "--reinstall",
-        "--upgrade",
-        "-n",
-        "--system-certs",
-        "-q",
-        "-U",
-        "-v",
-    }
-)
-_UV_RUN_SCRIPT_OPTIONS = frozenset({"--gui-script", "--script", "-s"})
-_UV_RUN_MODULE_OPTIONS = frozenset({"--module", "-m"})
-_UV_RUN_NON_EXECUTING_OPTIONS = frozenset({"--help", "-h", "--version", "-V"})
-
-
-def _strip_uv_run_options(parts: list[str]) -> list[str] | None:
-    """Return the executed command, rejecting unknown or mode-changing options."""
-    if len(parts) < 3 or parts[:2] != ["uv", "run"]:
-        return parts
-    index = 2
-    module_mode = False
-    while index < len(parts) and parts[index] != "--" and parts[index].startswith("-"):
-        raw_option = parts[index]
-        option = raw_option.split("=", 1)[0]
-        attached_value: str | None = None
-        if (
-            "=" not in raw_option
-            and len(raw_option) > 2
-            and raw_option[:2] in {"-C", "-f", "-i", "-p", "-P", "-w"}
-        ):
-            option, attached_value = raw_option[:2], raw_option[2:]
-        index += 1
-        if option in _UV_RUN_NON_EXECUTING_OPTIONS or option in _UV_RUN_SCRIPT_OPTIONS:
-            return None
-        if option in _UV_RUN_MODULE_OPTIONS:
-            module_mode = True
-            continue
-        if option in _UV_RUN_FLAG_OPTIONS or re.fullmatch(r"-(?:q+|v+)", option):
-            continue
-        if option not in _UV_RUN_OPTIONS_WITH_VALUES:
-            return None
-        if attached_value is not None:
-            continue
-        if "=" not in raw_option:
-            if index >= len(parts) or parts[index].startswith("-"):
-                return None
-            index += 1
-    if index < len(parts) and parts[index] == "--":
-        index += 1
-    if index >= len(parts):
-        return None
-    command = parts[index:]
-    return ["python", "-m", *command] if module_mode else ["uv", "run", *command]
-
 
 def _looks_like_test_command(command: str) -> bool:
     """Return True for common whole-suite or targeted test invocations."""
@@ -401,7 +266,8 @@ def _has_gradle_or_maven_test_skip(parts: list[str]) -> bool:
             if maven_skip_property_disables_tests(parts[index + 1]):
                 return True
         if normalized.startswith("--define="):
-            if maven_skip_property_disables_tests(normalized.partition("=")[2]):
+            _, _, define_value = normalized.partition("=")
+            if maven_skip_property_disables_tests(define_value):
                 return True
         if normalized.startswith("-d") and maven_skip_property_disables_tests(normalized[2:]):
             return True
@@ -459,6 +325,27 @@ def _has_unquoted_status_masking_control(command: str) -> bool:
     return False
 
 
+def _uv_run_contains_pytest(parts: list[str]) -> bool:
+    """Recognize pytest selected by uv without reimplementing uv's option grammar.
+
+    This is only a candidate classifier. Evidence acceptance separately requires
+    the exact recorded command, successful structured runtime status, and real
+    pytest success output. Script mode is excluded because a file named pytest
+    can emit arbitrary lookalike text.
+    """
+    if len(parts) < 3 or parts[:2] != ["uv", "run"]:
+        return False
+    tail = parts[2:]
+    if any(part in {"-s", "--script", "--gui-script"} for part in tail):
+        return False
+    for index, part in enumerate(tail):
+        if part in {"-m", "--module"}:
+            return index + 1 < len(tail) and tail[index + 1] in {"pytest", "py.test"}
+        if part in {"pytest", "py.test"}:
+            return True
+    return False
+
+
 def _test_invocation_from_prefix(command: str) -> str | None:
     """Return a normalized test invocation only when it starts the command text.
 
@@ -477,10 +364,6 @@ def _test_invocation_from_prefix(command: str) -> str | None:
     except ValueError:
         parts = command.replace('"', "").replace("'", "").split()
     parts = _strip_env_prefix(parts)
-    uv_parts = _strip_uv_run_options(parts)
-    if uv_parts is None:
-        return None
-    parts = uv_parts
     if not parts:
         return None
     if any(part in {"|", "||", ";", "&"} for part in parts):
@@ -492,7 +375,7 @@ def _test_invocation_from_prefix(command: str) -> str | None:
         return _normalized_evidence_text(" ".join(parts))
     if len(parts) >= 2 and parts[0] in {"npm", "pnpm", "yarn"} and parts[1] == "test":
         return _normalized_evidence_text(" ".join(parts))
-    if len(parts) >= 3 and parts[:3] == ["uv", "run", "pytest"]:
+    if _uv_run_contains_pytest(parts):
         return _normalized_evidence_text(" ".join(parts))
     if (
         len(parts) >= 3

--- a/src/ouroboros/orchestrator/evidence/shell_parsing.py
+++ b/src/ouroboros/orchestrator/evidence/shell_parsing.py
@@ -11,6 +11,71 @@ from ouroboros.orchestrator.evidence.common import (
     _normalized_evidence_text,
 )
 
+_UV_RUN_OPTIONS_WITH_VALUES = frozenset(
+    {
+        "--allow-insecure-host",
+        "--cache-dir",
+        "--color",
+        "--config-file",
+        "--config-setting",
+        "--config-settings-package",
+        "--default-index",
+        "--directory",
+        "--env-file",
+        "--exclude-newer",
+        "--exclude-newer-package",
+        "--extra",
+        "--extra-index-url",
+        "--find-links",
+        "--group",
+        "--index",
+        "--index-strategy",
+        "--index-url",
+        "--keyring-provider",
+        "--link-mode",
+        "--no-binary-package",
+        "--no-build-isolation-package",
+        "--no-build-package",
+        "--no-extra",
+        "--no-group",
+        "--only-group",
+        "--package",
+        "--prerelease",
+        "--project",
+        "--python",
+        "--python-platform",
+        "--refresh-package",
+        "--reinstall-package",
+        "--resolution",
+        "--upgrade-package",
+        "--with",
+        "--with-editable",
+        "--with-requirements",
+        "-C",
+        "-f",
+        "-i",
+        "-p",
+        "-P",
+        "-w",
+    }
+)
+
+
+def _strip_uv_run_options(parts: list[str]) -> list[str]:
+    """Remove uv options that precede the command being executed."""
+    if len(parts) < 3 or parts[:2] != ["uv", "run"]:
+        return parts
+    index = 2
+    while index < len(parts) and parts[index] != "--" and parts[index].startswith("-"):
+        raw_option = parts[index]
+        option = raw_option.split("=", 1)[0]
+        index += 1
+        if "=" not in raw_option and option in _UV_RUN_OPTIONS_WITH_VALUES:
+            index += 1
+    if index < len(parts) and parts[index] == "--":
+        index += 1
+    return ["uv", "run", *parts[index:]]
+
 
 def _looks_like_test_command(command: str) -> bool:
     """Return True for common whole-suite or targeted test invocations."""
@@ -343,6 +408,7 @@ def _test_invocation_from_prefix(command: str) -> str | None:
     except ValueError:
         parts = command.replace('"', "").replace("'", "").split()
     parts = _strip_env_prefix(parts)
+    parts = _strip_uv_run_options(parts)
     if not parts:
         return None
     if any(part in {"|", "||", ";", "&"} for part in parts):

--- a/src/ouroboros/orchestrator/evidence/shell_parsing.py
+++ b/src/ouroboros/orchestrator/evidence/shell_parsing.py
@@ -325,25 +325,145 @@ def _has_unquoted_status_masking_control(command: str) -> bool:
     return False
 
 
-def _uv_run_contains_pytest(parts: list[str]) -> bool:
-    """Recognize pytest selected by uv without reimplementing uv's option grammar.
+_UV_VALUE_OPTIONS = frozenset(
+    {
+        "--allow-insecure-host",
+        "--cache-dir",
+        "--color",
+        "--config-file",
+        "--config-setting",
+        "--config-settings-package",
+        "--default-index",
+        "--directory",
+        "--env-file",
+        "--exclude-newer",
+        "--exclude-newer-package",
+        "--extra",
+        "--extra-index-url",
+        "--find-links",
+        "--fork-strategy",
+        "--group",
+        "--index",
+        "--index-strategy",
+        "--index-url",
+        "--keyring-provider",
+        "--link-mode",
+        "--no-binary-package",
+        "--no-build-isolation-package",
+        "--no-build-package",
+        "--no-editable-package",
+        "--no-extra",
+        "--no-group",
+        "--no-sources-package",
+        "--only-group",
+        "--package",
+        "--prerelease",
+        "--project",
+        "--python",
+        "--python-platform",
+        "--refresh-package",
+        "--reinstall-package",
+        "--resolution",
+        "--upgrade-group",
+        "--upgrade-package",
+        "--with",
+        "--with-editable",
+        "--with-requirements",
+    }
+)
+_UV_FLAG_OPTIONS = frozenset(
+    {
+        "--active",
+        "--all-extras",
+        "--all-groups",
+        "--all-packages",
+        "--compile-bytecode",
+        "--exact",
+        "--frozen",
+        "--isolated",
+        "--locked",
+        "--managed-python",
+        "--native-tls",
+        "--no-binary",
+        "--no-build",
+        "--no-build-isolation",
+        "--no-cache",
+        "--no-config",
+        "--no-default-groups",
+        "--no-dev",
+        "--no-editable",
+        "--no-env-file",
+        "--no-index",
+        "--no-managed-python",
+        "--no-progress",
+        "--no-project",
+        "--no-python-downloads",
+        "--no-sources",
+        "--no-sync",
+        "--offline",
+        "--only-dev",
+        "--refresh",
+        "--reinstall",
+        "--upgrade",
+    }
+)
+_UV_SHORT_VALUE_OPTIONS = frozenset({"C", "f", "i", "p", "P", "w"})
+_UV_SHORT_FLAG_OPTIONS = frozenset({"n", "q", "U", "v"})
 
-    This is only a candidate classifier. Evidence acceptance separately requires
-    the exact recorded command, successful structured runtime status, and real
-    pytest success output. Script mode is excluded because a file named pytest
-    can emit arbitrary lookalike text.
-    """
+
+def _uv_run_pytest_operand(parts: list[str]) -> bool:
+    """Parse the uv option prefix and identify the selected program/module."""
     if len(parts) < 3 or parts[:2] != ["uv", "run"]:
         return False
-    tail = parts[2:]
-    if any(part in {"-s", "--script", "--gui-script"} for part in tail):
+    index = 2
+    while index < len(parts):
+        token = parts[index]
+        if token == "--":
+            index += 1
+            break
+        if not token.startswith("-") or token == "-":
+            break
+        if token in {"--help", "-h", "--version", "-V", "--script", "-s", "--gui-script"}:
+            return False
+        if token in {"--module", "-m"}:
+            index += 1
+            continue
+        if token.startswith("--"):
+            option, separator, _attached = token.partition("=")
+            if option in _UV_FLAG_OPTIONS:
+                if separator:
+                    return False
+                index += 1
+                continue
+            if option not in _UV_VALUE_OPTIONS:
+                return False
+            index += 1
+            if not separator:
+                if index >= len(parts):
+                    return False
+                index += 1
+            continue
+        cluster = token[1:]
+        position = 0
+        while position < len(cluster):
+            option = cluster[position]
+            if option in {"h", "s"}:
+                return False
+            if option == "m" or option in _UV_SHORT_FLAG_OPTIONS:
+                position += 1
+                continue
+            if option not in _UV_SHORT_VALUE_OPTIONS:
+                return False
+            if position + 1 == len(cluster):
+                index += 1
+                if index >= len(parts):
+                    return False
+            position = len(cluster)
+        index += 1
+    if index >= len(parts):
         return False
-    for index, part in enumerate(tail):
-        if part in {"-m", "--module"}:
-            return index + 1 < len(tail) and tail[index + 1] in {"pytest", "py.test"}
-        if part in {"pytest", "py.test"}:
-            return True
-    return False
+    operand = parts[index]
+    return operand in {"pytest", "py.test"}
 
 
 def _test_invocation_from_prefix(command: str) -> str | None:
@@ -375,7 +495,7 @@ def _test_invocation_from_prefix(command: str) -> str | None:
         return _normalized_evidence_text(" ".join(parts))
     if len(parts) >= 2 and parts[0] in {"npm", "pnpm", "yarn"} and parts[1] == "test":
         return _normalized_evidence_text(" ".join(parts))
-    if _uv_run_contains_pytest(parts):
+    if _uv_run_pytest_operand(parts):
         return _normalized_evidence_text(" ".join(parts))
     if (
         len(parts) >= 3

--- a/src/ouroboros/orchestrator/evidence/shell_parsing.py
+++ b/src/ouroboros/orchestrator/evidence/shell_parsing.py
@@ -37,6 +37,7 @@ _UV_RUN_OPTIONS_WITH_VALUES = frozenset(
         "--no-binary-package",
         "--no-build-isolation-package",
         "--no-build-package",
+        "--no-editable-package",
         "--no-extra",
         "--no-group",
         "--only-group",
@@ -73,6 +74,10 @@ _UV_RUN_FLAG_OPTIONS = frozenset(
         "--locked",
         "--managed-python",
         "--native-tls",
+        "--no-config",
+        "--no-binary",
+        "--no-build-isolation",
+        "--no-default-groups",
         "--no-build",
         "--no-cache",
         "--no-dev",
@@ -91,6 +96,7 @@ _UV_RUN_FLAG_OPTIONS = frozenset(
         "--reinstall",
         "--upgrade",
         "-n",
+        "--system-certs",
         "-q",
         "-U",
         "-v",
@@ -110,16 +116,25 @@ def _strip_uv_run_options(parts: list[str]) -> list[str] | None:
     while index < len(parts) and parts[index] != "--" and parts[index].startswith("-"):
         raw_option = parts[index]
         option = raw_option.split("=", 1)[0]
+        attached_value: str | None = None
+        if (
+            "=" not in raw_option
+            and len(raw_option) > 2
+            and raw_option[:2] in {"-C", "-f", "-i", "-p", "-P", "-w"}
+        ):
+            option, attached_value = raw_option[:2], raw_option[2:]
         index += 1
         if option in _UV_RUN_NON_EXECUTING_OPTIONS or option in _UV_RUN_SCRIPT_OPTIONS:
             return None
         if option in _UV_RUN_MODULE_OPTIONS:
             module_mode = True
             continue
-        if option in _UV_RUN_FLAG_OPTIONS or option.startswith(("-q", "-v")):
+        if option in _UV_RUN_FLAG_OPTIONS or re.fullmatch(r"-(?:q+|v+)", option):
             continue
         if option not in _UV_RUN_OPTIONS_WITH_VALUES:
             return None
+        if attached_value is not None:
+            continue
         if "=" not in raw_option:
             if index >= len(parts) or parts[index].startswith("-"):
                 return None

--- a/src/ouroboros/orchestrator/evidence/shell_parsing.py
+++ b/src/ouroboros/orchestrator/evidence/shell_parsing.py
@@ -27,6 +27,7 @@ _UV_RUN_OPTIONS_WITH_VALUES = frozenset(
         "--extra",
         "--extra-index-url",
         "--find-links",
+        "--fork-strategy",
         "--group",
         "--index",
         "--index-strategy",
@@ -59,22 +60,76 @@ _UV_RUN_OPTIONS_WITH_VALUES = frozenset(
         "-w",
     }
 )
+_UV_RUN_FLAG_OPTIONS = frozenset(
+    {
+        "--active",
+        "--all-extras",
+        "--all-groups",
+        "--all-packages",
+        "--compile-bytecode",
+        "--exact",
+        "--frozen",
+        "--isolated",
+        "--locked",
+        "--managed-python",
+        "--native-tls",
+        "--no-build",
+        "--no-cache",
+        "--no-dev",
+        "--no-editable",
+        "--no-env-file",
+        "--no-index",
+        "--no-managed-python",
+        "--no-project",
+        "--no-progress",
+        "--no-python-downloads",
+        "--no-sources",
+        "--no-sync",
+        "--offline",
+        "--only-dev",
+        "--refresh",
+        "--reinstall",
+        "--upgrade",
+        "-n",
+        "-q",
+        "-U",
+        "-v",
+    }
+)
+_UV_RUN_SCRIPT_OPTIONS = frozenset({"--gui-script", "--script", "-s"})
+_UV_RUN_MODULE_OPTIONS = frozenset({"--module", "-m"})
+_UV_RUN_NON_EXECUTING_OPTIONS = frozenset({"--help", "-h", "--version", "-V"})
 
 
-def _strip_uv_run_options(parts: list[str]) -> list[str]:
-    """Remove uv options that precede the command being executed."""
+def _strip_uv_run_options(parts: list[str]) -> list[str] | None:
+    """Return the executed command, rejecting unknown or mode-changing options."""
     if len(parts) < 3 or parts[:2] != ["uv", "run"]:
         return parts
     index = 2
+    module_mode = False
     while index < len(parts) and parts[index] != "--" and parts[index].startswith("-"):
         raw_option = parts[index]
         option = raw_option.split("=", 1)[0]
         index += 1
-        if "=" not in raw_option and option in _UV_RUN_OPTIONS_WITH_VALUES:
+        if option in _UV_RUN_NON_EXECUTING_OPTIONS or option in _UV_RUN_SCRIPT_OPTIONS:
+            return None
+        if option in _UV_RUN_MODULE_OPTIONS:
+            module_mode = True
+            continue
+        if option in _UV_RUN_FLAG_OPTIONS or option.startswith(("-q", "-v")):
+            continue
+        if option not in _UV_RUN_OPTIONS_WITH_VALUES:
+            return None
+        if "=" not in raw_option:
+            if index >= len(parts) or parts[index].startswith("-"):
+                return None
             index += 1
     if index < len(parts) and parts[index] == "--":
         index += 1
-    return ["uv", "run", *parts[index:]]
+    if index >= len(parts):
+        return None
+    command = parts[index:]
+    return ["python", "-m", *command] if module_mode else ["uv", "run", *command]
 
 
 def _looks_like_test_command(command: str) -> bool:
@@ -331,8 +386,7 @@ def _has_gradle_or_maven_test_skip(parts: list[str]) -> bool:
             if maven_skip_property_disables_tests(parts[index + 1]):
                 return True
         if normalized.startswith("--define="):
-            _, _, define_value = normalized.partition("=")
-            if maven_skip_property_disables_tests(define_value):
+            if maven_skip_property_disables_tests(normalized.partition("=")[2]):
                 return True
         if normalized.startswith("-d") and maven_skip_property_disables_tests(normalized[2:]):
             return True
@@ -408,7 +462,10 @@ def _test_invocation_from_prefix(command: str) -> str | None:
     except ValueError:
         parts = command.replace('"', "").replace("'", "").split()
     parts = _strip_env_prefix(parts)
-    parts = _strip_uv_run_options(parts)
+    uv_parts = _strip_uv_run_options(parts)
+    if uv_parts is None:
+        return None
+    parts = uv_parts
     if not parts:
         return None
     if any(part in {"|", "||", ";", "&"} for part in parts):

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -2507,8 +2507,10 @@ def render_parallel_verification_report(
         lines.append(f"Externally Satisfied: {parallel_result.externally_satisfied_count}")
     if parallel_result.failure_count > 0:
         lines.append(f"Failed: {parallel_result.failure_count}")
-    if parallel_result.skipped_count > 0:
-        lines.append(f"Skipped: {parallel_result.skipped_count}")
+    if parallel_result.blocked_count > 0:
+        lines.append(f"Blocked: {parallel_result.blocked_count}")
+    if parallel_result.invalid_count > 0:
+        lines.append(f"Invalid: {parallel_result.invalid_count}")
     unverifiable_indices = [
         result.ac_index + 1
         for result in parallel_result.results
@@ -2584,6 +2586,10 @@ def render_parallel_completion_message(
         lines.append(f"Externally Satisfied: {parallel_result.externally_satisfied_count}")
     if parallel_result.failure_count > 0:
         lines.append(f"Failed: {parallel_result.failure_count}")
+    if parallel_result.blocked_count > 0:
+        lines.append(f"Blocked: {parallel_result.blocked_count}")
+    if parallel_result.invalid_count > 0:
+        lines.append(f"Invalid: {parallel_result.invalid_count}")
     if parallel_result.skipped_count > 0:
         lines.append(f"Skipped: {parallel_result.skipped_count}")
 
@@ -2593,9 +2599,17 @@ def render_parallel_completion_message(
         if result.outcome == ACExecutionOutcome.SATISFIED_EXTERNALLY:
             status = "COMPLETED"
             suffix = " (externally satisfied)"
+        elif result.outcome == ACExecutionOutcome.BLOCKED:
+            status = "BLOCKED"
+            suffix = f" — {result.error}" if result.error else ""
+        elif result.outcome == ACExecutionOutcome.INVALID:
+            status = "INVALID"
+            suffix = f" — {result.error}" if result.error else ""
         else:
             status = "COMPLETED" if result.success else "FAILED"
             suffix = f" ({len(result.sub_results)} subtasks)" if result.is_decomposed else ""
+            if not result.success and result.error:
+                suffix += f" — {result.error}"
         lines.append(f"- Task {result.ac_index + 1}: [{status}] {result.ac_content}{suffix}")
     return "\n".join(lines)
 
@@ -4537,7 +4551,10 @@ class ParallelACExecutor:
 
                 self._console.print(
                     f"[green]Level {level_num} complete: "
-                    f"{level_success} succeeded, {level_failed} failed[/green]"
+                    f"{stage_result.success_count} succeeded, "
+                    f"{stage_result.failure_count} failed, "
+                    f"{stage_result.blocked_count} blocked, "
+                    f"{stage_result.invalid_count} invalid[/green]"
                 )
                 self._flush_console()
 

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -2590,8 +2590,6 @@ def render_parallel_completion_message(
         lines.append(f"Blocked: {parallel_result.blocked_count}")
     if parallel_result.invalid_count > 0:
         lines.append(f"Invalid: {parallel_result.invalid_count}")
-    if parallel_result.skipped_count > 0:
-        lines.append(f"Skipped: {parallel_result.skipped_count}")
 
     lines.append("")
     lines.append("Task Status:")

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -10595,6 +10595,27 @@ class TestParallelACExecutor:
     def test_pytest_s_argument_is_not_uv_script_mode(self, command: str) -> None:
         assert _looks_like_test_command(command) is True
 
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "uv run --with --isolated pytest -q",
+            "uv run --color -- pytest -q",
+        ),
+    )
+    def test_uv_missing_option_values_fail_closed(self, command: str) -> None:
+        assert _looks_like_test_command(command) is False
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "uv run --quiet pytest -q",
+            "uv run --verbose pytest -q",
+            "uv run --system-certs pytest -q",
+        ),
+    )
+    def test_uv_current_global_flags_remain_test_evidence(self, command: str) -> None:
+        assert _looks_like_test_command(command) is True
+
     def test_option_bearing_uv_command_backs_its_exact_tests_passed_claim(self) -> None:
         command = "uv run --python 3.12 --with pytest pytest -q"
         message = AgentMessage(

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -10587,6 +10587,14 @@ class TestParallelACExecutor:
     def test_uv_script_modes_are_not_test_evidence(self, command: str) -> None:
         assert _looks_like_test_command(command) is False
 
+    def test_uv_dependency_named_pytest_does_not_become_program_identity(self) -> None:
+        command = "uv run --with pytest python -c \"print('2 passed in 0.01s')\""
+        assert _looks_like_test_command(command) is False
+
+    @pytest.mark.parametrize("command", ("uv run pytest -s -q", "uv run -- pytest -s -q"))
+    def test_pytest_s_argument_is_not_uv_script_mode(self, command: str) -> None:
+        assert _looks_like_test_command(command) is True
+
     def test_option_bearing_uv_command_backs_its_exact_tests_passed_claim(self) -> None:
         command = "uv run --python 3.12 --with pytest pytest -q"
         message = AgentMessage(

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -62,6 +62,10 @@ from ouroboros.orchestrator.evidence.claims import (
     _shell_command_mutation_targets,
     _text_needs_shell_expansion,
 )
+from ouroboros.orchestrator.evidence.shell_parsing import (
+    _looks_like_test_command,
+    _test_command_invocation,
+)
 from ouroboros.orchestrator.evidence_schema import EvidenceRecord, ValidationResult
 from ouroboros.orchestrator.execution_authority import (
     runtime_effect_capabilities_contract,
@@ -10560,6 +10564,46 @@ class TestParallelACExecutor:
         )
         assert evidence_event.data["verifier_passed"] is False
 
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "uv run --python 3.12 --with pytest pytest -q",
+            "uv run -p 3.12 -w pytest pytest test_hello.py -q",
+            "uv run --isolated --with=pytest -- pytest -q",
+        ),
+    )
+    def test_option_bearing_uv_run_is_test_evidence(self, command: str) -> None:
+        assert _looks_like_test_command(command) is True
+        assert _test_command_invocation(command).startswith("uv run pytest")
+
+    def test_option_bearing_uv_collect_only_is_not_test_evidence(self) -> None:
+        command = "uv run --python 3.12 --with pytest pytest --collect-only"
+
+        assert _looks_like_test_command(command) is False
+
+    def test_option_bearing_uv_command_backs_tests_passed_claim(self) -> None:
+        command = "uv run --python 3.12 --with pytest pytest -q"
+        message = AgentMessage(
+            type="assistant",
+            content=f"Calling tool: Bash: {command}",
+            tool_name="Bash",
+            data={
+                "tool_input": {"command": command},
+                "output": "2 passed in 0.01s",
+                "exit_code": 0,
+            },
+        )
+
+        assert (
+            _runtime_messages_support_test_claim(
+                value=command,
+                backed_commands=(command,),
+                messages=(message,),
+                task_cwd="/tmp",
+            )
+            is True
+        )
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize("build_case", _ACCEPTED_UNITTEST_CLAIM_CASES)
     async def test_fat_harness_verifier_accepts_backed_unittest_claim(
@@ -14631,6 +14675,10 @@ class TestParallelACExecutor:
         assert result.stages[1].success_count == 1
         assert result.stages[1].blocked_count == 1
         executor._emit_level_started.assert_awaited()
+        assert any(
+            "1 succeeded, 0 failed, 1 blocked, 0 invalid" in str(call)
+            for call in executor._console.print.call_args_list
+        )
 
     @pytest.mark.asyncio
     async def test_fully_blocked_stage_does_not_start(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -62,10 +62,7 @@ from ouroboros.orchestrator.evidence.claims import (
     _shell_command_mutation_targets,
     _text_needs_shell_expansion,
 )
-from ouroboros.orchestrator.evidence.shell_parsing import (
-    _looks_like_test_command,
-    _test_command_invocation,
-)
+from ouroboros.orchestrator.evidence.shell_parsing import _looks_like_test_command
 from ouroboros.orchestrator.evidence_schema import EvidenceRecord, ValidationResult
 from ouroboros.orchestrator.execution_authority import (
     runtime_effect_capabilities_contract,
@@ -10568,61 +10565,29 @@ class TestParallelACExecutor:
         "command",
         (
             "uv run --python 3.12 --with pytest pytest -q",
-            "uv run -p 3.12 -w pytest pytest test_hello.py -q",
-            "uv run --isolated --with=pytest -- pytest -q",
-        ),
-    )
-    def test_option_bearing_uv_run_is_test_evidence(self, command: str) -> None:
-        assert _looks_like_test_command(command) is True
-        assert _test_command_invocation(command).startswith("uv run pytest")
-
-    def test_option_bearing_uv_collect_only_is_not_test_evidence(self) -> None:
-        command = "uv run --python 3.12 --with pytest pytest --collect-only"
-
-        assert _looks_like_test_command(command) is False
-
-    @pytest.mark.parametrize(
-        "command",
-        (
-            "uv run --help pytest",
-            "uv run --no-project -s pytest",
-            "uv run --unknown-option pytest",
-            "uv run --python pytest",
-        ),
-    )
-    def test_uv_run_non_test_or_unknown_modes_fail_closed(self, command: str) -> None:
-        assert _looks_like_test_command(command) is False
-
-    @pytest.mark.parametrize(
-        "command",
-        (
             "uv run --fork-strategy fewest --with pytest pytest -q",
+            "uv run --no-sources-package foo pytest -q",
+            "uv run --upgrade-group foo pytest -q",
+            "uv run -qn pytest -q",
+            "uv run -p3.12 pytest -q",
             "uv run -m pytest -q",
         ),
     )
-    def test_uv_run_supported_option_matrix_remains_test_evidence(self, command: str) -> None:
+    def test_option_bearing_uv_pytest_is_candidate_evidence(self, command: str) -> None:
         assert _looks_like_test_command(command) is True
 
     @pytest.mark.parametrize(
         "command",
         (
-            "uv run --no-default-groups pytest -q",
-            "uv run --no-editable-package foo pytest -q",
-            "uv run --no-build-isolation pytest -q",
-            "uv run --no-binary pytest -q",
-            "uv run --system-certs pytest -q",
-            "uv run --no-config pytest -q",
-            "uv run -p3.12 pytest -q",
+            "uv run --no-project -s pytest",
+            "uv run --script pytest",
+            "uv run --gui-script pytest",
         ),
     )
-    def test_uv_run_current_option_grammar_remains_test_evidence(self, command: str) -> None:
-        assert _looks_like_test_command(command) is True
-
-    @pytest.mark.parametrize("command", ("uv run -version pytest", "uv run -vanything pytest -q"))
-    def test_uv_run_malformed_short_clusters_fail_closed(self, command: str) -> None:
+    def test_uv_script_modes_are_not_test_evidence(self, command: str) -> None:
         assert _looks_like_test_command(command) is False
 
-    def test_option_bearing_uv_command_backs_tests_passed_claim(self) -> None:
+    def test_option_bearing_uv_command_backs_its_exact_tests_passed_claim(self) -> None:
         command = "uv run --python 3.12 --with pytest pytest -q"
         message = AgentMessage(
             type="assistant",
@@ -14716,10 +14681,6 @@ class TestParallelACExecutor:
         assert result.stages[1].success_count == 1
         assert result.stages[1].blocked_count == 1
         executor._emit_level_started.assert_awaited()
-        assert any(
-            "1 succeeded, 0 failed, 1 blocked, 0 invalid" in str(call)
-            for call in executor._console.print.call_args_list
-        )
 
     @pytest.mark.asyncio
     async def test_fully_blocked_stage_does_not_start(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -10648,6 +10648,31 @@ class TestParallelACExecutor:
             is False
         )
 
+    @pytest.mark.parametrize("shell", ("bash", "/bin/zsh"))
+    def test_wrapped_compound_uv_command_cannot_back_standalone_claim(self, shell: str) -> None:
+        inner = "uv run pytest -q && python scripts/postprocess.py"
+        command = f"{shell} -lc '{inner}'"
+        claim = "uv run pytest -q"
+        message = AgentMessage(
+            type="assistant",
+            content=f"Calling tool: Bash: {command}",
+            tool_name="Bash",
+            data={
+                "tool_input": {"command": command},
+                "output": "2 passed in 0.01s",
+                "exit_code": 0,
+            },
+        )
+        assert (
+            _runtime_messages_support_test_claim(
+                value=claim,
+                backed_commands=(command,),
+                messages=(message,),
+                task_cwd="/tmp",
+            )
+            is False
+        )
+
     @pytest.mark.parametrize(
         ("command", "expected"),
         (

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -10625,6 +10625,47 @@ class TestParallelACExecutor:
     def test_uv_non_executing_pytest_modes_are_not_evidence(self, command: str) -> None:
         assert _looks_like_test_command(command) is False
 
+    def test_uv_preview_features_value_is_test_evidence(self) -> None:
+        command = "uv run --preview-features target-workspace-discovery pytest -q"
+        assert _looks_like_test_command(command) is True
+
+    @pytest.mark.parametrize("option", ("--color=", "--directory="))
+    def test_uv_empty_attached_option_values_fail_closed(self, option: str) -> None:
+        assert _looks_like_test_command(f"uv run {option} pytest -q") is False
+
+    @pytest.mark.parametrize(
+        ("command", "expected"),
+        (
+            ("uv run --preview-features target-workspace-discovery pytest -q", True),
+            ("uv run --color= pytest -q", False),
+            ("uv run --directory= pytest -q", False),
+        ),
+    )
+    def test_uv_long_option_operands_gate_end_to_end_claims(
+        self,
+        command: str,
+        expected: bool,
+    ) -> None:
+        message = AgentMessage(
+            type="assistant",
+            content=f"Calling tool: Bash: {command}",
+            tool_name="Bash",
+            data={
+                "tool_input": {"command": command},
+                "output": "2 passed in 0.01s",
+                "exit_code": 0,
+            },
+        )
+        assert (
+            _runtime_messages_support_test_claim(
+                value=command,
+                backed_commands=(command,),
+                messages=(message,),
+                task_cwd="/tmp",
+            )
+            is expected
+        )
+
     def test_compound_uv_command_cannot_back_standalone_pytest_claim(self) -> None:
         command = "uv run --with pytest pytest -q && python scripts/postprocess.py"
         claim = "uv run --with pytest pytest -q"

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -10581,6 +10581,28 @@ class TestParallelACExecutor:
 
         assert _looks_like_test_command(command) is False
 
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "uv run --help pytest",
+            "uv run --no-project -s pytest",
+            "uv run --unknown-option pytest",
+            "uv run --python pytest",
+        ),
+    )
+    def test_uv_run_non_test_or_unknown_modes_fail_closed(self, command: str) -> None:
+        assert _looks_like_test_command(command) is False
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "uv run --fork-strategy fewest --with pytest pytest -q",
+            "uv run -m pytest -q",
+        ),
+    )
+    def test_uv_run_supported_option_matrix_remains_test_evidence(self, command: str) -> None:
+        assert _looks_like_test_command(command) is True
+
     def test_option_bearing_uv_command_backs_tests_passed_claim(self) -> None:
         command = "uv run --python 3.12 --with pytest pytest -q"
         message = AgentMessage(

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -10608,6 +10608,49 @@ class TestParallelACExecutor:
     @pytest.mark.parametrize(
         "command",
         (
+            "uv run -p --isolated pytest -q",
+            "uv run -w --isolated pytest -q",
+        ),
+    )
+    def test_uv_missing_short_option_values_fail_closed(self, command: str) -> None:
+        assert _looks_like_test_command(command) is False
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "uv run --python 3.12 pytest --collect-only",
+            "uv run -m pytest --setup-only",
+        ),
+    )
+    def test_uv_non_executing_pytest_modes_are_not_evidence(self, command: str) -> None:
+        assert _looks_like_test_command(command) is False
+
+    def test_compound_uv_command_cannot_back_standalone_pytest_claim(self) -> None:
+        command = "uv run --with pytest pytest -q && python scripts/postprocess.py"
+        claim = "uv run --with pytest pytest -q"
+        message = AgentMessage(
+            type="assistant",
+            content=f"Calling tool: Bash: {command}",
+            tool_name="Bash",
+            data={
+                "tool_input": {"command": command},
+                "output": "2 passed in 0.01s",
+                "exit_code": 0,
+            },
+        )
+        assert (
+            _runtime_messages_support_test_claim(
+                value=claim,
+                backed_commands=(command,),
+                messages=(message,),
+                task_cwd="/tmp",
+            )
+            is False
+        )
+
+    @pytest.mark.parametrize(
+        "command",
+        (
             "uv run --quiet pytest -q",
             "uv run --verbose pytest -q",
             "uv run --system-certs pytest -q",

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -10649,6 +10649,39 @@ class TestParallelACExecutor:
         )
 
     @pytest.mark.parametrize(
+        ("command", "expected"),
+        (
+            ("uv run -V pytest", False),
+            ("uv run -C foo=bar pytest -q", True),
+            ("uv run -U pytest -q", True),
+        ),
+    )
+    def test_uv_short_options_preserve_case(self, command: str, expected: bool) -> None:
+        assert _looks_like_test_command(command) is expected
+
+    def test_uv_version_mode_cannot_back_tests_passed_claim(self) -> None:
+        command = "uv run -V pytest"
+        message = AgentMessage(
+            type="assistant",
+            content=f"Calling tool: Bash: {command}",
+            tool_name="Bash",
+            data={
+                "tool_input": {"command": command},
+                "output": "2 passed in 0.01s",
+                "exit_code": 0,
+            },
+        )
+        assert (
+            _runtime_messages_support_test_claim(
+                value=command,
+                backed_commands=(command,),
+                messages=(message,),
+                task_cwd="/tmp",
+            )
+            is False
+        )
+
+    @pytest.mark.parametrize(
         "command",
         (
             "uv run --quiet pytest -q",

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -10603,6 +10603,25 @@ class TestParallelACExecutor:
     def test_uv_run_supported_option_matrix_remains_test_evidence(self, command: str) -> None:
         assert _looks_like_test_command(command) is True
 
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "uv run --no-default-groups pytest -q",
+            "uv run --no-editable-package foo pytest -q",
+            "uv run --no-build-isolation pytest -q",
+            "uv run --no-binary pytest -q",
+            "uv run --system-certs pytest -q",
+            "uv run --no-config pytest -q",
+            "uv run -p3.12 pytest -q",
+        ),
+    )
+    def test_uv_run_current_option_grammar_remains_test_evidence(self, command: str) -> None:
+        assert _looks_like_test_command(command) is True
+
+    @pytest.mark.parametrize("command", ("uv run -version pytest", "uv run -vanything pytest -q"))
+    def test_uv_run_malformed_short_clusters_fail_closed(self, command: str) -> None:
+        assert _looks_like_test_command(command) is False
+
     def test_option_bearing_uv_command_backs_tests_passed_claim(self) -> None:
         command = "uv run --python 3.12 --with pytest pytest -q"
         message = AgentMessage(

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -42,6 +42,7 @@ from ouroboros.orchestrator.parallel_executor import (
     _missing_expected_artifacts,
     _serialize_verify_gate_outcome,
     _VerifyGateOutcome,
+    render_parallel_completion_message,
     render_parallel_verification_report,
 )
 from ouroboros.orchestrator.retry_hints import is_retryable_failure
@@ -2190,6 +2191,39 @@ def test_report_surfaces_unverified_success() -> None:
 
     assert "Success: 1/1" in report
     assert "needs confirmation: AC 1" in report
+
+
+def test_completion_message_distinguishes_blocked_and_failure_reasons() -> None:
+    failed = ACExecutionResult(
+        ac_index=0,
+        ac_content="Run the tests",
+        success=False,
+        error="unsupported uv evidence command",
+        outcome=ACExecutionOutcome.FAILED,
+    )
+    blocked = ACExecutionResult(
+        ac_index=1,
+        ac_content="Package the result",
+        success=False,
+        error="Skipped: dependency failed",
+        outcome=ACExecutionOutcome.BLOCKED,
+    )
+    parallel_result = ParallelExecutionResult(
+        results=(failed, blocked),
+        success_count=0,
+        failure_count=1,
+        blocked_count=1,
+        skipped_count=1,
+        total_duration_seconds=0.0,
+    )
+
+    message = render_parallel_completion_message(parallel_result, 2)
+
+    assert "Failed: 1" in message
+    assert "Blocked: 1" in message
+    assert "Skipped: 1" in message
+    assert "[FAILED] Run the tests — unsupported uv evidence command" in message
+    assert "[BLOCKED] Package the result — Skipped: dependency failed" in message
 
 
 def test_verify_gate_outcome_roundtrips_the_quarantine_flag() -> None:

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -2221,7 +2221,7 @@ def test_completion_message_distinguishes_blocked_and_failure_reasons() -> None:
 
     assert "Failed: 1" in message
     assert "Blocked: 1" in message
-    assert "Skipped: 1" in message
+    assert "\nSkipped:" not in message
     assert "[FAILED] Run the tests — unsupported uv evidence command" in message
     assert "[BLOCKED] Package the result — Skipped: dependency failed" in message
 


### PR DESCRIPTION
## Summary

- Parse `uv run` options before classifying transcript-backed pytest evidence, covering `--python`, `--with`, `-p`, `-w`, `--isolated`, and `--` forms.
- Keep `--collect-only` and other non-executing test modes rejected.
- Make level and final summaries distinguish failed, blocked, and invalid ACs and include terminal reasons, preventing the reported `0 succeeded / 0 failed` ambiguity.

## Verification

- `tests/unit/orchestrator/test_parallel_executor.py` and `test_parallel_executor_verify_by_default.py` — 613 passed
- Ruff, format, diff check, and diagnostics pass

Closes #2124