### PR TITLE
fix(lateral): avoid false no-parallel host claims

### DIFF
--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -1750,7 +1750,8 @@ class LateralThinkHandler(BridgeAwareMixin):
             #     from inline payloads via its own primitive (e.g. Codex). Emit
             #     the inline result stamped with ``host_action=spawn_subagents``.
             #   - SEQUENTIAL: no parallel surface at all → plain inline fallback.
-            dispatch = resolve_subagent_dispatch(self.agent_runtime_backend, self.opencode_mode)
+            dispatch_backend = self.agent_runtime_backend or "claude_code"
+            dispatch = resolve_subagent_dispatch(dispatch_backend, self.opencode_mode)
             if dispatch is SubagentDispatchMode.PLUGIN_PASSIVE:
                 # Preserve public response shape (#442): ouroboros_lateral_think
                 # natural response documents alternative-thinking metadata.
@@ -1818,11 +1819,8 @@ class LateralThinkHandler(BridgeAwareMixin):
             host_driven = dispatch is SubagentDispatchMode.HOST_DRIVEN
             payload_dicts = [p.to_dict() for p in payloads]
             panel_metadata = lateral_persona_panel_metadata_from_capability_definitions()
-            contract_backend = self.agent_runtime_backend
-            if not contract_backend:
-                contract_backend = "codex" if host_driven else "gemini"
             contract = build_runtime_subagent_orchestration_contract(
-                contract_backend,
+                dispatch_backend,
                 directive_metadata=panel_metadata,
                 opencode_mode=self.opencode_mode,
             )

--- a/tests/unit/mcp/tools/test_lateral_think_handler.py
+++ b/tests/unit/mcp/tools/test_lateral_think_handler.py
@@ -665,6 +665,25 @@ async def test_sequential_lateral_synthesis_precedes_interview_continuation() ->
 
 
 @pytest.mark.asyncio
+async def test_unknown_host_defaults_to_capability_neutral_host_driven_dispatch() -> None:
+    handler = LateralThinkHandler(agent_runtime_backend=None, opencode_mode=None)
+
+    result = await handler.handle(
+        {
+            "problem_context": "stuck on X",
+            "current_approach": "tried Y",
+            "persona": "all",
+        }
+    )
+
+    assert result.is_ok
+    payload = result.unwrap()
+    assert payload.meta["dispatch_mode"] == "host_driven"
+    assert payload.meta["host_action"] == "spawn_subagents"
+    assert "no native parallel subagent primitive" not in payload.text_content
+
+
+@pytest.mark.asyncio
 async def test_multi_persona_subprocess_mode_falls_back_inline() -> None:
     """Subprocess mode → no envelope, inline concatenated prompt text."""
     handler = LateralThinkHandler(


### PR DESCRIPTION
## Problem

The server inferred host subagent capability from its configured worker runtime and emitted a false “this runtime has no native parallel primitive” instruction. The MCP server does not receive a reliable client capability handshake, so that diagnosis was not authoritative.

## Decision

- An unspecified host emits the capability-neutral host-driven contract (`spawn_subagents`).
- The host uses its native primitive when available and the already documented sequential fallback otherwise.
- Explicitly known sequential runtimes remain sequential.

## Verification

- `tests/unit/mcp/tools/test_lateral_think_handler.py` — 24 passed
- Ruff and format pass

Closes #2189