### PR TITLE
fix(execution): keep one runtime per run by default

### DIFF
--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -733,8 +733,8 @@ def get_cross_harness_redispatch_enabled() -> bool:
     Priority:
         1. OUROBOROS_CROSS_HARNESS_REDISPATCH environment variable
         2. config.yaml execution.cross_harness_redispatch
-        3. True (default: meta-harness recovery is on, but a no-op unless a
-           second runtime backend is actually installed)
+        3. False (default: one run retains one explicitly selected runtime;
+           cross-harness workspace mutation requires explicit opt-in)
     """
     env = _env_flag("OUROBOROS_CROSS_HARNESS_REDISPATCH")
     if env is not None:
@@ -742,7 +742,7 @@ def get_cross_harness_redispatch_enabled() -> bool:
     try:
         return load_config().execution.cross_harness_redispatch
     except ConfigError:
-        return True
+        return False
 
 
 def get_n_version_tournament_enabled() -> bool:

--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -728,21 +728,15 @@ def _env_flag(name: str) -> bool | None:
 
 
 def get_cross_harness_redispatch_enabled() -> bool:
-    """Whether a terminally failing AC may redispatch onto an alternative harness.
+    """Return explicit process-level opt-in for cross-harness mutation.
 
-    Priority:
-        1. OUROBOROS_CROSS_HARNESS_REDISPATCH environment variable
-        2. config.yaml execution.cross_harness_redispatch
-        3. False (default: one run retains one explicitly selected runtime;
-           cross-harness workspace mutation requires explicit opt-in)
+    Historical releases materialized ``true`` into generated config files, so
+    a persisted scalar cannot distinguish operator consent from the old default.
+    Only the environment flag is therefore authoritative during the deprecation
+    window; absent explicit process consent, one run keeps one runtime.
     """
     env = _env_flag("OUROBOROS_CROSS_HARNESS_REDISPATCH")
-    if env is not None:
-        return env
-    try:
-        return load_config().execution.cross_harness_redispatch
-    except ConfigError:
-        return False
+    return env if env is not None else False
 
 
 def get_n_version_tournament_enabled() -> bool:

--- a/src/ouroboros/config/models.py
+++ b/src/ouroboros/config/models.py
@@ -276,7 +276,7 @@ class ExecutionConfig(BaseModel, frozen=True):
     run_verify_commands: bool = True
     verify_command_timeout_seconds: int = Field(default=600, ge=1)
     ac_retry_attempts: int = Field(default=2, ge=0)
-    cross_harness_redispatch: bool = True
+    cross_harness_redispatch: bool = False
     n_version_tournament: bool = False
     decomposition_mode: Literal["bounce_only", "off"] = "bounce_only"
     context_pack: bool = True

--- a/src/ouroboros/config/untrusted_env.py
+++ b/src/ouroboros/config/untrusted_env.py
@@ -192,6 +192,9 @@ UNTRUSTED_ENV_DENYLIST = frozenset(
         # orchestrator backend profile and therefore which backend behavior /
         # executable is used — same routing class as the selectors above.
         "OUROBOROS_RUNTIME_PROFILE",
+        # Shared-workspace provider switching is execution authority, not a
+        # repository preference. Only the real process/trusted home may opt in.
+        "OUROBOROS_CROSS_HARNESS_REDISPATCH",
         # Permission-mode overrides — must not silently disable the
         # user's approval gate from an untrusted repo.
         "OUROBOROS_AGENT_PERMISSION_MODE",

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -32,6 +32,7 @@ from ouroboros.config.loader import (
     get_consensus_advocate_model,
     get_consensus_models,
     get_context_compression_model,
+    get_cross_harness_redispatch_enabled,
     get_dependency_analysis_model,
     get_gemini_cli_path,
     get_gjc_cli_path,
@@ -2466,6 +2467,15 @@ class TestGetAgentReasoningEffort:
 
         with pytest.raises(pydantic.ValidationError):
             OrchestratorConfig(reasoning_effort="minimal")
+
+
+def test_cross_harness_ignores_legacy_generated_true_config() -> None:
+    config = OuroborosConfig(execution=ExecutionConfig(cross_harness_redispatch=True))
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("ouroboros.config.loader.load_config", return_value=config),
+    ):
+        assert get_cross_harness_redispatch_enabled() is False
 
 
 class TestGetExecutionModel:

--- a/tests/unit/config/test_loader_env.py
+++ b/tests/unit/config/test_loader_env.py
@@ -150,6 +150,7 @@ def test_denylist_covers_known_execution_routing_keys() -> None:
         "OUROBOROS_AGENT_RUNTIME",
         "OUROBOROS_LLM_BACKEND",
         "OUROBOROS_RUNTIME_PROFILE",
+        "OUROBOROS_CROSS_HARNESS_REDISPATCH",
         "OUROBOROS_AGENT_PERMISSION_MODE",
         "OUROBOROS_TOOL_CAPABILITIES",
         # Execution-cost/behavior dial — must not be forced from an untrusted repo.

--- a/tests/unit/config/test_models.py
+++ b/tests/unit/config/test_models.py
@@ -337,6 +337,7 @@ class TestExecutionConfig:
         assert config.auto_evolve_max_generations == 3
         assert config.default_model is None
         assert config.decomposition_mode == "bounce_only"
+        assert config.cross_harness_redispatch is False
         assert config.context_pack is True
 
     @pytest.mark.parametrize(("raw", "expected"), [(0, 1), (11, 10), (4, 4)])


### PR DESCRIPTION
## Problem

The real failure in #2202 is implicit execution authority: an optional recovery path can silently switch providers/transports, mutate the shared workspace, and replace the selected runtime result. Making that implicit switch safer would require a second runtime identity, policy, resume, and mutation-authority system.

## Decision

- Default `execution.cross_harness_redispatch` to `false`.
- Preserve explicit environment/config opt-in for operators who accept the existing same-workspace authority semantics.
- Keep same-runtime retries and model/effort escalation unchanged.

## Verification

- Config model/loader focused tests pass
- Ruff and format pass

Refs #2202