### PR TITLE
fix(codex): prevent native Windows stdio registration

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -248,7 +248,7 @@ ouroboros setup [OPTIONS]
 | `-r, --runtime TEXT` | Runtime backend to configure. Shipped values: `claude`, `claude-sdk`, `claude-cli`, `codex`, `opencode`, `hermes`, `gemini`, `goose`, `kiro`, `copilot`, `pi`, `gjc`, `antigravity`, `grok`, `zcode`. Auto-detected if omitted |
 | `--opencode-mode TEXT` | OpenCode integration mode: `plugin` (default, recommended — bridge plugin for interactive sessions) or `subprocess` (headless/CI). Mutually exclusive — see [OpenCode runtime guide](runtime-guides/opencode.md#configuration) |
 | `--non-interactive` | Skip interactive prompts (for scripted installs) |
-| `--mcp-mode TEXT` | Codex MCP config mode: `auto` (default), `preserve`, or `stdio` |
+| `--mcp-mode TEXT` | Codex MCP config mode: `auto` (default), `preserve`, `stdio`, or native-Windows-only explicit `http` |
 
 For Pi, setup also installs `~/.pi/agent/extensions/ouroboros-ooo-bridge.ts`.
 Restart Pi or run `/reload` and interactive Pi/roach-pi sessions can dispatch
@@ -291,7 +291,7 @@ ouroboros setup --non-interactive
 - For Codex CLI: sets `orchestrator.codex_cli_path` and `llm.backend: codex` in `~/.ouroboros/config.yaml`
 - For Codex CLI: installs managed Ouroboros rules into `~/.codex/rules/`
 - For Codex CLI: installs managed Ouroboros skills into `~/.codex/skills/`
-- For Codex CLI: registers the Ouroboros MCP/env block in `~/.codex/config.toml` when absent, refreshes setup-managed stdio blocks, and preserves user-managed URL/custom blocks by default
+- For Codex CLI: registers or refreshes setup-managed stdio blocks on supported hosts and preserves user-managed URL/custom blocks by default. Native Windows `auto` creates no MCP child, `stdio` is refused, and explicit `http` writes the loopback URL only after resolving a launchable MCP command; the operator owns that visible server process.
 - For Codex CLI: adds missing Ouroboros task profiles whose per-role reasoning effort is passed to each `codex exec` invocation; it retires only untouched legacy generated profile anchors and preserves user-created Codex profiles
 - For OpenCode: registers the Ouroboros MCP server in OpenCode's configuration
 - For OpenCode (plugin mode): installs the bridge plugin into `<opencode_config_dir>/plugins/ouroboros-bridge/`

--- a/docs/runtime-guides/codex.md
+++ b/docs/runtime-guides/codex.md
@@ -120,13 +120,13 @@ Under the hood, `CodexCliRuntime` still talks to the local `codex` executable, b
 - Records `orchestrator.codex_cli_path` when available
 - Installs managed Ouroboros rules into `~/.codex/rules/`
 - Installs managed Ouroboros skills into `~/.codex/skills/`
-- Registers the Ouroboros MCP/env hookup in `~/.codex/config.toml` when absent, refreshes setup-managed stdio blocks, and preserves user-managed URL/custom entries by default
+- Registers the Ouroboros MCP/env hookup in `~/.codex/config.toml` when absent, refreshes setup-managed stdio blocks, and preserves user-managed URL/custom entries by default. On native Windows, default setup creates no stdio child; use explicit `--mcp-mode http` and run the printed loopback server command before opening Codex Desktop. The server is not installed as background persistence.
 - Retires only untouched legacy generated `ouroboros-*.config.toml` task-profile anchors; user-created Codex profiles are preserved
 - Registers a managed `ouroboros-worker.config.toml` file so Agent OS worker subprocesses can opt out of interactive Codex defaults without losing the MCP/env hookup
 
 Setup also creates artifacts outside `~/.codex/`: `ensure_config_dir()` creates `~/.ouroboros/data/` and `~/.ouroboros/logs/` (`cli/commands/setup.py:2632`), and a fresh configuration gets a new `~/.ouroboros/credentials.yaml` written at mode `0600` (`:2771`).
 
-`~/.codex/config.toml` is not where Ouroboros stage model pins belong. Use the settings UI or the equivalent `~/.ouroboros/config.yaml` values; keep user-managed native Codex profiles when you need an explicit `--profile`. If you manage a long-running URL-based Ouroboros MCP server, keep that URL entry in `~/.codex/config.toml`; `ouroboros setup --runtime codex` preserves it by default. Use `--mcp-mode stdio` only when you intentionally want setup to replace the entry with the managed command-spawned server.
+`~/.codex/config.toml` is not where Ouroboros stage model pins belong. Use the settings UI or the equivalent `~/.ouroboros/config.yaml` values; keep user-managed native Codex profiles when you need an explicit `--profile`. If you manage a long-running URL-based Ouroboros MCP server, keep that URL entry in `~/.codex/config.toml`; setup preserves it by default. Use `--mcp-mode stdio` only on supported hosts when you intentionally want a managed command-spawned server. Native Windows refuses that crash-prone topology and offers explicit operator-owned `--mcp-mode http` instead.
 
 ### Worker subprocess isolation (Agent OS `runtime_profile`)
 

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -76,6 +76,7 @@ from ouroboros.cli.setup_model_config import (
 from ouroboros.cli.setup_model_config import (
     neutralize_fresh_codex_model_defaults as _neutralize_fresh_codex_model_defaults,
 )
+from ouroboros.cli.windows_codex_mcp import apply_windows_codex_mcp_mode, is_native_windows
 from ouroboros.codex.cli_policy import resolve_codex_cli_path
 from ouroboros.codex.home import resolve_codex_home
 from ouroboros.codex.runtime_profile import codex_uses_profile_v2 as _shared_codex_uses_profile_v2
@@ -436,14 +437,6 @@ _CODEX_MCP_SECTION_TEMPLATE = """# Ouroboros MCP hookup for Codex CLI.
 OUROBOROS_AGENT_RUNTIME = "codex"
 OUROBOROS_LLM_BACKEND = "codex"
 """
-_CODEX_HTTP_MCP_SECTION = """# Ouroboros native-Windows HTTP MCP (explicit opt-in; no persistence).
-[mcp_servers.ouroboros]
-url = "http://127.0.0.1:8765/mcp"
-"""
-_CODEX_HTTP_MCP_COMMAND = (
-    "ouroboros mcp serve --runtime codex --llm-backend codex "
-    "--transport streamable-http --host 127.0.0.1 --port 8765"
-)
 
 _CODEX_MCP_COMMENT_LINES = (
     "# Ouroboros MCP hookup for Codex CLI.",
@@ -549,10 +542,6 @@ _CODEX_DEFAULT_LLM_ROLE_PROFILES: dict[str, str] = {
     "agent_runtime_coordinator": "standard",
     "agent_runtime_evaluation": "deep",
 }
-
-
-def _is_native_windows() -> bool:
-    return os.name == "nt"
 
 
 def _normalize_codex_mcp_mode(value: str) -> CodexMcpMode:
@@ -1217,57 +1206,22 @@ def _register_codex_mcp_server(
         print_info("Preserved Codex MCP config.")
         return True
 
-    if _is_native_windows():
-        if mode == "stdio":
-            print_error(
-                "Native-Windows Codex Desktop stdio MCP can terminate the app server. "
-                "Use --mcp-mode http and run the printed loopback server command, or use WSL 2."
-            )
-            return False
-        if mode == "auto":
-            codex_config = resolve_codex_home() / "config.toml"
-            if codex_config.exists():
-                try:
-                    parsed = tomllib.loads(codex_config.read_text(encoding="utf-8"))
-                except tomllib.TOMLDecodeError:
-                    print_error(f"Could not parse {codex_config} — Codex setup not saved.")
-                    return False
-                if _codex_mcp_entry_from_toml(parsed) is not None:
-                    print_info("Preserved existing Codex MCP config on native Windows.")
-                    return True
-            print_info(
-                "Skipped persistent MCP registration on native Windows. "
-                "Use --mcp-mode http for the explicit loopback HTTP topology."
-            )
-            return True
-        if mode == "http":
-            launcher = _codex_release_mcp_launcher()
-            if launcher is None:
-                print_error("Could not find a launchable MCP [mcp] command for explicit HTTP mode.")
-                return False
-            command, launcher_args = launcher
-            http_args = [
-                *launcher_args,
-                "--transport",
-                "streamable-http",
-                "--host",
-                "127.0.0.1",
-                "--port",
-                "8765",
-            ]
-            rendered_section = _CODEX_HTTP_MCP_SECTION
-            print_info(
-                "Start the MCP server before opening Codex Desktop: "
-                + " ".join([command, *(json.dumps(arg) for arg in http_args)])
-            )
-        else:
-            rendered_section = _render_codex_mcp_section()
+    if is_native_windows():
+        handled, success, section = apply_windows_codex_mcp_mode(
+            mode,
+            codex_config=resolve_codex_home() / "config.toml",
+            launcher=_codex_release_mcp_launcher() if mode == "http" else None,
+            print_error=print_error,
+            print_info=print_info,
+        )
+        if handled and (not success or section is None):
+            return success
+        rendered_section = section if handled else _render_codex_mcp_section()
     else:
         if mode == "http":
             print_error("--mcp-mode http is only for native Windows Codex Desktop.")
             return False
         rendered_section = _render_codex_mcp_section()
-
     if rendered_section is None:
         print_error(
             "Could not find a launchable Ouroboros MCP command. Install uv, or install "

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -436,6 +436,14 @@ _CODEX_MCP_SECTION_TEMPLATE = """# Ouroboros MCP hookup for Codex CLI.
 OUROBOROS_AGENT_RUNTIME = "codex"
 OUROBOROS_LLM_BACKEND = "codex"
 """
+_CODEX_HTTP_MCP_SECTION = """# Ouroboros native-Windows HTTP MCP (explicit opt-in; no persistence).
+[mcp_servers.ouroboros]
+url = "http://127.0.0.1:8765/mcp"
+"""
+_CODEX_HTTP_MCP_COMMAND = (
+    "ouroboros mcp serve --runtime codex --llm-backend codex "
+    "--transport streamable-http --host 127.0.0.1 --port 8765"
+)
 
 _CODEX_MCP_COMMENT_LINES = (
     "# Ouroboros MCP hookup for Codex CLI.",
@@ -445,7 +453,7 @@ _CODEX_MCP_COMMENT_LINES = (
     "# This file is only for the Codex MCP/env registration block.",
 )
 
-CodexMcpMode = Literal["auto", "preserve", "stdio"]
+CodexMcpMode = Literal["auto", "http", "preserve", "stdio"]
 _CODEX_APP_CLI_PATH = Path("/Applications/ChatGPT.app/Contents/Resources/codex")
 _CODEX_UVX_MCP_ARGS = _build_uvx_mcp_args("ouroboros-ai[mcp]")
 _CODEX_LEGACY_UVX_MCP_ARGS: tuple[tuple[str, ...], ...] = (
@@ -543,11 +551,15 @@ _CODEX_DEFAULT_LLM_ROLE_PROFILES: dict[str, str] = {
 }
 
 
+def _is_native_windows() -> bool:
+    return os.name == "nt"
+
+
 def _normalize_codex_mcp_mode(value: str) -> CodexMcpMode:
     """Validate and normalize the Codex MCP setup mode."""
     normalized = value.lower()
-    if normalized not in {"auto", "preserve", "stdio"}:
-        print_error("Unsupported Codex MCP mode. Use one of: auto, preserve, stdio.")
+    if normalized not in {"auto", "http", "preserve", "stdio"}:
+        print_error("Unsupported Codex MCP mode. Use one of: auto, http, preserve, stdio.")
         raise typer.Exit(1)
     return normalized  # type: ignore[return-value]
 
@@ -1205,7 +1217,42 @@ def _register_codex_mcp_server(
         print_info("Preserved Codex MCP config.")
         return True
 
-    rendered_section = _render_codex_mcp_section()
+    if _is_native_windows():
+        if mode == "stdio":
+            print_error(
+                "Native-Windows Codex Desktop stdio MCP can terminate the app server. "
+                "Use --mcp-mode http and run the printed loopback server command, or use WSL 2."
+            )
+            return False
+        if mode == "auto":
+            codex_config = resolve_codex_home() / "config.toml"
+            if codex_config.exists():
+                try:
+                    parsed = tomllib.loads(codex_config.read_text(encoding="utf-8"))
+                except tomllib.TOMLDecodeError:
+                    print_error(f"Could not parse {codex_config} — Codex setup not saved.")
+                    return False
+                if _codex_mcp_entry_from_toml(parsed) is not None:
+                    print_info("Preserved existing Codex MCP config on native Windows.")
+                    return True
+            print_info(
+                "Skipped persistent MCP registration on native Windows. "
+                "Use --mcp-mode http for the explicit loopback HTTP topology."
+            )
+            return True
+        if mode == "http":
+            rendered_section = _CODEX_HTTP_MCP_SECTION
+            print_info(
+                f"Start the MCP server before opening Codex Desktop: {_CODEX_HTTP_MCP_COMMAND}"
+            )
+        else:
+            rendered_section = _render_codex_mcp_section()
+    else:
+        if mode == "http":
+            print_error("--mcp-mode http is only for native Windows Codex Desktop.")
+            return False
+        rendered_section = _render_codex_mcp_section()
+
     if rendered_section is None:
         print_error(
             "Could not find a launchable Ouroboros MCP command. Install uv, or install "
@@ -4771,7 +4818,7 @@ def setup(
         str,
         typer.Option(
             "--mcp-mode",
-            help="Codex MCP config mode: auto preserves user-managed entries, preserve skips MCP changes, stdio replaces with the managed stdio entry.",
+            help="Codex MCP config mode: auto preserves native-Windows safety and user entries; http explicitly writes the native-Windows loopback URL; preserve skips MCP changes; stdio replaces with the managed entry on supported hosts.",
         ),
     ] = "auto",
     preserve_existing_llm: Annotated[

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -1241,9 +1241,24 @@ def _register_codex_mcp_server(
             )
             return True
         if mode == "http":
+            launcher = _codex_release_mcp_launcher()
+            if launcher is None:
+                print_error("Could not find a launchable MCP [mcp] command for explicit HTTP mode.")
+                return False
+            command, launcher_args = launcher
+            http_args = [
+                *launcher_args,
+                "--transport",
+                "streamable-http",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "8765",
+            ]
             rendered_section = _CODEX_HTTP_MCP_SECTION
             print_info(
-                f"Start the MCP server before opening Codex Desktop: {_CODEX_HTTP_MCP_COMMAND}"
+                "Start the MCP server before opening Codex Desktop: "
+                + " ".join([command, *(json.dumps(arg) for arg in http_args)])
             )
         else:
             rendered_section = _render_codex_mcp_section()
@@ -1274,10 +1289,14 @@ def _register_codex_mcp_server(
 
         entry = _codex_mcp_entry_from_toml(parsed)
         has_managed_comment = _has_managed_codex_mcp_comment(raw)
-        if entry is not None and not _codex_mcp_entry_has_endpoint(entry) and mode != "stdio":
+        if (
+            entry is not None
+            and not _codex_mcp_entry_has_endpoint(entry)
+            and mode not in {"stdio", "http"}
+        ):
             print_error(
                 "Existing Codex Ouroboros MCP config has no usable command or URL; "
-                "Codex setup not saved. Use --mcp-mode stdio to replace it."
+                "Codex setup not saved. Use an explicit replacement mode."
             )
             return False
         if (

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -437,7 +437,6 @@ _CODEX_MCP_SECTION_TEMPLATE = """# Ouroboros MCP hookup for Codex CLI.
 OUROBOROS_AGENT_RUNTIME = "codex"
 OUROBOROS_LLM_BACKEND = "codex"
 """
-
 _CODEX_MCP_COMMENT_LINES = (
     "# Ouroboros MCP hookup for Codex CLI.",
     "# Keep Ouroboros runtime settings and per-role model overrides in",
@@ -545,7 +544,6 @@ _CODEX_DEFAULT_LLM_ROLE_PROFILES: dict[str, str] = {
 
 
 def _normalize_codex_mcp_mode(value: str) -> CodexMcpMode:
-    """Validate and normalize the Codex MCP setup mode."""
     normalized = value.lower()
     if normalized not in {"auto", "http", "preserve", "stdio"}:
         print_error("Unsupported Codex MCP mode. Use one of: auto, http, preserve, stdio.")
@@ -1210,9 +1208,15 @@ def _register_codex_mcp_server(
         handled, success, section = apply_windows_codex_mcp_mode(
             mode,
             codex_config=resolve_codex_home() / "config.toml",
-            launcher=_codex_release_mcp_launcher() if mode == "http" else None,
-            print_error=print_error,
+            launcher=(
+                (sys.executable, list(_CODEX_MODULE_MCP_ARGS))
+                if _is_dev_ouroboros_build()
+                else _codex_release_mcp_launcher()
+            )
+            if mode == "http"
+            else None,
             print_info=print_info,
+            print_error=print_error,
         )
         if handled and (not success or section is None):
             return success

--- a/src/ouroboros/cli/windows_codex_mcp.py
+++ b/src/ouroboros/cli/windows_codex_mcp.py
@@ -1,0 +1,114 @@
+"""Native-Windows Codex Desktop MCP topology policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import tomllib
+
+HTTP_MCP_SECTION = """# Ouroboros native-Windows HTTP MCP (explicit opt-in; no persistence).
+[mcp_servers.ouroboros]
+url = "http://127.0.0.1:8765/mcp"
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class WindowsCodexMcpDecision:
+    handled: bool
+    success: bool
+    rendered_section: str | None = None
+    message: str | None = None
+    error: str | None = None
+
+
+def is_native_windows() -> bool:
+    return os.name == "nt"
+
+
+def resolve_windows_codex_mcp_mode(
+    mode: str,
+    *,
+    codex_config: Path,
+    launcher: tuple[str, list[str]] | None,
+) -> WindowsCodexMcpDecision:
+    """Resolve native-Windows modes without installing background persistence."""
+    existing_entry = False
+    if codex_config.exists():
+        try:
+            parsed = tomllib.loads(codex_config.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError:
+            return WindowsCodexMcpDecision(
+                handled=True,
+                success=False,
+                error=f"Could not parse {codex_config} — Codex setup not saved.",
+            )
+        servers = parsed.get("mcp_servers")
+        existing_entry = isinstance(servers, dict) and isinstance(servers.get("ouroboros"), dict)
+    if mode == "stdio":
+        return WindowsCodexMcpDecision(
+            handled=True,
+            success=False,
+            error=(
+                "Native-Windows Codex Desktop stdio MCP can terminate the app server. "
+                "Use --mcp-mode http and run the printed loopback server command, or use WSL 2."
+            ),
+        )
+    if mode == "auto":
+        return WindowsCodexMcpDecision(
+            handled=True,
+            success=True,
+            message=(
+                "Preserved existing Codex MCP config on native Windows."
+                if existing_entry
+                else "Skipped persistent MCP registration on native Windows. "
+                "Use --mcp-mode http for the explicit loopback HTTP topology."
+            ),
+        )
+    if mode != "http":
+        return WindowsCodexMcpDecision(handled=False, success=False)
+    if launcher is None:
+        return WindowsCodexMcpDecision(
+            handled=True,
+            success=False,
+            error="Could not find a launchable MCP [mcp] command for explicit HTTP mode.",
+        )
+    command, launcher_args = launcher
+    http_args = [
+        *launcher_args,
+        "--transport",
+        "streamable-http",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "8765",
+    ]
+    rendered = " ".join([command, *(json.dumps(arg) for arg in http_args)])
+    return WindowsCodexMcpDecision(
+        handled=True,
+        success=True,
+        rendered_section=HTTP_MCP_SECTION,
+        message=f"Start the MCP server before opening Codex Desktop: {rendered}",
+    )
+
+
+def apply_windows_codex_mcp_mode(
+    mode: str,
+    *,
+    codex_config: Path,
+    launcher: tuple[str, list[str]] | None,
+    print_error: object,
+    print_info: object,
+) -> tuple[bool, bool, str | None]:
+    """Resolve the mode, report its message, and return integration state."""
+    decision = resolve_windows_codex_mcp_mode(
+        mode,
+        codex_config=codex_config,
+        launcher=launcher,
+    )
+    if decision.error:
+        print_error(decision.error)  # type: ignore[operator]
+    if decision.message:
+        print_info(decision.message)  # type: ignore[operator]
+    return decision.handled, decision.success, decision.rendered_section

--- a/src/ouroboros/cli/windows_codex_mcp.py
+++ b/src/ouroboros/cli/windows_codex_mcp.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import json
 import os
 from pathlib import Path
+import subprocess
 import tomllib
+
+from rich.markup import escape
 
 HTTP_MCP_SECTION = """# Ouroboros native-Windows HTTP MCP (explicit opt-in; no persistence).
 [mcp_servers.ouroboros]
@@ -25,6 +27,20 @@ class WindowsCodexMcpDecision:
 
 def is_native_windows() -> bool:
     return os.name == "nt"
+
+
+def _launcher_is_usable(launcher: tuple[str, list[str]]) -> bool:
+    command, args = launcher
+    try:
+        result = subprocess.run(
+            [command, *args, "--help"],
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
 
 
 def resolve_windows_codex_mcp_mode(
@@ -74,6 +90,12 @@ def resolve_windows_codex_mcp_mode(
             success=False,
             error="Could not find a launchable MCP [mcp] command for explicit HTTP mode.",
         )
+    if not _launcher_is_usable(launcher):
+        return WindowsCodexMcpDecision(
+            handled=True,
+            success=False,
+            error="The selected MCP launcher failed its `mcp serve --help` activation probe.",
+        )
     command, launcher_args = launcher
     http_args = [
         *launcher_args,
@@ -84,7 +106,7 @@ def resolve_windows_codex_mcp_mode(
         "--port",
         "8765",
     ]
-    rendered = " ".join([command, *(json.dumps(arg) for arg in http_args)])
+    rendered = subprocess.list2cmdline([command, *http_args])
     return WindowsCodexMcpDecision(
         handled=True,
         success=True,
@@ -110,5 +132,5 @@ def apply_windows_codex_mcp_mode(
     if decision.error:
         print_error(decision.error)  # type: ignore[operator]
     if decision.message:
-        print_info(decision.message)  # type: ignore[operator]
+        print_info(escape(decision.message))  # type: ignore[operator]
     return decision.handled, decision.success, decision.rendered_section

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -4473,6 +4473,32 @@ class TestCodexSetup:
 class TestClaudeSetup:
     """Tests for Claude-specific setup behavior."""
 
+    def test_native_windows_auto_skips_persistent_mcp_registration(self, tmp_path: Path) -> None:
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup._is_native_windows", return_value=True),
+        ):
+            assert setup_cmd._register_codex_mcp_server(mode="auto") is True
+
+        assert not (tmp_path / ".codex" / "config.toml").exists()
+
+    def test_native_windows_stdio_fails_closed(self, tmp_path: Path) -> None:
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup._is_native_windows", return_value=True),
+        ):
+            assert setup_cmd._register_codex_mcp_server(mode="stdio") is False
+
+    def test_native_windows_http_mode_writes_explicit_loopback_url(self, tmp_path: Path) -> None:
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup._is_native_windows", return_value=True),
+        ):
+            assert setup_cmd._register_codex_mcp_server(mode="http") is True
+
+        config = (tmp_path / ".codex" / "config.toml").read_text(encoding="utf-8")
+        assert 'url = "http://127.0.0.1:8765/mcp"' in config
+
     def test_windows_prepared_file_ignores_synthetic_posix_mode(self, tmp_path: Path) -> None:
         path = tmp_path / "credentials.yaml"
 

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -4476,7 +4476,7 @@ class TestClaudeSetup:
     def test_native_windows_auto_skips_persistent_mcp_registration(self, tmp_path: Path) -> None:
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
-            patch("ouroboros.cli.commands.setup._is_native_windows", return_value=True),
+            patch("ouroboros.cli.commands.setup.is_native_windows", return_value=True),
         ):
             assert setup_cmd._register_codex_mcp_server(mode="auto") is True
 
@@ -4485,14 +4485,14 @@ class TestClaudeSetup:
     def test_native_windows_stdio_fails_closed(self, tmp_path: Path) -> None:
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
-            patch("ouroboros.cli.commands.setup._is_native_windows", return_value=True),
+            patch("ouroboros.cli.commands.setup.is_native_windows", return_value=True),
         ):
             assert setup_cmd._register_codex_mcp_server(mode="stdio") is False
 
     def test_native_windows_http_mode_writes_explicit_loopback_url(self, tmp_path: Path) -> None:
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
-            patch("ouroboros.cli.commands.setup._is_native_windows", return_value=True),
+            patch("ouroboros.cli.commands.setup.is_native_windows", return_value=True),
         ):
             assert setup_cmd._register_codex_mcp_server(mode="http") is True
 
@@ -4502,7 +4502,7 @@ class TestClaudeSetup:
     def test_native_windows_http_fails_without_launchable_mcp(self, tmp_path: Path) -> None:
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
-            patch("ouroboros.cli.commands.setup._is_native_windows", return_value=True),
+            patch("ouroboros.cli.commands.setup.is_native_windows", return_value=True),
             patch("ouroboros.cli.commands.setup._codex_release_mcp_launcher", return_value=None),
         ):
             assert setup_cmd._register_codex_mcp_server(mode="http") is False
@@ -4515,7 +4515,7 @@ class TestClaudeSetup:
         config.write_text("[mcp_servers.ouroboros]\n", encoding="utf-8")
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
-            patch("ouroboros.cli.commands.setup._is_native_windows", return_value=True),
+            patch("ouroboros.cli.commands.setup.is_native_windows", return_value=True),
             patch(
                 "ouroboros.cli.commands.setup._codex_release_mcp_launcher",
                 return_value=("uvx", ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]),

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -4499,6 +4499,32 @@ class TestClaudeSetup:
         config = (tmp_path / ".codex" / "config.toml").read_text(encoding="utf-8")
         assert 'url = "http://127.0.0.1:8765/mcp"' in config
 
+    def test_native_windows_http_fails_without_launchable_mcp(self, tmp_path: Path) -> None:
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup._is_native_windows", return_value=True),
+            patch("ouroboros.cli.commands.setup._codex_release_mcp_launcher", return_value=None),
+        ):
+            assert setup_cmd._register_codex_mcp_server(mode="http") is False
+
+        assert not (tmp_path / ".codex" / "config.toml").exists()
+
+    def test_native_windows_http_repairs_endpointless_entry(self, tmp_path: Path) -> None:
+        config = tmp_path / ".codex" / "config.toml"
+        config.parent.mkdir(parents=True)
+        config.write_text("[mcp_servers.ouroboros]\n", encoding="utf-8")
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup._is_native_windows", return_value=True),
+            patch(
+                "ouroboros.cli.commands.setup._codex_release_mcp_launcher",
+                return_value=("uvx", ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]),
+            ),
+        ):
+            assert setup_cmd._register_codex_mcp_server(mode="http") is True
+
+        assert 'url = "http://127.0.0.1:8765/mcp"' in config.read_text(encoding="utf-8")
+
     def test_windows_prepared_file_ignores_synthetic_posix_mode(self, tmp_path: Path) -> None:
         path = tmp_path / "credentials.yaml"
 

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -4504,6 +4504,7 @@ class TestClaudeSetup:
             patch("pathlib.Path.home", return_value=tmp_path),
             patch("ouroboros.cli.commands.setup.is_native_windows", return_value=True),
             patch("ouroboros.cli.commands.setup._codex_release_mcp_launcher", return_value=None),
+            patch("ouroboros.cli.commands.setup._is_dev_ouroboros_build", return_value=False),
         ):
             assert setup_cmd._register_codex_mcp_server(mode="http") is False
 
@@ -4520,6 +4521,7 @@ class TestClaudeSetup:
                 "ouroboros.cli.commands.setup._codex_release_mcp_launcher",
                 return_value=("uvx", ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]),
             ),
+            patch("ouroboros.cli.windows_codex_mcp._launcher_is_usable", return_value=True),
         ):
             assert setup_cmd._register_codex_mcp_server(mode="http") is True
 

--- a/tests/unit/cli/test_windows_codex_mcp.py
+++ b/tests/unit/cli/test_windows_codex_mcp.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from ouroboros.cli.windows_codex_mcp import (
+    apply_windows_codex_mcp_mode,
+    resolve_windows_codex_mcp_mode,
+)
+
+
+def test_http_mode_rejects_launcher_that_cannot_start_mcp(tmp_path: Path) -> None:
+    with patch("ouroboros.cli.windows_codex_mcp._launcher_is_usable", return_value=False):
+        decision = resolve_windows_codex_mcp_mode(
+            "http",
+            codex_config=tmp_path / "config.toml",
+            launcher=("uvx", ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]),
+        )
+
+    assert decision.success is False
+    assert decision.rendered_section is None
+
+
+def test_http_mode_renders_spaced_executable_and_preserves_mcp_extra(tmp_path: Path) -> None:
+    info = MagicMock()
+    with patch("ouroboros.cli.windows_codex_mcp._launcher_is_usable", return_value=True):
+        handled, success, section = apply_windows_codex_mcp_mode(
+            "http",
+            codex_config=tmp_path / "config.toml",
+            launcher=(
+                r"C:\Program Files\uv\uvx.exe",
+                ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"],
+            ),
+            print_error=MagicMock(),
+            print_info=info,
+        )
+
+    assert handled is True
+    assert success is True
+    assert section is not None
+    rendered = info.call_args.args[0]
+    assert rendered.startswith(
+        'Start the MCP server before opening Codex Desktop: "C:\\Program Files'
+    )
+    assert "ouroboros-ai\\[mcp]" in rendered


### PR DESCRIPTION
## Problem

Native Codex Desktop can terminate its own app-server when it owns an Ouroboros stdio MCP child (#2024). Prior proposals tried to solve this with persistent HKCU or Task Scheduler lifecycle machinery, but that Y adds restart, ownership, rollback, uninstall, and shared-machine contracts beyond the actual X: setup must not create the crash-triggering topology.

## Decision

- Native-Windows `auto` preserves an existing MCP entry and otherwise creates no persistent/stdio registration.
- Native-Windows `stdio` fails closed with HTTP/WSL guidance.
- Explicit `--mcp-mode http` writes `http://127.0.0.1:8765/mcp` and prints the exact loopback server command; process lifetime remains operator-owned and visible.
- Non-Windows behavior and user-managed entries remain unchanged.

## Verification

- Native Windows mode regressions — 3 passed
- Codex MCP registration suite with MCP extra — 29 passed
- Ruff, format, diff check, and diagnostics pass

Closes #2024
Supersedes #2056 and #2026