### PR TITLE
fix(mcp): negotiate host subagent dispatch capability

### DIFF
--- a/.claude-plugin/skills/interview/SKILL.md
+++ b/.claude-plugin/skills/interview/SKILL.md
@@ -180,13 +180,14 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    parent-session assist layer. The advisory exists to help the human answer;
    it must not hide, replace, or delay the question itself.
 
-   Run the advisory lanes through your runtime's native subagent mechanism when
-   one exists. For Claude Code this is the Task/Agent tool; for Codex, explicitly
-   start a native subagent workflow in natural language. Spawn one subagent per
-   lane, pass that lane's payload prompt, wait for all agents, then synthesize.
-   If the runtime has no parallel primitive, process payloads sequentially per
-   `dispatch_mode="sequential"` and the request's `sequential_fallback`
-   semantics. The standard lanes are:
+   Read the stamped dispatch contract before running the lanes. With
+   `dispatch_mode="host_driven"`, use the declared native parallel mechanism.
+   With `dispatch_mode="host_decides"`, use native parallel fan-out when the
+   current host exposes it and otherwise process the same payloads sequentially.
+   With `dispatch_mode="sequential"`, process payloads in order. For Claude Code
+   the parallel mechanism is Task/Agent; for Codex, explicitly start one native
+   subagent per payload in a single fan-out turn. Wait for every result, then
+   synthesize. The standard lanes are:
    - `code_context` — inspect repo-local facts and reuse
      `meta.code_investigation_request` when present.
    - `web_context` — browse/search only when current external facts genuinely
@@ -204,21 +205,16 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    options, one recommended draft, or a short "I found these ambiguities" note.
    Do not forward advisory output to `ouroboros_interview` until the user
    approves, edits, or explicitly asks you to auto-confirm a safe answer.
-   When `meta.question_advisory_subagents` is present you MUST fan out: treat
-   each entry as a spawn-ready advisory payload with `title`, `agent`, `prompt`,
-   and `context`, and dispatch every payload through your host's native subagent
-   mechanism (Claude Code → one Task/Agent call per payload in one parallel
-   batch; Codex → explicitly spawn one Codex subagent per payload, wait for all
-   results, then synthesize; runtimes without a parallel primitive → process
-   payloads sequentially per `dispatch_mode="sequential"`) instead of
-   reconstructing prompts from prose. This
-   is required regardless of dispatch mode: the payloads themselves are the
-   spawn signal.
-   Treat `meta.question_advisory_host_action=spawn_subagents`, when present, as
-   a reinforcing cue for host-driven runtimes such as Codex or Claude Code, not
-   as a prerequisite. The only time you skip spawning is when the host has no
-   subagent primitive at all (then use `sequential_fallback`).
-   Preserve the original question text while advisory children run.
+   When `meta.question_advisory_subagents` is present you MUST process every
+   payload: treat each entry as spawn-ready advisory work with `title`, `agent`,
+   `prompt`, and `context`, and pass its prompt unchanged. Obey
+   `meta.question_advisory_host_action`: `spawn_subagents` means parallel support
+   was declared; `dispatch_subagents_if_supported` means use native parallel
+   dispatch when available and sequential fallback otherwise;
+   `process_payloads_sequentially` means ordered processing is required. This is
+   required regardless of mode—the payloads themselves are the work contract,
+   while the host action selects the execution strategy. Never reconstruct
+   prompts from prose. Preserve the original question text while children run.
 
    **Submitting fan-out results back (re-entry)**:
    When the originating `meta` carries a `fanout_id` (e.g.

--- a/.claude-plugin/skills/pm/SKILL.md
+++ b/.claude-plugin/skills/pm/SKILL.md
@@ -114,18 +114,15 @@ bounded by the roster, and not checked against the answer contract. This skill
 is self-contained: everything you need is here and in the tool response, so do
 not go looking for exploration rules in another skill's file.
 
-**When `meta.question_advisory_subagents` is present you MUST fan out.** Show
-the question text to the user first, then treat each entry as a spawn-ready
-payload with `title`, `agent`, `prompt`, and `context`, and dispatch every
-payload through your host's native subagent mechanism — Claude Code → **one
-Task/Agent call per payload in one parallel batch**; Codex → one native Codex
-subagent per payload; a runtime with no parallel primitive → process them
-sequentially. Pass each payload's `prompt` unchanged rather than rewriting it.
-
-This holds regardless of dispatch mode: **the payloads themselves are the spawn
-signal.** `meta.question_advisory_host_action=spawn_subagents` is a reinforcing
-cue, not a prerequisite. The only time you skip spawning is when the host has no
-subagent primitive at all.
+**When `meta.question_advisory_subagents` is present you MUST process every
+payload.** Show the question first, then pass each payload's `prompt` unchanged.
+Obey `meta.question_advisory_host_action`: `spawn_subagents` means parallel
+support was declared; `dispatch_subagents_if_supported` means use the host's
+native parallel mechanism when available and process the same payloads
+sequentially otherwise; `process_payloads_sequentially` requires ordered
+processing. Claude Code parallel dispatch is one Task/Agent call per payload in
+one batch; Codex uses one native Codex subagent per payload. The payloads are
+the work contract, while the host action selects the execution strategy.
 
 **Say what is running.** Same shape the regular interview uses: after the
 question, set off by a divider, one line naming how many perspectives are running

--- a/.claude-plugin/skills/unstuck/SKILL.md
+++ b/.claude-plugin/skills/unstuck/SKILL.md
@@ -107,13 +107,17 @@ Two pieces matter:
 - **Hidden HTML comment** — markdown viewers render nothing for `<!-- ... -->`, so the block doesn't pollute the human-visible output.
 - **Base64 body** — base64's alphabet is `[A-Za-z0-9+/=]`, which can never produce the sequence `-->`. So even if a user-supplied `problem_context` or `current_approach` contains `-->` (HTML/JS debugging is the obvious case), the encoded body cannot prematurely close the wrapper and leak the dispatch into the visible markdown.
 
-Decoded, the body is JSON:
+Decoded, the body is JSON. An MCP host that did not declare subagent capability
+receives the neutral shape:
 
 ```json
-{"dispatch_mode": "sequential", "legacy_dispatch_mode": "inline_fallback", "persona_count": N, "payloads": [...]}
+{"dispatch_mode": "host_decides", "host_action": "dispatch_subagents_if_supported", "execution_preference": "parallel", "fallback_strategy": "sequential", "persona_count": N, "payloads": [...]}
 ```
 
-To recover: locate the substring between `<!-- ouroboros-lateral-inline-dispatch-v1 base64\n` and `\n-->` at the end of `content`, base64-decode it, then `JSON.parse`. (See `tests/unit/mcp/tools/test_lateral_think_handler.py::_extract_inline_dispatch` for the canonical extraction helper.)
+An explicitly sequential execution authority receives `dispatch_mode="sequential"`
+with `legacy_dispatch_mode="inline_fallback"` for compatibility. To recover:
+locate the substring between `<!-- ouroboros-lateral-inline-dispatch-v1 base64\n`
+and `\n-->` at the end of `content`, base64-decode it, then `JSON.parse`.
 
 #### Shape A — `dispatch_mode = "plugin"` (OpenCode plugin mode only)
 
@@ -134,7 +138,7 @@ If you expected plugin mode but the response is inline text (neither `_subagent`
 The handler ran the prompt builder internally and returned ready-to-use markdown:
 
 - Solo response: a single `# Lateral Thinking: <approach>` block followed by the reframing prompt.
-- Debate response (`dispatch_mode = "sequential"`; `legacy_dispatch_mode = "inline_fallback"` may also be present): N such blocks concatenated with `\n\n---\n\n` separators.
+- Debate response: N such blocks concatenated with `\n\n---\n\n` separators. The dispatch block distinguishes declared `host_driven`, capability-neutral `host_decides`, and explicit `sequential` execution.
 
 ##### Solo (any runtime)
 
@@ -150,22 +154,23 @@ Driving fan-out from this dispatch block — instead of from the joined human-di
 - **Separator collision** — `\n\n---\n\n` can legitimately appear inside a user-supplied `problem_context` or `current_approach`, so splitting the joined text would over-fragment and corrupt prompts. The dispatch block uses a unique versioned sentinel that user content cannot collide with.
 - **Behavioral drift across runtimes** — the dispatch block carries the same canonical payloads `_subagents` carries, so debate results don't diverge by environment.
 
-1. Locate the dispatch block at the end of the MCP response's `content` text — the substring between `<!-- ouroboros-lateral-inline-dispatch-v1 base64\n` and `\n-->`. Base64-decode the captured body, then `JSON.parse` to get `{dispatch_mode, persona_count, payloads}`. If the block is missing (older handler that pre-dates the v1 sentinel), fall through to the constrained-runtime path below — *do not* split the joined text.
+1. Locate the dispatch block at the end of the MCP response's `content` text. Base64-decode the captured body, then `JSON.parse` to get `{dispatch_mode, host_action, persona_count, payloads}`. If the block is missing, fall through to the constrained-runtime path below — *do not* split the joined text.
 2. Surface a short "what the lateral toolkit suggests" header to the user, with the markdown above the dispatch block, so the MCP call is visible as a real product surface, not silent.
-3. Spawn N persona subagents in parallel — one per entry in `payloads` — using your host's native subagent mechanism. Each child receives the payload's `prompt` verbatim plus the payload's `context` so the persona is grounded, with strict isolation per child. The user sees "Running N agents…".
-   - **Claude Code** → emit N `Task` calls (`general-purpose` subagent) in a **single message** so they run concurrently.
-   - **Codex** → Codex subagents are triggered by explicit natural-language delegation, not a callable tool name (do NOT call `multi_agent_v1.spawn_agent` — it does not exist). In one turn, explicitly spawn one Codex subagent per payload, hand each child its payload `prompt` + `context`, wait for all children, then continue.
+3. If `host_action="dispatch_subagents_if_supported"`, use the host's native parallel mechanism when available and otherwise process the same payloads sequentially. If `host_action="spawn_subagents"`, spawn N persona subagents in parallel. Each child receives the payload's `prompt` verbatim plus its `context`, with strict isolation per child.
+   - **Claude Code** → emit N `Task` calls (`general-purpose` subagent) in a **single message** so they run concurrently when the Task surface is available.
+   - **Codex** → explicitly delegate one Codex subagent per payload in one turn; do not call a nonexistent `multi_agent_v1.spawn_agent` tool.
 4. Wait for all N to return.
 5. (Optional) **Round 2 cross-attack** — only if Round 1 answers diverge meaningfully. Dispatch a second N-fan-out where each persona receives short summaries of the other answers and is asked: "Identify one weakness in each. ≤200 words." Skip if Round 1 already converges.
 6. Synthesize per the **Synthesize** block below.
 
 ##### Debate, constrained runtime without sub-agent dispatch
 
-If the response is stamped with `dispatch_mode="sequential"` and the host has no
-native parallel primitive, process each payload in order. Correlate every result
-by `result_correlation_key` (normally `context.persona`), then synthesize after
-the last payload. Treat `legacy_dispatch_mode="inline_fallback"` as compatibility
-metadata only; do not use it to override the canonical sequential contract.
+If the response is stamped with `dispatch_mode="sequential"`, or with
+`dispatch_mode="host_decides"` and the host has no native parallel primitive,
+process each payload in order. Correlate every result by
+`result_correlation_key` (normally `context.persona`), then synthesize after the
+last payload. Treat `legacy_dispatch_mode="inline_fallback"` as compatibility
+metadata only.
 
 ##### Debate, runtime cannot dispatch sub-agents (constrained subprocess, no Task surface)
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -94,6 +94,7 @@ together, always.
 | `command_run` (source=cli) | A direct `ooo <subcommand>` invocation in a terminal | command, source, is_funnel, app_version, os, python_version, frontdoor, ci — no tool, phase, duration/outcome fields, or backend context: those are mcp-only |
 | `workflow_outcome` | Two producers (never both for the same evaluation — see Notes): a background MCP job reaches a durable terminal event, **or** a direct (non-job) `ouroboros_evaluate` / `ouroboros_checklist_verify` completion | command, phase (`terminal`), terminal_status, ok, verified, final_approved, failure_reason_code (failed/cancelled/interrupted outcomes only), recovery_action (failed/cancelled/interrupted outcomes only), `$insert_id` (job-derived variant only — one-way event deduplication digest), runtime_backend, execute_runtime_backend, interview_llm_backend, evaluate_llm_backend, app_version, os, python_version, frontdoor, ci |
 | `mcp_serve_started` | A host CLI attaches the Ouroboros MCP server for a session | transport, tool_count, frontdoor, first_command_surface, app_version, os, ci — no python_version, no backend/provider context |
+| `subagent_dispatch` | A structured fan-out contract is emitted (`phase=emitted`) or correlated child results return through `ouroboros_submit_fanout_results` (`phase=submitted`) | phase, fanout_kind, payload_count, invocation_surface, dispatch_authority, host_family, host_identity_status, host_capability, capability_source, delivery_mode, execution_preference, fallback_strategy, configured_worker_backend, host_worker_mismatch, decision_reason, contract_version, fanout_reentry_available, submission_status, expected_count, received_count, undispatched_count, frontdoor, first_command_surface, app_version, os, python_version, ci |
 
 Notes:
 
@@ -147,6 +148,14 @@ Notes:
   Current recovery actions are `retry`, `setup`, `login`, `update`,
   `inspect_logs`, and `none`. An unclassified failure is always `unknown` with
   `inspect_logs`, so the failure denominator remains measurable.
+- `subagent_dispatch` uses closed enums only. Raw MCP `clientInfo.name`, client
+  versions, custom backend names, `fanout_id`, session ids, correlation values,
+  prompts, problem context, child outputs, repository paths, and file paths are
+  never sent. Recognized client identities are folded to `claude_code`, `codex`,
+  or `opencode`; every other non-empty identity becomes `other_known`, and an
+  absent identity becomes `unknown`. Custom worker backends become `other`.
+  Counts are bounded to 0–64. The submitted event reports only aggregate lane
+  counts and never infers whether execution was parallel from elapsed time.
 - Start-tool `command_run` events are submission receipts. They intentionally
   have `accepted`, not `ok`; queue acceptance is never a completed or verified
   run. `workflow_outcome` is the durable/direct terminal boundary described

--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -180,13 +180,14 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    parent-session assist layer. The advisory exists to help the human answer;
    it must not hide, replace, or delay the question itself.
 
-   Run the advisory lanes through your runtime's native subagent mechanism when
-   one exists. For Claude Code this is the Task/Agent tool; for Codex, explicitly
-   start a native subagent workflow in natural language. Spawn one subagent per
-   lane, pass that lane's payload prompt, wait for all agents, then synthesize.
-   If the runtime has no parallel primitive, process payloads sequentially per
-   `dispatch_mode="sequential"` and the request's `sequential_fallback`
-   semantics. The standard lanes are:
+   Read the stamped dispatch contract before running the lanes. With
+   `dispatch_mode="host_driven"`, use the declared native parallel mechanism.
+   With `dispatch_mode="host_decides"`, use native parallel fan-out when the
+   current host exposes it and otherwise process the same payloads sequentially.
+   With `dispatch_mode="sequential"`, process payloads in order. For Claude Code
+   the parallel mechanism is Task/Agent; for Codex, explicitly start one native
+   subagent per payload in a single fan-out turn. Wait for every result, then
+   synthesize. The standard lanes are:
    - `code_context` — inspect repo-local facts and reuse
      `meta.code_investigation_request` when present.
    - `web_context` — browse/search only when current external facts genuinely
@@ -204,21 +205,16 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    options, one recommended draft, or a short "I found these ambiguities" note.
    Do not forward advisory output to `ouroboros_interview` until the user
    approves, edits, or explicitly asks you to auto-confirm a safe answer.
-   When `meta.question_advisory_subagents` is present you MUST fan out: treat
-   each entry as a spawn-ready advisory payload with `title`, `agent`, `prompt`,
-   and `context`, and dispatch every payload through your host's native subagent
-   mechanism (Claude Code → one Task/Agent call per payload in one parallel
-   batch; Codex → explicitly spawn one Codex subagent per payload, wait for all
-   results, then synthesize; runtimes without a parallel primitive → process
-   payloads sequentially per `dispatch_mode="sequential"`) instead of
-   reconstructing prompts from prose. This
-   is required regardless of dispatch mode: the payloads themselves are the
-   spawn signal.
-   Treat `meta.question_advisory_host_action=spawn_subagents`, when present, as
-   a reinforcing cue for host-driven runtimes such as Codex or Claude Code, not
-   as a prerequisite. The only time you skip spawning is when the host has no
-   subagent primitive at all (then use `sequential_fallback`).
-   Preserve the original question text while advisory children run.
+   When `meta.question_advisory_subagents` is present you MUST process every
+   payload: treat each entry as spawn-ready advisory work with `title`, `agent`,
+   `prompt`, and `context`, and pass its prompt unchanged. Obey
+   `meta.question_advisory_host_action`: `spawn_subagents` means parallel support
+   was declared; `dispatch_subagents_if_supported` means use native parallel
+   dispatch when available and sequential fallback otherwise;
+   `process_payloads_sequentially` means ordered processing is required. This is
+   required regardless of mode—the payloads themselves are the work contract,
+   while the host action selects the execution strategy. Never reconstruct
+   prompts from prose. Preserve the original question text while children run.
 
    **Submitting fan-out results back (re-entry)**:
    When the originating `meta` carries a `fanout_id` (e.g.

--- a/skills/pm/SKILL.md
+++ b/skills/pm/SKILL.md
@@ -114,18 +114,15 @@ bounded by the roster, and not checked against the answer contract. This skill
 is self-contained: everything you need is here and in the tool response, so do
 not go looking for exploration rules in another skill's file.
 
-**When `meta.question_advisory_subagents` is present you MUST fan out.** Show
-the question text to the user first, then treat each entry as a spawn-ready
-payload with `title`, `agent`, `prompt`, and `context`, and dispatch every
-payload through your host's native subagent mechanism — Claude Code → **one
-Task/Agent call per payload in one parallel batch**; Codex → one native Codex
-subagent per payload; a runtime with no parallel primitive → process them
-sequentially. Pass each payload's `prompt` unchanged rather than rewriting it.
-
-This holds regardless of dispatch mode: **the payloads themselves are the spawn
-signal.** `meta.question_advisory_host_action=spawn_subagents` is a reinforcing
-cue, not a prerequisite. The only time you skip spawning is when the host has no
-subagent primitive at all.
+**When `meta.question_advisory_subagents` is present you MUST process every
+payload.** Show the question first, then pass each payload's `prompt` unchanged.
+Obey `meta.question_advisory_host_action`: `spawn_subagents` means parallel
+support was declared; `dispatch_subagents_if_supported` means use the host's
+native parallel mechanism when available and process the same payloads
+sequentially otherwise; `process_payloads_sequentially` requires ordered
+processing. Claude Code parallel dispatch is one Task/Agent call per payload in
+one batch; Codex uses one native Codex subagent per payload. The payloads are
+the work contract, while the host action selects the execution strategy.
 
 **Say what is running.** Same shape the regular interview uses: after the
 question, set off by a divider, one line naming how many perspectives are running

--- a/skills/unstuck/SKILL.md
+++ b/skills/unstuck/SKILL.md
@@ -107,13 +107,17 @@ Two pieces matter:
 - **Hidden HTML comment** — markdown viewers render nothing for `<!-- ... -->`, so the block doesn't pollute the human-visible output.
 - **Base64 body** — base64's alphabet is `[A-Za-z0-9+/=]`, which can never produce the sequence `-->`. So even if a user-supplied `problem_context` or `current_approach` contains `-->` (HTML/JS debugging is the obvious case), the encoded body cannot prematurely close the wrapper and leak the dispatch into the visible markdown.
 
-Decoded, the body is JSON:
+Decoded, the body is JSON. An MCP host that did not declare subagent capability
+receives the neutral shape:
 
 ```json
-{"dispatch_mode": "sequential", "legacy_dispatch_mode": "inline_fallback", "persona_count": N, "payloads": [...]}
+{"dispatch_mode": "host_decides", "host_action": "dispatch_subagents_if_supported", "execution_preference": "parallel", "fallback_strategy": "sequential", "persona_count": N, "payloads": [...]}
 ```
 
-To recover: locate the substring between `<!-- ouroboros-lateral-inline-dispatch-v1 base64\n` and `\n-->` at the end of `content`, base64-decode it, then `JSON.parse`. (See `tests/unit/mcp/tools/test_lateral_think_handler.py::_extract_inline_dispatch` for the canonical extraction helper.)
+An explicitly sequential execution authority receives `dispatch_mode="sequential"`
+with `legacy_dispatch_mode="inline_fallback"` for compatibility. To recover:
+locate the substring between `<!-- ouroboros-lateral-inline-dispatch-v1 base64\n`
+and `\n-->` at the end of `content`, base64-decode it, then `JSON.parse`.
 
 #### Shape A — `dispatch_mode = "plugin"` (OpenCode plugin mode only)
 
@@ -134,7 +138,7 @@ If you expected plugin mode but the response is inline text (neither `_subagent`
 The handler ran the prompt builder internally and returned ready-to-use markdown:
 
 - Solo response: a single `# Lateral Thinking: <approach>` block followed by the reframing prompt.
-- Debate response (`dispatch_mode = "sequential"`; `legacy_dispatch_mode = "inline_fallback"` may also be present): N such blocks concatenated with `\n\n---\n\n` separators.
+- Debate response: N such blocks concatenated with `\n\n---\n\n` separators. The dispatch block distinguishes declared `host_driven`, capability-neutral `host_decides`, and explicit `sequential` execution.
 
 ##### Solo (any runtime)
 
@@ -150,22 +154,23 @@ Driving fan-out from this dispatch block — instead of from the joined human-di
 - **Separator collision** — `\n\n---\n\n` can legitimately appear inside a user-supplied `problem_context` or `current_approach`, so splitting the joined text would over-fragment and corrupt prompts. The dispatch block uses a unique versioned sentinel that user content cannot collide with.
 - **Behavioral drift across runtimes** — the dispatch block carries the same canonical payloads `_subagents` carries, so debate results don't diverge by environment.
 
-1. Locate the dispatch block at the end of the MCP response's `content` text — the substring between `<!-- ouroboros-lateral-inline-dispatch-v1 base64\n` and `\n-->`. Base64-decode the captured body, then `JSON.parse` to get `{dispatch_mode, persona_count, payloads}`. If the block is missing (older handler that pre-dates the v1 sentinel), fall through to the constrained-runtime path below — *do not* split the joined text.
+1. Locate the dispatch block at the end of the MCP response's `content` text. Base64-decode the captured body, then `JSON.parse` to get `{dispatch_mode, host_action, persona_count, payloads}`. If the block is missing, fall through to the constrained-runtime path below — *do not* split the joined text.
 2. Surface a short "what the lateral toolkit suggests" header to the user, with the markdown above the dispatch block, so the MCP call is visible as a real product surface, not silent.
-3. Spawn N persona subagents in parallel — one per entry in `payloads` — using your host's native subagent mechanism. Each child receives the payload's `prompt` verbatim plus the payload's `context` so the persona is grounded, with strict isolation per child. The user sees "Running N agents…".
-   - **Claude Code** → emit N `Task` calls (`general-purpose` subagent) in a **single message** so they run concurrently.
-   - **Codex** → Codex subagents are triggered by explicit natural-language delegation, not a callable tool name (do NOT call `multi_agent_v1.spawn_agent` — it does not exist). In one turn, explicitly spawn one Codex subagent per payload, hand each child its payload `prompt` + `context`, wait for all children, then continue.
+3. If `host_action="dispatch_subagents_if_supported"`, use the host's native parallel mechanism when available and otherwise process the same payloads sequentially. If `host_action="spawn_subagents"`, spawn N persona subagents in parallel. Each child receives the payload's `prompt` verbatim plus its `context`, with strict isolation per child.
+   - **Claude Code** → emit N `Task` calls (`general-purpose` subagent) in a **single message** so they run concurrently when the Task surface is available.
+   - **Codex** → explicitly delegate one Codex subagent per payload in one turn; do not call a nonexistent `multi_agent_v1.spawn_agent` tool.
 4. Wait for all N to return.
 5. (Optional) **Round 2 cross-attack** — only if Round 1 answers diverge meaningfully. Dispatch a second N-fan-out where each persona receives short summaries of the other answers and is asked: "Identify one weakness in each. ≤200 words." Skip if Round 1 already converges.
 6. Synthesize per the **Synthesize** block below.
 
 ##### Debate, constrained runtime without sub-agent dispatch
 
-If the response is stamped with `dispatch_mode="sequential"` and the host has no
-native parallel primitive, process each payload in order. Correlate every result
-by `result_correlation_key` (normally `context.persona`), then synthesize after
-the last payload. Treat `legacy_dispatch_mode="inline_fallback"` as compatibility
-metadata only; do not use it to override the canonical sequential contract.
+If the response is stamped with `dispatch_mode="sequential"`, or with
+`dispatch_mode="host_decides"` and the host has no native parallel primitive,
+process each payload in order. Correlate every result by
+`result_correlation_key` (normally `context.persona`), then synthesize after the
+last payload. Treat `legacy_dispatch_mode="inline_fallback"` as compatibility
+metadata only.
 
 ##### Debate, runtime cannot dispatch sub-agents (constrained subprocess, no Task surface)
 

--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -64,24 +64,24 @@ class BackendCapability:
 
 
 class SubagentDispatchMode(StrEnum):
-    """How a handler should surface subagent fan-out for the active runtime.
+    """How a handler should surface subagent fan-out for the active consumer.
 
-    Three distinct layers, not a boolean:
+    Delivery ownership and execution capability are kept distinct:
 
-    - ``PLUGIN_PASSIVE``: a passive bridge receiver (the OpenCode plugin) auto-
-      intercepts the ``_subagents`` envelope and spawns children. The handler
-      returns the envelope and skips the real in-process work.
-    - ``HOST_DRIVEN``: there is no passive receiver, but the host *model* can
-      spawn subagents from inline payloads via its own native primitive (e.g.
-      Codex Desktop's multi-agent spawn). The handler returns the inline result
-      plus an explicit ``dispatch_mode=host_driven`` / ``host_action`` stamp so
-      the host deterministically fans out.
-    - ``SEQUENTIAL``: neither a passive receiver nor a native parallel primitive
-      is available; the handler runs the in-process / inline sequential path.
+    - ``PLUGIN_PASSIVE``: a passive bridge receiver auto-consumes the
+      ``_subagents`` envelope and spawns children.
+    - ``HOST_DRIVEN``: the external host explicitly declared a native parallel
+      subagent primitive, so the response requests deterministic fan-out.
+    - ``HOST_DECIDES``: an external host will consume inline payloads, but it
+      declared no authoritative subagent capability. The response prefers
+      parallel fan-out and states sequential processing as the fallback.
+    - ``SEQUENTIAL``: the selected execution authority explicitly cannot or
+      must not run parallel subagents.
     """
 
     PLUGIN_PASSIVE = "plugin_passive"
     HOST_DRIVEN = "host_driven"
+    HOST_DECIDES = "host_decides"
     SEQUENTIAL = "sequential"
 
 
@@ -91,6 +91,7 @@ class SubagentSpawnTriggerMechanism(StrEnum):
     PASSIVE_BRIDGE_ENVELOPE = "passive_bridge_envelope"
     CODEX_NATURAL_LANGUAGE_DELEGATION = "codex_natural_language_delegation"
     CLAUDE_TASK_AGENT_TOOL = "claude_task_agent_tool"
+    HOST_CAPABILITY_DECISION = "host_capability_decision"
     SEQUENTIAL_FALLBACK = "sequential_fallback"
 
 
@@ -737,16 +738,15 @@ def render_mcp_server_instructions() -> str:
         "exposed, call it directly — discovery is a no-op then, and an empty "
         "discovery result is expected, not a failure. Never surface this "
         "tool-discovery plumbing to the user.\n"
-        "\n"
-        "SUBAGENT FAN-OUT: when a tool result's `meta` carries "
-        "`host_action=spawn_subagents` (or `dispatch_mode=host_driven`) with a "
-        "payload array (e.g. `question_advisory_subagents`), spawn ONE subagent "
-        "per payload using your runtime's native primitive, give each the "
-        "payload `prompt`, await all, correlate results by the "
-        "`result_correlation_key` named in `meta`, then synthesize while "
-        "preserving the user-facing content. With no parallel primitive, process "
-        "the payloads sequentially. Keep any user-facing question visible before "
-        "the assistive work it triggers."
+        "SUBAGENT FAN-OUT: when a tool result carries a payload array, obey its "
+        "dispatch contract. `host_action=spawn_subagents` means the host declared "
+        "parallel support: spawn ONE child per payload, await all, correlate by "
+        "`result_correlation_key`, then synthesize. "
+        "`host_action=dispatch_subagents_if_supported` means host capability was "
+        "not declared: use the host's native parallel primitive when available, "
+        "otherwise process the same payloads sequentially. A passive plugin bridge "
+        "consumes `_subagents` itself. Preserve user-facing content while assistive "
+        "work runs."
     )
 
 
@@ -771,6 +771,7 @@ def build_runtime_subagent_orchestration_contract(
     *,
     directive_metadata: Mapping[str, Any],
     opencode_mode: str | None = None,
+    dispatch_mode: SubagentDispatchMode | None = None,
     callable_mcp_tool_capabilities: Sequence[Mapping[str, Any]] = (),
 ) -> RuntimeSubagentOrchestrationContract:
     """Build runtime-specific handling metadata for MCP subagent directives.
@@ -789,11 +790,11 @@ def build_runtime_subagent_orchestration_contract(
     if not isinstance(sequential_fallback, Mapping):
         sequential_fallback = {}
 
-    mode = resolve_subagent_dispatch(name, opencode_mode)
-    # The contract speaks the same vocabulary as the resolver: ``dispatch_mode``
-    # is exactly the ``SubagentDispatchMode`` value, so there is one source of
-    # truth for the mode string ({plugin_passive | host_driven | sequential}).
-    dispatch_mode = mode.value
+    mode = dispatch_mode or resolve_subagent_dispatch(name, opencode_mode)
+    # ``dispatch_mode`` normally comes from the backend resolver. Request-scoped
+    # MCP calls may override it with HOST_DECIDES when the external host did not
+    # advertise an authoritative subagent capability.
+    resolved_dispatch_mode = mode.value
 
     if mode is SubagentDispatchMode.PLUGIN_PASSIVE:
         spawn_trigger_mechanism = SubagentSpawnTriggerMechanism.PASSIVE_BRIDGE_ENVELOPE
@@ -824,16 +825,29 @@ def build_runtime_subagent_orchestration_contract(
             "Fall back to the MCP `sequential_fallback` contract only when no "
             "parallel primitive is available."
         )
+    elif mode is SubagentDispatchMode.HOST_DECIDES:
+        spawn_trigger_mechanism = SubagentSpawnTriggerMechanism.HOST_CAPABILITY_DECISION
+        requires_explicit_spawn_request = False
+        callable_spawn_tool_name = None
+        prohibited_spawn_tool_names = ()
+        runtime_instruction_handling = (
+            "The calling MCP host did not declare whether a native parallel "
+            "subagent primitive is available. Consume the inline `host_decides` "
+            "payloads without inferring capability from the configured worker: "
+            "dispatch one child per payload in parallel when the host supports it; "
+            "otherwise process the same payloads sequentially. Correlate every "
+            "result by the directive metadata's correlation key before synthesis."
+        )
     else:
         spawn_trigger_mechanism = SubagentSpawnTriggerMechanism.SEQUENTIAL_FALLBACK
         requires_explicit_spawn_request = False
         callable_spawn_tool_name = None
         prohibited_spawn_tool_names = ()
         runtime_instruction_handling = (
-            "This runtime has no native parallel subagent primitive. Follow the "
-            "MCP `sequential_fallback` contract and process each structured "
-            "subagent payload sequentially, preserving the response correlation "
-            "keys declared by the directive metadata."
+            "The selected execution authority has no native parallel subagent "
+            "primitive available. Follow the MCP `sequential_fallback` contract "
+            "and process each structured subagent payload sequentially, preserving "
+            "the response correlation keys declared by the directive metadata."
         )
 
     return RuntimeSubagentOrchestrationContract(
@@ -841,7 +855,7 @@ def build_runtime_subagent_orchestration_contract(
         # This boolean is the *passive bridge* axis only; ``HOST_DRIVEN`` runtimes
         # report False here and carry their capability via ``dispatch_mode``.
         supports_native_parallel_subagents=mode is SubagentDispatchMode.PLUGIN_PASSIVE,
-        dispatch_mode=dispatch_mode,
+        dispatch_mode=resolved_dispatch_mode,
         spawn_trigger_mechanism=spawn_trigger_mechanism.value,
         requires_explicit_spawn_request=requires_explicit_spawn_request,
         callable_spawn_tool_name=callable_spawn_tool_name,

--- a/src/ouroboros/mcp/host_context.py
+++ b/src/ouroboros/mcp/host_context.py
@@ -1,0 +1,304 @@
+"""Request-scoped MCP host identity and subagent capability facts.
+
+The configured Ouroboros worker backend is not the same thing as the MCP
+client that will consume an inline fan-out payload. This module keeps those
+facts separate and exposes only normalized, privacy-safe values to handlers
+and telemetry.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from ouroboros.backends.capabilities import (
+    SubagentDispatchMode,
+    get_backend_capability,
+    resolve_subagent_dispatch,
+)
+
+
+class HostFamily(StrEnum):
+    CLAUDE_CODE = "claude_code"
+    CODEX = "codex"
+    OPENCODE = "opencode"
+    OTHER_KNOWN = "other_known"
+    UNKNOWN = "unknown"
+
+
+class HostIdentityStatus(StrEnum):
+    KNOWN = "known"
+    UNKNOWN = "unknown"
+
+
+class HostSubagentCapability(StrEnum):
+    PARALLEL = "parallel"
+    SEQUENTIAL = "sequential"
+    UNAVAILABLE = "unavailable"
+    UNDECLARED = "undeclared"
+
+
+class HostCapabilitySource(StrEnum):
+    MCP_EXTENSION = "mcp_extension"
+    TRUSTED_SERVER_OPTION = "trusted_server_option"
+    PASSIVE_BRIDGE = "passive_bridge"
+    NONE = "none"
+
+
+class DispatchAuthority(StrEnum):
+    MCP_HOST = "mcp_host"
+    INTERNAL_RUNTIME = "internal_runtime"
+    PASSIVE_BRIDGE = "passive_bridge"
+
+
+SUBAGENT_CAPABILITY_EXTENSION = "io.ouroboros/subagents"
+_CAPABILITY_MODES = frozenset(item.value for item in HostSubagentCapability)
+
+
+@dataclass(frozen=True, slots=True)
+class MCPHostContext:
+    """Normalized facts about the current MCP consumer.
+
+    ``UNDECLARED`` is intentionally different from ``SEQUENTIAL`` and
+    ``UNAVAILABLE``. It means the server has no authoritative host capability
+    fact and must not emit either a positive or negative native-subagent claim.
+    """
+
+    host_family: HostFamily = HostFamily.UNKNOWN
+    identity_status: HostIdentityStatus = HostIdentityStatus.UNKNOWN
+    subagent_capability: HostSubagentCapability = HostSubagentCapability.UNDECLARED
+    capability_source: HostCapabilitySource = HostCapabilitySource.NONE
+    dispatch_authority: DispatchAuthority = DispatchAuthority.INTERNAL_RUNTIME
+
+    @property
+    def is_mcp_host(self) -> bool:
+        return self.dispatch_authority is DispatchAuthority.MCP_HOST
+
+    @property
+    def is_capability_known(self) -> bool:
+        return self.subagent_capability is not HostSubagentCapability.UNDECLARED
+
+    def to_telemetry(self) -> dict[str, str]:
+        return {
+            "host_family": self.host_family.value,
+            "host_identity_status": self.identity_status.value,
+            "host_capability": self.subagent_capability.value,
+            "capability_source": self.capability_source.value,
+            "dispatch_authority": self.dispatch_authority.value,
+        }
+
+
+_DEFAULT_CONTEXT = MCPHostContext()
+_current_context: ContextVar[MCPHostContext] = ContextVar(
+    "ouroboros_mcp_host_context",
+    default=_DEFAULT_CONTEXT,
+)
+
+
+def current_mcp_host_context() -> MCPHostContext:
+    """Return the current request context, or internal-runtime defaults."""
+    return _current_context.get()
+
+
+@contextmanager
+def use_mcp_host_context(context: MCPHostContext) -> Iterator[None]:
+    """Install a request context for the duration of one handler call."""
+    token: Token[MCPHostContext] = _current_context.set(context)
+    try:
+        yield
+    finally:
+        _current_context.reset(token)
+
+
+def _host_family(name: str | None) -> HostFamily:
+    normalized = (name or "").strip().lower().replace("-", "_").replace(" ", "_")
+    if normalized in {"claude", "claude_code", "claude_cli", "claude_code_cli"}:
+        return HostFamily.CLAUDE_CODE
+    if normalized in {"codex", "codex_cli", "codex_app"}:
+        return HostFamily.CODEX
+    if normalized in {"opencode", "opencode_cli"}:
+        return HostFamily.OPENCODE
+    if normalized:
+        return HostFamily.OTHER_KNOWN
+    return HostFamily.UNKNOWN
+
+
+def _extension_mode(
+    capabilities: Any,
+) -> HostSubagentCapability | None:
+    if capabilities is None:
+        return None
+    candidates: list[Mapping[str, Any]] = []
+    for field_name in ("extensions", "experimental"):
+        raw = getattr(capabilities, field_name, None)
+        if isinstance(raw, Mapping):
+            value = raw.get(SUBAGENT_CAPABILITY_EXTENSION)
+            if isinstance(value, Mapping):
+                candidates.append(value)
+    for value in candidates:
+        mode = value.get("mode")
+        if isinstance(mode, str) and mode.strip().lower() in _CAPABILITY_MODES:
+            return HostSubagentCapability(mode.strip().lower())
+        if value.get("parallel") is True:
+            return HostSubagentCapability.PARALLEL
+        if value.get("parallel") is False:
+            return HostSubagentCapability.SEQUENTIAL
+    return None
+
+
+def from_sdk_context(context: Any) -> MCPHostContext:
+    """Normalize an MCP SDK ``Context`` without retaining raw client data."""
+    if context is None:
+        return _DEFAULT_CONTEXT
+    try:
+        session = context.session
+        params = getattr(session, "client_params", None)
+        client_info = getattr(params, "client_info", None)
+        name = getattr(client_info, "name", None)
+        identity = HostIdentityStatus.KNOWN if name else HostIdentityStatus.UNKNOWN
+        capabilities = getattr(session, "client_capabilities", None)
+        extension_mode = _extension_mode(capabilities)
+        return MCPHostContext(
+            host_family=_host_family(name),
+            identity_status=identity,
+            subagent_capability=(extension_mode or HostSubagentCapability.UNDECLARED),
+            capability_source=(
+                HostCapabilitySource.MCP_EXTENSION
+                if extension_mode is not None
+                else HostCapabilitySource.NONE
+            ),
+            dispatch_authority=DispatchAuthority.MCP_HOST,
+        )
+    except (AttributeError, TypeError):
+        return MCPHostContext(
+            dispatch_authority=DispatchAuthority.MCP_HOST,
+        )
+
+
+def resolve_request_subagent_dispatch(
+    worker_backend: str | None,
+    opencode_mode: str | None,
+) -> SubagentDispatchMode:
+    """Resolve dispatch without treating worker configuration as host capability.
+
+    Direct/internal calls retain the backend resolver, including a trusted
+    passive plugin bridge. External MCP calls use only an explicit request-scoped
+    capability fact; neither plugin delivery nor execution capability is inferred
+    from the configured worker. Absence becomes HOST_DECIDES.
+    """
+
+    worker_mode = resolve_subagent_dispatch(worker_backend, opencode_mode)
+    context = current_mcp_host_context()
+    if not context.is_mcp_host:
+        return worker_mode
+    if context.dispatch_authority is DispatchAuthority.PASSIVE_BRIDGE:
+        return SubagentDispatchMode.PLUGIN_PASSIVE
+    if (
+        worker_mode is SubagentDispatchMode.PLUGIN_PASSIVE
+        and context.host_family is HostFamily.OPENCODE
+    ):
+        return SubagentDispatchMode.PLUGIN_PASSIVE
+    if context.subagent_capability is HostSubagentCapability.PARALLEL:
+        return SubagentDispatchMode.HOST_DRIVEN
+    if context.subagent_capability in {
+        HostSubagentCapability.SEQUENTIAL,
+        HostSubagentCapability.UNAVAILABLE,
+    }:
+        return SubagentDispatchMode.SEQUENTIAL
+    return SubagentDispatchMode.HOST_DECIDES
+
+
+def normalized_worker_backend(worker_backend: str | None) -> str:
+    """Return a closed, telemetry-safe worker backend value."""
+
+    capability = get_backend_capability((worker_backend or "").strip().lower())
+    return capability.name if capability is not None else "other"
+
+
+def host_worker_mismatch(context: MCPHostContext, worker_backend: str | None) -> bool:
+    """Return whether a known host family differs from the configured worker."""
+    expected = {
+        HostFamily.CLAUDE_CODE: "claude",
+        HostFamily.CODEX: "codex",
+        HostFamily.OPENCODE: "opencode",
+    }.get(context.host_family)
+    return expected is not None and expected != normalized_worker_backend(worker_backend)
+
+
+def context_for_internal_runtime(
+    capability: HostSubagentCapability,
+) -> MCPHostContext:
+    """Create an explicit context for trusted in-process execution."""
+    return MCPHostContext(
+        host_family=HostFamily.UNKNOWN,
+        identity_status=HostIdentityStatus.UNKNOWN,
+        subagent_capability=capability,
+        capability_source=HostCapabilitySource.TRUSTED_SERVER_OPTION,
+        dispatch_authority=DispatchAuthority.INTERNAL_RUNTIME,
+    )
+
+
+def subagent_capability_extensions() -> list[Any] | None:
+    """Return the optional SDK extension advertising this capability contract."""
+    try:
+        from mcp.server.extension import Extension
+    except ImportError:
+        return None
+
+    class SubagentCapabilityExtension(Extension):
+        identifier = SUBAGENT_CAPABILITY_EXTENSION
+
+        def settings(self) -> dict[str, Any]:
+            return {
+                "modes": ["parallel", "sequential", "unavailable"],
+                "undeclaredBehavior": "parallel_preferred_sequential_fallback",
+            }
+
+    return [SubagentCapabilityExtension()]
+
+
+def render_lateral_host_banner(
+    dispatch_mode: SubagentDispatchMode,
+    payload_count: int,
+) -> str:
+    """Render the text-only counterpart of a lateral host dispatch contract."""
+    if dispatch_mode is SubagentDispatchMode.HOST_DRIVEN:
+        return (
+            "> **Host action — spawn subagents:** this request declared a native "
+            "parallel subagent primitive. Spawn one child per payload, correlate "
+            f"results by `context.persona`, then synthesise. Payloads: {payload_count} "
+            "(structured copy in `meta` and the dispatch block).\n\n"
+        )
+    if dispatch_mode is SubagentDispatchMode.HOST_DECIDES:
+        return (
+            "> **Host action — dispatch if supported:** this request did not "
+            "declare whether parallel subagents are available. Use the host's native "
+            "parallel primitive when available; otherwise process the same payloads "
+            f"sequentially. Correlate by `context.persona`. Payloads: {payload_count} "
+            "(structured copy in `meta` and the dispatch block).\n\n"
+        )
+    return ""
+
+
+__all__ = [
+    "DispatchAuthority",
+    "HostCapabilitySource",
+    "HostFamily",
+    "HostIdentityStatus",
+    "HostSubagentCapability",
+    "MCPHostContext",
+    "SUBAGENT_CAPABILITY_EXTENSION",
+    "context_for_internal_runtime",
+    "current_mcp_host_context",
+    "from_sdk_context",
+    "host_worker_mismatch",
+    "normalized_worker_backend",
+    "render_lateral_host_banner",
+    "resolve_request_subagent_dispatch",
+    "subagent_capability_extensions",
+    "use_mcp_host_context",
+]

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -32,6 +32,7 @@ from ouroboros.mcp.errors import (
     MCPServerError,
     MCPToolError,
 )
+from ouroboros.mcp.host_context import from_sdk_context, subagent_capability_extensions
 from ouroboros.mcp.server.auth import current_auth_context, resolve_network_security
 
 # Re-exported: split out in #1754, still imported from here by evaluation tests.
@@ -85,7 +86,6 @@ try:  # Keep the core package importable when the optional MCP extra is absent.
 except ImportError:  # pragma: no cover - exercised by packaging smoke tests.
     _SDKMCPServer = None  # type: ignore[assignment,misc]
 
-
 if _SDKMCPServer is not None:
 
     class _OuroborosSDKServer(_SDKMCPServer):  # type: ignore[misc,valid-type]
@@ -116,10 +116,14 @@ if _SDKMCPServer is not None:
             arguments: dict[str, Any],
             context: Any = None,
         ) -> Any:
-            del context
             from ouroboros.mcp.telemetry_boundary import call_sdk_tool
 
-            return await call_sdk_tool(self._ouroboros_adapter, name, arguments)
+            return await call_sdk_tool(
+                self._ouroboros_adapter,
+                name,
+                arguments,
+                host_context=from_sdk_context(context),
+            )
 
         async def list_resources(self) -> list[Any]:
             from ouroboros.mcp.sdk_mapping import resource_to_sdk
@@ -1131,6 +1135,7 @@ class MCPServerAdapter:
             version=self._version,
             token_verifier=wiring.token_verifier,
             auth=wiring.auth_settings,
+            extensions=subagent_capability_extensions(),
         )
 
         # Register tools with MCPServer.

--- a/src/ouroboros/mcp/telemetry_boundary.py
+++ b/src/ouroboros/mcp/telemetry_boundary.py
@@ -8,8 +8,19 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from ouroboros import telemetry as usage_telemetry
+from ouroboros.backends.capabilities import SubagentDispatchMode
 from ouroboros.core.types import Result
 from ouroboros.mcp.failure_taxonomy import classify_failure
+from ouroboros.mcp.host_context import (
+    DispatchAuthority,
+    HostCapabilitySource,
+    HostSubagentCapability,
+    MCPHostContext,
+    current_mcp_host_context,
+    host_worker_mismatch,
+    normalized_worker_backend,
+    use_mcp_host_context,
+)
 
 if TYPE_CHECKING:
     from ouroboros.mcp.server.adapter import MCPServerAdapter
@@ -195,6 +206,8 @@ async def call_sdk_tool(
     adapter: MCPServerAdapter,
     name: str,
     arguments: dict[str, Any],
+    *,
+    host_context: MCPHostContext | None = None,
 ) -> Any:
     """Own SDK validation plus the one complete request-outcome event.
 
@@ -236,11 +249,12 @@ async def call_sdk_tool(
         # token and the raw credential is gone by now, so carry its decision
         # across instead -- that restores the client identity authorization and
         # rate limiting key on.
-        result = await adapter._call_tool_impl(
-            name,
-            arguments,
-            auth_context=current_auth_context(),
-        )
+        with use_mcp_host_context(host_context or MCPHostContext()):
+            result = await adapter._call_tool_impl(
+                name,
+                arguments,
+                auth_context=current_auth_context(),
+            )
         if result.is_err:
             error_type = _safe_error_type(result.error)
             raise RuntimeError(str(result.error))
@@ -308,6 +322,90 @@ def record_direct_evaluation_outcome(
         pass
 
 
+def record_subagent_dispatch_emitted(
+    *,
+    fanout_kind: str,
+    payload_count: int,
+    dispatch_mode: SubagentDispatchMode,
+    worker_backend: str | None,
+    fanout_reentry_available: bool,
+) -> None:
+    """Record the privacy-safe contract emitted to a fan-out consumer."""
+    try:
+        context = current_mcp_host_context()
+        if dispatch_mode is SubagentDispatchMode.PLUGIN_PASSIVE:
+            authority = DispatchAuthority.PASSIVE_BRIDGE.value
+            capability = HostSubagentCapability.PARALLEL.value
+            capability_source = HostCapabilitySource.PASSIVE_BRIDGE.value
+            delivery_mode = "passive_bridge"
+            preference = "parallel"
+            fallback = "none"
+            reason = "passive_bridge_detected"
+        else:
+            authority = context.dispatch_authority.value
+            capability = context.subagent_capability.value
+            capability_source = context.capability_source.value
+            delivery_mode = "inline_host" if context.is_mcp_host else "inline_runtime"
+            preference = (
+                "sequential" if dispatch_mode is SubagentDispatchMode.SEQUENTIAL else "parallel"
+            )
+            fallback = "sequential"
+            if dispatch_mode is SubagentDispatchMode.HOST_DRIVEN:
+                reason = "declared_parallel"
+            elif context.is_mcp_host and dispatch_mode is SubagentDispatchMode.SEQUENTIAL:
+                reason = "declared_sequential"
+            elif dispatch_mode is SubagentDispatchMode.HOST_DECIDES:
+                reason = "host_capability_undeclared"
+            else:
+                reason = "configured_internal_runtime"
+
+        usage_telemetry.capture_subagent_dispatch(
+            {
+                "phase": "emitted",
+                "fanout_kind": fanout_kind,
+                "payload_count": payload_count,
+                "invocation_surface": ("mcp_host" if context.is_mcp_host else "internal_runtime"),
+                "dispatch_authority": authority,
+                "host_family": context.host_family.value,
+                "host_identity_status": context.identity_status.value,
+                "host_capability": capability,
+                "capability_source": capability_source,
+                "delivery_mode": delivery_mode,
+                "execution_preference": preference,
+                "fallback_strategy": fallback,
+                "configured_worker_backend": normalized_worker_backend(worker_backend),
+                "host_worker_mismatch": host_worker_mismatch(context, worker_backend),
+                "decision_reason": reason,
+                "contract_version": "v2",
+                "fanout_reentry_available": fanout_reentry_available,
+            }
+        )
+    except Exception:
+        pass
+
+
+def record_subagent_dispatch_submitted(
+    *,
+    fanout_kind: str,
+    submission_status: str,
+    expected_count: int,
+    received_count: int,
+    undispatched_count: int,
+) -> None:
+    """Record fan-out re-entry counts without identifiers or output content."""
+    usage_telemetry.capture_subagent_dispatch(
+        {
+            "phase": "submitted",
+            "fanout_kind": fanout_kind,
+            "submission_status": submission_status,
+            "expected_count": expected_count,
+            "received_count": received_count,
+            "undispatched_count": undispatched_count,
+            "contract_version": "v2",
+        }
+    )
+
+
 def stamp_backend_context(
     runtime_backend: str | None,
     execute_runtime_backend: str | None,
@@ -363,5 +461,7 @@ __all__ = [
     "call_sdk_tool",
     "observe_adapter_tool_call",
     "record_direct_evaluation_outcome",
+    "record_subagent_dispatch_emitted",
+    "record_subagent_dispatch_submitted",
     "stamp_backend_context",
 ]

--- a/src/ouroboros/mcp/tools/advisory_dispatch.py
+++ b/src/ouroboros/mcp/tools/advisory_dispatch.py
@@ -43,6 +43,7 @@ _CORRELATION_KEY = "question_advisory_result_correlation_key"
 _FANOUT_ID_KEY = "question_advisory_fanout_id"
 _DEFAULT_CORRELATION_KEY = "context.lane_id"
 _SEQUENTIAL_HOST_ACTION = "process_payloads_sequentially"
+_HOST_DECIDES_ACTION = "dispatch_subagents_if_supported"
 
 #: Boundary between the question and the host directive that follows it.
 #:
@@ -150,11 +151,15 @@ def append_question_advisory_dispatch(response_text: str, meta: dict[str, Any]) 
     correlation_key = str(meta.get(_CORRELATION_KEY) or _DEFAULT_CORRELATION_KEY)
     lanes = _lane_ids(payloads)
     required_lanes = _lane_ids(payloads, required_only=True)
-    directive = (
-        "process every payload below sequentially"
-        if host_action == _SEQUENTIAL_HOST_ACTION
-        else "spawn one subagent per payload below with your native subagent primitive"
-    )
+    if host_action == _SEQUENTIAL_HOST_ACTION:
+        directive = "process every payload below sequentially"
+    elif host_action == _HOST_DECIDES_ACTION:
+        directive = (
+            "use your native parallel subagent primitive when available; "
+            "otherwise process every payload below sequentially"
+        )
+    else:
+        directive = "spawn one subagent per payload below with your native subagent primitive"
 
     lines = [
         response_text,

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -58,6 +58,7 @@ from ouroboros.interview_adapters import (
     InterviewTurnContext,
 )
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
+from ouroboros.mcp.host_context import resolve_request_subagent_dispatch
 from ouroboros.mcp.tools.advisory_dispatch import (
     append_lateral_review_notice,
     append_question_advisory_dispatch,
@@ -78,7 +79,6 @@ from ouroboros.mcp.tools.subagent import (
     build_interview_subagent,
     dispatch_plugin_terminal,
     lateral_persona_panel_metadata_from_capability_definitions,
-    resolve_subagent_dispatch,
     should_dispatch_via_plugin,
 )
 from ouroboros.mcp.types import (
@@ -2665,7 +2665,7 @@ class InterviewHandler:
                             question=question,
                             phase="start",
                             score=live_score,
-                            dispatch_mode=resolve_subagent_dispatch(
+                            dispatch_mode=resolve_request_subagent_dispatch(
                                 self.agent_runtime_backend, self.opencode_mode
                             ),
                             runtime_backend=self.agent_runtime_backend,
@@ -3313,7 +3313,7 @@ class InterviewHandler:
                             question=pending_question,
                             phase="resume_pending",
                             score=_load_state_ambiguity_score(state),
-                            dispatch_mode=resolve_subagent_dispatch(
+                            dispatch_mode=resolve_request_subagent_dispatch(
                                 self.agent_runtime_backend, self.opencode_mode
                             ),
                             runtime_backend=self.agent_runtime_backend,
@@ -3592,7 +3592,7 @@ class InterviewHandler:
                     question=question,
                     phase="answer",
                     score=live_score,
-                    dispatch_mode=resolve_subagent_dispatch(
+                    dispatch_mode=resolve_request_subagent_dispatch(
                         self.agent_runtime_backend, self.opencode_mode
                     ),
                     runtime_backend=self.agent_runtime_backend,

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -28,8 +28,15 @@ from ouroboros.core.project_paths import resolve_path_against_base, resolve_seed
 from ouroboros.core.seed import AcceptanceCriterionSpec, Seed, ac_text
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPAuthError, MCPServerError, MCPTimeoutError, MCPToolError
+from ouroboros.mcp.host_context import (
+    render_lateral_host_banner,
+    resolve_request_subagent_dispatch,
+)
 from ouroboros.mcp.job_manager import JobLinks, JobManager
-from ouroboros.mcp.telemetry_boundary import record_direct_evaluation_outcome
+from ouroboros.mcp.telemetry_boundary import (
+    record_direct_evaluation_outcome,
+    record_subagent_dispatch_emitted,
+)
 from ouroboros.mcp.tools import background as background_jobs
 from ouroboros.mcp.tools.bridge_mixin import BridgeAwareMixin
 from ouroboros.mcp.tools.fanout_handler import (  # noqa: F401
@@ -1688,7 +1695,6 @@ class LateralThinkHandler(BridgeAwareMixin):
                 build_lateral_multi_subagent,
                 build_multi_subagent_result,
                 lateral_persona_panel_metadata_from_capability_definitions,
-                resolve_subagent_dispatch,
                 stamp_fanout_meta,
                 stamp_lateral_persona_fanout,
             )
@@ -1750,12 +1756,22 @@ class LateralThinkHandler(BridgeAwareMixin):
             #     from inline payloads via its own primitive (e.g. Codex). Emit
             #     the inline result stamped with ``host_action=spawn_subagents``.
             #   - SEQUENTIAL: no parallel surface at all → plain inline fallback.
-            dispatch = resolve_subagent_dispatch(self.agent_runtime_backend, self.opencode_mode)
+            dispatch = resolve_request_subagent_dispatch(
+                self.agent_runtime_backend,
+                self.opencode_mode,
+            )
             if dispatch is SubagentDispatchMode.PLUGIN_PASSIVE:
                 # Preserve public response shape (#442): ouroboros_lateral_think
                 # natural response documents alternative-thinking metadata.
                 # Expose persona_count + dispatch status at top level so callers
                 # can branch on delegation without parsing the envelope.
+                record_subagent_dispatch_emitted(
+                    fanout_kind="lateral_persona_panel",
+                    payload_count=len(payloads),
+                    dispatch_mode=dispatch,
+                    worker_backend=self.agent_runtime_backend,
+                    fanout_reentry_available=False,
+                )
                 return build_multi_subagent_result(
                     payloads,
                     response_shape={
@@ -1815,16 +1831,13 @@ class LateralThinkHandler(BridgeAwareMixin):
             # spawn subagents themselves. SEQUENTIAL runtimes now get the same
             # machine-readable contract vocabulary, while preserving
             # ``inline_fallback`` as a legacy alias for older skill prose.
-            host_driven = dispatch is SubagentDispatchMode.HOST_DRIVEN
             payload_dicts = [p.to_dict() for p in payloads]
             panel_metadata = lateral_persona_panel_metadata_from_capability_definitions()
-            contract_backend = self.agent_runtime_backend
-            if not contract_backend:
-                contract_backend = "codex" if host_driven else "gemini"
             contract = build_runtime_subagent_orchestration_contract(
-                contract_backend,
+                self.agent_runtime_backend or "unknown",
                 directive_metadata=panel_metadata,
                 opencode_mode=self.opencode_mode,
+                dispatch_mode=dispatch,
             )
             dispatch_record: dict[str, Any] = {
                 "persona_count": len(sections),
@@ -1842,7 +1855,7 @@ class LateralThinkHandler(BridgeAwareMixin):
                 payloads=payloads,
                 correlation_key="context.persona",
             )
-            if not host_driven:
+            if dispatch is SubagentDispatchMode.SEQUENTIAL:
                 dispatch_record["legacy_dispatch_mode"] = "inline_fallback"
             stamp_lateral_persona_fanout(
                 dispatch_record,
@@ -1850,19 +1863,16 @@ class LateralThinkHandler(BridgeAwareMixin):
                 session_id=str(arguments.get("session_id") or ""),
                 payloads=payloads,
             )
+            record_subagent_dispatch_emitted(
+                fanout_kind="lateral_persona_panel",
+                payload_count=len(payloads),
+                dispatch_mode=dispatch,
+                worker_backend=self.agent_runtime_backend,
+                fanout_reentry_available="fanout_id" in dispatch_record,
+            )
             dispatch_blob = json.dumps(dispatch_record)
             dispatch_b64 = base64.b64encode(dispatch_blob.encode("utf-8")).decode("ascii")
-            host_banner = (
-                (
-                    "> **Host action — spawn subagents:** this runtime drives "
-                    "fan-out itself. Spawn one subagent per payload below with "
-                    "your native subagent primitive, correlate results by "
-                    f"`context.persona`, then synthesise. Payloads: {len(sections)} "
-                    "(structured copy in `meta` and the dispatch block).\n\n"
-                )
-                if host_driven
-                else ""
-            )
+            host_banner = render_lateral_host_banner(dispatch, len(sections))
             content_text = (
                 f"{host_banner}{combined}\n\n"
                 "<!-- ouroboros-lateral-inline-dispatch-v1 base64\n"

--- a/src/ouroboros/mcp/tools/fanout_handler.py
+++ b/src/ouroboros/mcp/tools/fanout_handler.py
@@ -13,6 +13,7 @@ import structlog
 
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
+from ouroboros.mcp.telemetry_boundary import record_subagent_dispatch_submitted
 from ouroboros.mcp.tools.fanout import (
     FanoutRegistry,
     PreparedFanoutSynthesis,
@@ -169,9 +170,39 @@ class SubmitFanoutResultsHandler:
             results=list(raw_results),
             fanout_id=fanout_id,
         )
+        record = self._registry.load(fanout_id)
+        expected_count = len(record.expected_keys) if record is not None else 0
+        received_count = sum(
+            1
+            for item in raw_results
+            if isinstance(item, dict) and "content" in item and "undispatched" not in item
+        )
+        undispatched_count = sum(
+            1 for item in raw_results if isinstance(item, dict) and item.get("undispatched") is True
+        )
         outcome = await self._publish_or_synthesize(prepared, fanout_id=fanout_id)
+        fanout_kind = record.kind if record is not None else "unknown"
         if isinstance(outcome, MCPToolError):
+            record_subagent_dispatch_submitted(
+                fanout_kind=fanout_kind,
+                submission_status="publication_failed",
+                expected_count=expected_count,
+                received_count=received_count,
+                undispatched_count=undispatched_count,
+            )
             return Result.err(outcome)
+        submission_status = (
+            "complete"
+            if isinstance(prepared, PreparedFanoutSynthesis)
+            else str(outcome.get("status") or "unknown_kind")
+        )
+        record_subagent_dispatch_submitted(
+            fanout_kind=fanout_kind,
+            submission_status=submission_status,
+            expected_count=expected_count,
+            received_count=received_count,
+            undispatched_count=undispatched_count,
+        )
         if outcome.get("status") == "unknown_fanout_id":
             return Result.err(
                 MCPToolError(

--- a/src/ouroboros/mcp/tools/pm_handler.py
+++ b/src/ouroboros/mcp/tools/pm_handler.py
@@ -52,6 +52,7 @@ from ouroboros.core.owner_only import secure_directory, write_owner_only
 from ouroboros.core.pm_snapshot import refresh_pm_snapshot_worktrees
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
+from ouroboros.mcp.host_context import resolve_request_subagent_dispatch
 from ouroboros.mcp.tools.advisory_dispatch import append_question_advisory_dispatch
 from ouroboros.mcp.tools.fanout import FanoutRegistry
 from ouroboros.mcp.tools.question_advisory import attach_question_advisory
@@ -59,7 +60,6 @@ from ouroboros.mcp.tools.subagent import (
     DELEGATED_TO_SUBAGENT,
     build_pm_interview_subagent,
     dispatch_plugin_terminal,
-    resolve_subagent_dispatch,
     should_dispatch_via_plugin,
 )
 from ouroboros.mcp.types import (
@@ -405,7 +405,10 @@ class PMInterviewHandler:
             repository_roster=pm_repository_roster(
                 pm_meta.get("brownfield_repos") if pm_meta else None
             ),
-            dispatch_mode=resolve_subagent_dispatch(self.agent_runtime_backend, self.opencode_mode),
+            dispatch_mode=resolve_request_subagent_dispatch(
+                self.agent_runtime_backend,
+                self.opencode_mode,
+            ),
             runtime_backend=self.agent_runtime_backend,
             opencode_mode=self.opencode_mode,
             fanout_registry=self.fanout_registry,

--- a/src/ouroboros/mcp/tools/question_advisory.py
+++ b/src/ouroboros/mcp/tools/question_advisory.py
@@ -31,6 +31,7 @@ from typing import Any
 import structlog
 
 from ouroboros.backends.capabilities import build_runtime_subagent_orchestration_contract
+from ouroboros.mcp.telemetry_boundary import record_subagent_dispatch_emitted
 from ouroboros.mcp.tools.advisory_prompts import (
     _INTERVIEW_DATA_CONTRACT_MAX_JSON_CHARS,
     _advisory_output_section,
@@ -670,19 +671,11 @@ def attach_question_advisory(
     if code_investigation_request is not None:
         meta["code_investigation_request"] = dict(code_investigation_request)
 
-    contract_backend = runtime_backend
-    if not contract_backend:
-        contract_backend = (
-            "codex"
-            if dispatch_mode is SubagentDispatchMode.HOST_DRIVEN
-            else "opencode"
-            if dispatch_mode is SubagentDispatchMode.PLUGIN_PASSIVE
-            else "gemini"
-        )
     contract = build_runtime_subagent_orchestration_contract(
-        contract_backend,
+        runtime_backend or "unknown",
         directive_metadata=request,
         opencode_mode=opencode_mode,
+        dispatch_mode=dispatch_mode,
     )
     meta["subagent_orchestration_instruction"] = contract.runtime_instruction_handling
     # Advisory lanes are keyed by lane_id; their persona is absent on some
@@ -708,6 +701,13 @@ def attach_question_advisory(
             if repository_roster is not None
             else None
         ),
+    )
+    record_subagent_dispatch_emitted(
+        fanout_kind="question_advisory",
+        payload_count=len(payloads),
+        dispatch_mode=dispatch_mode,
+        worker_backend=runtime_backend,
+        fanout_reentry_available="question_advisory_fanout_id" in meta,
     )
 
 

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -2360,11 +2360,10 @@ do not enqueue another background Ralph job."""
 # served by ``FanoutRegistry`` + ``submit_fanout_results`` and the
 # ``ouroboros_submit_fanout_results`` MCP tool.
 
-# host_action cue keyed by inline dispatch mode. PLUGIN_PASSIVE is intentionally
-# absent: that surface consumes the ``_subagents`` bridge envelope built by
-# ``build_multi_subagent_result`` and stamps no host-action cue here.
+# Host-action cue for inline modes; HOST_DECIDES carries an explicit fallback.
 _FANOUT_HOST_ACTION_BY_MODE: dict[SubagentDispatchMode, str] = {
     SubagentDispatchMode.HOST_DRIVEN: "spawn_subagents",
+    SubagentDispatchMode.HOST_DECIDES: "dispatch_subagents_if_supported",
     SubagentDispatchMode.SEQUENTIAL: "process_payloads_sequentially",
 }
 
@@ -2436,20 +2435,15 @@ def stamp_fanout_meta(
     payloads: list[SubagentPayload],
     correlation_key: str,
 ) -> None:
-    """Stamp the standardized 3-mode fan-out dispatch contract onto ``meta``.
+    """Stamp the standardized fan-out dispatch contract onto ``meta``.
 
-    Single source of truth for the dispatch-mode stamping PR-C standardized and
-    that the two legacy producers (interview question advisory + lateral persona
-    panel) previously copy-pasted:
+    ``HOST_DRIVEN`` requests parallel spawn, ``HOST_DECIDES`` asks the host to
+    choose native parallel dispatch or sequential fallback, and ``SEQUENTIAL``
+    requires ordered processing. ``PLUGIN_PASSIVE`` stamps no host cue because
+    its bridge consumes the ``_subagents`` envelope.
 
-    * ``HOST_DRIVEN``    → ``host_action = "spawn_subagents"``
-    * ``SEQUENTIAL``     → ``host_action = "process_payloads_sequentially"``
-    * ``PLUGIN_PASSIVE`` → no host-action cue (the bridge consumes the
-      ``_subagents`` envelope from :func:`build_multi_subagent_result`).
-
-    ``{prefix}_result_correlation_key`` is written on all three: it names how a
-    submission is keyed, which the cue does not own. The other two keys are the
-    cue's, so ``PLUGIN_PASSIVE`` gets neither.
+    ``{prefix}_result_correlation_key`` is written on all modes. The cue itself
+    is host-only, so PLUGIN_PASSIVE gets no dispatch mode or host action.
 
     Args:
         meta: Response meta dict, mutated in place.
@@ -2468,6 +2462,11 @@ def stamp_fanout_meta(
         return  # PLUGIN_PASSIVE: no cue, and no dispatch mode to announce with it.
     meta[_fanout_meta_key(prefix, "dispatch_mode")] = dispatch_mode.value
     meta[_fanout_meta_key(prefix, "host_action")] = host_action
+    if dispatch_mode is SubagentDispatchMode.HOST_DECIDES:
+        meta[_fanout_meta_key(prefix, "delivery_mode")] = "inline_host"
+        meta[_fanout_meta_key(prefix, "execution_preference")] = "parallel"
+        meta[_fanout_meta_key(prefix, "fallback_strategy")] = "sequential"
+        meta[_fanout_meta_key(prefix, "host_capability")] = "undeclared"
 
 
 # ---------------------------------------------------------------------------

--- a/src/ouroboros/orchestrator/capabilities/lateral_personas.py
+++ b/src/ouroboros/orchestrator/capabilities/lateral_personas.py
@@ -118,7 +118,7 @@ def _lateral_persona_panel_metadata() -> LateralPersonaPanelMetadata:
     return LateralPersonaPanelMetadata(
         panel_id="lateral_persona_panel.v1",
         mcp_tool="ouroboros_lateral_think",
-        dispatch_modes=("plugin", "sequential"),
+        dispatch_modes=("plugin", "host_driven", "host_decides", "sequential"),
         legacy_dispatch_modes=("inline_fallback",),
         parallel_preference="parallel_when_runtime_supports_subagents",
         sequential_fallback={
@@ -156,11 +156,12 @@ def _lateral_persona_panel_metadata() -> LateralPersonaPanelMetadata:
         },
         runtime_instruction=(
             "Call ouroboros_lateral_think first. If the response delegates via "
-            "_subagents, consume those payloads. If it returns sequential "
-            "payload metadata and the runtime has a native subagent primitive, "
-            "dispatch each structured payload by context.persona; otherwise "
-            "process those payloads sequentially. Treat inline_fallback as a "
-            "legacy alias for sequential."
+            "_subagents, consume those structured payloads. For inline structured "
+            "payloads, host_driven means the host declared parallel support; "
+            "host_decides means use native parallel fan-out when available and "
+            "otherwise process sequentially; sequential means the selected "
+            "authority explicitly requires ordered processing. Treat "
+            "inline_fallback as a legacy alias for sequential."
         ),
     )
 

--- a/src/ouroboros/telemetry.py
+++ b/src/ouroboros/telemetry.py
@@ -376,6 +376,76 @@ _MCP_SERVE_STARTED_KEYS = frozenset(
         "ci",
     }
 )
+_SUBAGENT_DISPATCH_KEYS = frozenset(
+    {
+        "phase",
+        "fanout_kind",
+        "payload_count",
+        "invocation_surface",
+        "dispatch_authority",
+        "host_family",
+        "host_identity_status",
+        "host_capability",
+        "capability_source",
+        "delivery_mode",
+        "execution_preference",
+        "fallback_strategy",
+        "configured_worker_backend",
+        "host_worker_mismatch",
+        "decision_reason",
+        "contract_version",
+        "fanout_reentry_available",
+        "submission_status",
+        "expected_count",
+        "received_count",
+        "undispatched_count",
+        "frontdoor",
+        "first_command_surface",
+        "app_version",
+        "os",
+        "python_version",
+        "ci",
+    }
+)
+
+_SUBAGENT_DISPATCH_ENUMS: dict[str, frozenset[str]] = {
+    "phase": frozenset({"emitted", "submitted"}),
+    "fanout_kind": frozenset(
+        {"lateral_persona_panel", "question_advisory", "code_investigation", "unknown"}
+    ),
+    "invocation_surface": frozenset({"mcp_host", "internal_runtime"}),
+    "dispatch_authority": frozenset({"mcp_host", "internal_runtime", "passive_bridge"}),
+    "host_family": frozenset({"claude_code", "codex", "opencode", "other_known", "unknown"}),
+    "host_identity_status": frozenset({"known", "unknown"}),
+    "host_capability": frozenset({"parallel", "sequential", "unavailable", "undeclared"}),
+    "capability_source": frozenset(
+        {"mcp_extension", "trusted_server_option", "passive_bridge", "none"}
+    ),
+    "delivery_mode": frozenset({"passive_bridge", "inline_host", "inline_runtime"}),
+    "execution_preference": frozenset({"parallel", "sequential"}),
+    "fallback_strategy": frozenset({"sequential", "none"}),
+    "decision_reason": frozenset(
+        {
+            "passive_bridge_detected",
+            "declared_parallel",
+            "declared_sequential",
+            "host_capability_undeclared",
+            "configured_internal_runtime",
+        }
+    ),
+    "contract_version": frozenset({"v2"}),
+    "submission_status": frozenset(
+        {
+            "complete",
+            "partial",
+            "invalid_result_entry",
+            "unknown_fanout_id",
+            "correlation_mismatch",
+            "unknown_kind",
+            "publication_failed",
+        }
+    ),
+}
 _FIRST_COMMAND_SURFACES = frozenset(
     {"setup_complete", "readme_quickstart", "getting_started", "unknown"}
 )
@@ -976,6 +1046,8 @@ def _resolve_allowed_keys(event: str, properties: dict[str, Any] | None) -> froz
         return _WORKFLOW_OUTCOME_KEYS
     if event == "mcp_serve_started":
         return _MCP_SERVE_STARTED_KEYS
+    if event == "subagent_dispatch":
+        return _SUBAGENT_DISPATCH_KEYS
     return None
 
 
@@ -1075,6 +1147,44 @@ def capture_tool_call(
         else:
             properties["ok"] = ok
         capture("command_run", properties)
+    except Exception:
+        pass
+
+
+def capture_subagent_dispatch(properties: dict[str, Any]) -> None:
+    """Capture one privacy-safe fan-out contract or re-entry boundary.
+
+    Values are closed enums and bounded counts. Unknown/custom strings are
+    folded before ``capture`` so raw client names, backend names, identifiers,
+    prompts, and outputs can never reach PostHog through this event.
+    """
+    try:
+        safe: dict[str, Any] = {}
+        for key, value in properties.items():
+            allowed = _SUBAGENT_DISPATCH_ENUMS.get(key)
+            if allowed is not None:
+                if isinstance(value, str) and value in allowed:
+                    safe[key] = value
+                continue
+            if key in {
+                "payload_count",
+                "expected_count",
+                "received_count",
+                "undispatched_count",
+            }:
+                if isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= 64:
+                    safe[key] = value
+                continue
+            if key in {"host_worker_mismatch", "fanout_reentry_available"}:
+                if isinstance(value, bool):
+                    safe[key] = value
+                continue
+            if key == "configured_worker_backend":
+                from ouroboros.backends.capabilities import get_backend_capability
+
+                capability = get_backend_capability(str(value))
+                safe[key] = capability.name if capability is not None else "other"
+        capture("subagent_dispatch", safe)
     except Exception:
         pass
 
@@ -1297,5 +1407,6 @@ __all__ = [
     "flush",
     "is_enabled",
     "set_context",
+    "capture_subagent_dispatch",
     "show_first_run_notice",
 ]

--- a/tests/integration/mcp/test_server_adapter.py
+++ b/tests/integration/mcp/test_server_adapter.py
@@ -1061,6 +1061,51 @@ class TestCreateOuroborosServer:
         assert mock_wonder_engine.call_args.kwargs["adapter_backend"] == "codex"
         assert mock_reflect_engine.call_args.kwargs["adapter_backend"] == "codex"
 
+    @pytest.mark.asyncio
+    async def test_mcp_host_capability_is_not_inferred_from_reflect_worker(self) -> None:
+        """A server-composed Gemini worker cannot label a Claude host sequential."""
+        from ouroboros.mcp.host_context import (
+            DispatchAuthority,
+            HostFamily,
+            HostIdentityStatus,
+            MCPHostContext,
+            use_mcp_host_context,
+        )
+
+        config = OuroborosConfig(
+            orchestrator=OrchestratorConfig(
+                runtime_backend="claude",
+                runtime_profile=RuntimeProfileConfig(stages={"reflect": "gemini"}),
+            ),
+        )
+        with (
+            patch("ouroboros.config.load_config", return_value=config),
+            patch("ouroboros.config.loader.load_config", return_value=config),
+            patch("ouroboros.providers.create_llm_adapter", return_value=MagicMock()),
+            patch("ouroboros.orchestrator.create_agent_runtime", return_value=MagicMock()),
+        ):
+            server = create_ouroboros_server(runtime_backend="claude")
+
+        lateral = server._tool_handlers["ouroboros_lateral_think"]
+        assert lateral.agent_runtime_backend == "gemini"
+        host = MCPHostContext(
+            host_family=HostFamily.CLAUDE_CODE,
+            identity_status=HostIdentityStatus.KNOWN,
+            dispatch_authority=DispatchAuthority.MCP_HOST,
+        )
+        with use_mcp_host_context(host):
+            result = await lateral.handle(
+                {
+                    "problem_context": "stuck on X",
+                    "current_approach": "tried Y",
+                    "persona": "all",
+                }
+            )
+
+        assert result.is_ok
+        assert result.unwrap().meta["dispatch_mode"] == "host_decides"
+        assert result.unwrap().meta["host_action"] == "dispatch_subagents_if_supported"
+
     def test_legacy_llm_backend_config_override_honored_at_composition_root(self) -> None:
         """No per-stage profile: config.llm.backend drives internal LLM roles.
 

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -3291,6 +3291,12 @@ class TestServeTransport:
         mock_fastmcp_cls.assert_called_once()
         assert mock_fastmcp_cls.call_args.args == (adapter,)
         assert mock_fastmcp_cls.call_args.kwargs["version"] == __version__
+        extensions = mock_fastmcp_cls.call_args.kwargs["extensions"]
+        assert len(extensions) == 1
+        assert extensions[0].identifier == "io.ouroboros/subagents"
+        assert extensions[0].settings()["undeclaredBehavior"] == (
+            "parallel_preferred_sequential_fallback"
+        )
         # The SDK builds its own DNS-rebinding settings for this bind spelling,
         # so the adapter passes none of its own.
         mock_instance.run_sse_async.assert_awaited_once_with(
@@ -3672,6 +3678,52 @@ class TestServeTransport:
 
         assert capture.call_count == 3
         assert [call.kwargs["ok"] for call in capture.call_args_list] == [True, False, False]
+
+    async def test_sdk_call_preserves_normalized_host_context_for_handler(self) -> None:
+        """The SDK boundary must not discard client identity/capability facts."""
+        mcp_server_module = pytest.importorskip("mcp.server")
+        from ouroboros.mcp.host_context import current_mcp_host_context
+
+        adapter = MCPServerAdapter()
+        handler = MockToolHandler("ouroboros_sdk_host_context_probe")
+        observed = []
+
+        async def handle(arguments: dict[str, Any]):
+            observed.append(current_mcp_host_context())
+            return Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
+                )
+            )
+
+        handler.handle_mock.side_effect = handle
+        adapter.register_tool(handler)
+        with patch.object(
+            mcp_server_module.MCPServer,
+            "run_stdio_async",
+            new=AsyncMock(),
+        ):
+            await adapter.serve(transport="stdio")
+        sdk_context = SimpleNamespace(
+            session=SimpleNamespace(
+                client_params=SimpleNamespace(client_info=SimpleNamespace(name="claude-code")),
+                client_capabilities=SimpleNamespace(
+                    extensions={"io.ouroboros/subagents": {"mode": "parallel"}},
+                    experimental=None,
+                ),
+            )
+        )
+
+        await adapter._mcp_server.call_tool(
+            "ouroboros_sdk_host_context_probe",
+            {"input": "safe"},
+            sdk_context,
+        )
+
+        assert len(observed) == 1
+        assert observed[0].host_family.value == "claude_code"
+        assert observed[0].subagent_capability.value == "parallel"
+        assert observed[0].dispatch_authority.value == "mcp_host"
 
     async def test_sdk_failure_boundaries_are_captured_exactly_once(self) -> None:
         """Adapter, output-validation, and conversion failures are not double-counted."""

--- a/tests/unit/mcp/test_host_context.py
+++ b/tests/unit/mcp/test_host_context.py
@@ -1,0 +1,148 @@
+"""Request-scoped MCP host capability normalization and dispatch authority."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from ouroboros.backends.capabilities import SubagentDispatchMode
+from ouroboros.mcp.host_context import (
+    DispatchAuthority,
+    HostCapabilitySource,
+    HostFamily,
+    HostIdentityStatus,
+    HostSubagentCapability,
+    MCPHostContext,
+    current_mcp_host_context,
+    from_sdk_context,
+    resolve_request_subagent_dispatch,
+    use_mcp_host_context,
+)
+
+
+def _sdk_context(
+    *,
+    name: str | None = None,
+    extensions: dict[str, dict[str, object]] | None = None,
+    experimental: dict[str, dict[str, object]] | None = None,
+) -> SimpleNamespace:
+    client_info = SimpleNamespace(name=name) if name is not None else None
+    client_params = SimpleNamespace(client_info=client_info) if client_info is not None else None
+    capabilities = SimpleNamespace(extensions=extensions, experimental=experimental)
+    return SimpleNamespace(
+        session=SimpleNamespace(
+            client_params=client_params,
+            client_capabilities=capabilities,
+        )
+    )
+
+
+def test_missing_client_info_is_external_unknown_with_undeclared_capability() -> None:
+    context = from_sdk_context(_sdk_context())
+
+    assert context == MCPHostContext(
+        dispatch_authority=DispatchAuthority.MCP_HOST,
+    )
+
+
+def test_known_client_identity_does_not_imply_subagent_capability() -> None:
+    context = from_sdk_context(_sdk_context(name="claude-code"))
+
+    assert context.host_family is HostFamily.CLAUDE_CODE
+    assert context.identity_status is HostIdentityStatus.KNOWN
+    assert context.subagent_capability is HostSubagentCapability.UNDECLARED
+    assert context.capability_source is HostCapabilitySource.NONE
+
+
+def test_extension_declares_parallel_capability() -> None:
+    context = from_sdk_context(
+        _sdk_context(
+            name="codex",
+            extensions={"io.ouroboros/subagents": {"mode": "parallel"}},
+        )
+    )
+
+    assert context.host_family is HostFamily.CODEX
+    assert context.subagent_capability is HostSubagentCapability.PARALLEL
+    assert context.capability_source is HostCapabilitySource.MCP_EXTENSION
+
+
+def test_legacy_experimental_extension_declares_sequential_capability() -> None:
+    context = from_sdk_context(
+        _sdk_context(
+            name="custom-private-client-name",
+            experimental={"io.ouroboros/subagents": {"parallel": False}},
+        )
+    )
+
+    assert context.host_family is HostFamily.OTHER_KNOWN
+    assert context.subagent_capability is HostSubagentCapability.SEQUENTIAL
+
+
+def test_external_undeclared_host_gets_host_decides_not_worker_sequential() -> None:
+    context = MCPHostContext(dispatch_authority=DispatchAuthority.MCP_HOST)
+
+    with use_mcp_host_context(context):
+        dispatch = resolve_request_subagent_dispatch("gemini", None)
+
+    assert dispatch is SubagentDispatchMode.HOST_DECIDES
+    assert current_mcp_host_context().dispatch_authority is DispatchAuthority.INTERNAL_RUNTIME
+
+
+def test_external_declared_parallel_overrides_worker_backend() -> None:
+    context = MCPHostContext(
+        subagent_capability=HostSubagentCapability.PARALLEL,
+        capability_source=HostCapabilitySource.MCP_EXTENSION,
+        dispatch_authority=DispatchAuthority.MCP_HOST,
+    )
+
+    with use_mcp_host_context(context):
+        dispatch = resolve_request_subagent_dispatch("gemini", None)
+
+    assert dispatch is SubagentDispatchMode.HOST_DRIVEN
+
+
+def test_external_declared_sequential_overrides_host_driven_worker() -> None:
+    context = MCPHostContext(
+        subagent_capability=HostSubagentCapability.SEQUENTIAL,
+        capability_source=HostCapabilitySource.MCP_EXTENSION,
+        dispatch_authority=DispatchAuthority.MCP_HOST,
+    )
+
+    with use_mcp_host_context(context):
+        dispatch = resolve_request_subagent_dispatch("claude", None)
+
+    assert dispatch is SubagentDispatchMode.SEQUENTIAL
+
+
+def test_external_host_does_not_inherit_worker_passive_bridge() -> None:
+    context = MCPHostContext(dispatch_authority=DispatchAuthority.MCP_HOST)
+
+    with use_mcp_host_context(context):
+        dispatch = resolve_request_subagent_dispatch("opencode", "plugin")
+
+    assert dispatch is SubagentDispatchMode.HOST_DECIDES
+
+
+def test_external_opencode_identity_with_plugin_mode_keeps_passive_bridge() -> None:
+    context = MCPHostContext(
+        host_family=HostFamily.OPENCODE,
+        identity_status=HostIdentityStatus.KNOWN,
+        dispatch_authority=DispatchAuthority.MCP_HOST,
+    )
+
+    with use_mcp_host_context(context):
+        dispatch = resolve_request_subagent_dispatch("opencode", "plugin")
+
+    assert dispatch is SubagentDispatchMode.PLUGIN_PASSIVE
+
+
+def test_internal_runtime_keeps_existing_worker_resolution() -> None:
+    assert resolve_request_subagent_dispatch("gemini", None) is SubagentDispatchMode.SEQUENTIAL
+    assert resolve_request_subagent_dispatch("claude", None) is SubagentDispatchMode.HOST_DRIVEN
+
+
+def test_internal_plugin_passive_remains_server_owned() -> None:
+    assert (
+        resolve_request_subagent_dispatch("opencode", "plugin")
+        is SubagentDispatchMode.PLUGIN_PASSIVE
+    )

--- a/tests/unit/mcp/tools/test_fanout_core.py
+++ b/tests/unit/mcp/tools/test_fanout_core.py
@@ -806,6 +806,72 @@ def test_interview_handler_threads_state_dir_into_registry(tmp_path: Any) -> Non
 
 
 @pytest.mark.asyncio
+async def test_lateral_and_submit_emit_privacy_safe_dispatch_telemetry(
+    tmp_path: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "ouroboros.mcp.telemetry_boundary.usage_telemetry.capture_subagent_dispatch",
+        lambda properties: captured.append(properties),
+    )
+    registry = FanoutRegistry(tmp_path)
+    handler = LateralThinkHandler(
+        agent_runtime_backend="gemini",
+        fanout_registry=registry,
+    )
+    produced = await handler.handle(
+        {
+            "problem_context": "stuck",
+            "current_approach": "same",
+            "personas": ["researcher", "contrarian"],
+        }
+    )
+    fanout_id = produced.unwrap().meta["fanout_id"]
+    submit, _ = _bounded_submit(registry, tmp_path)
+    submitted = await submit.handle(
+        {
+            "correlation_key": "context.persona",
+            "fanout_id": fanout_id,
+            "results": [
+                {"key": "researcher", "content": "r"},
+                {"key": "contrarian", "undispatched": True},
+            ],
+        }
+    )
+
+    assert submitted.is_ok
+    assert captured[0] == {
+        "phase": "emitted",
+        "fanout_kind": "lateral_persona_panel",
+        "payload_count": 2,
+        "invocation_surface": "internal_runtime",
+        "dispatch_authority": "internal_runtime",
+        "host_family": "unknown",
+        "host_identity_status": "unknown",
+        "host_capability": "undeclared",
+        "capability_source": "none",
+        "delivery_mode": "inline_runtime",
+        "execution_preference": "sequential",
+        "fallback_strategy": "sequential",
+        "configured_worker_backend": "gemini",
+        "host_worker_mismatch": False,
+        "decision_reason": "configured_internal_runtime",
+        "contract_version": "v2",
+        "fanout_reentry_available": True,
+    }
+    assert captured[1] == {
+        "phase": "submitted",
+        "fanout_kind": "lateral_persona_panel",
+        "submission_status": "complete",
+        "expected_count": 2,
+        "received_count": 1,
+        "undispatched_count": 1,
+        "contract_version": "v2",
+    }
+
+
+@pytest.mark.asyncio
 async def test_lateral_handler_registers_fanout_and_submit_tool_synthesizes(
     tmp_path: Any,
 ) -> None:

--- a/tests/unit/mcp/tools/test_fanout_core.py
+++ b/tests/unit/mcp/tools/test_fanout_core.py
@@ -693,6 +693,9 @@ async def test_a_completed_submission_is_the_only_reply_carrying_a_contract_id(
         skill = (root / "pm" / "SKILL.md").read_text(encoding="utf-8")
         assert "With a `contract_id`, synthesize" in skill, root
         assert "leave out a lane you submitted as\n`undispatched`" in skill, root
+        assert "dispatch_subagents_if_supported" in skill, root
+        assert "process_payloads_sequentially" in skill, root
+        assert "host action selects the execution strategy" in skill, root
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
+++ b/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
@@ -222,7 +222,7 @@ async def test_handler_surfaces_runnable_lateral_review_dispatch() -> None:
     panel = orchestration["panel"]
     assert panel["panel_id"] == "lateral_persona_panel.v1"
     assert panel["mcp_tool"] == "ouroboros_lateral_think"
-    assert panel["dispatch_modes"] == ["plugin", "sequential"]
+    assert panel["dispatch_modes"] == ["plugin", "host_driven", "host_decides", "sequential"]
     assert panel["legacy_dispatch_modes"] == ["inline_fallback"]
     assert panel["parallel_preference"] == "parallel_when_runtime_supports_subagents"
     assert panel["sequential_fallback"] == {
@@ -349,6 +349,22 @@ async def test_advisory_fanout_is_host_driven_stamped_on_codex_runtime() -> None
     # Advisory lanes correlate by lane_id (persona is None on some lanes).
     assert meta["question_advisory_result_correlation_key"] == "context.lane_id"
     assert "subagent_orchestration_instruction" in meta
+
+
+def test_question_advisory_host_decides_contract_is_capability_neutral() -> None:
+    meta = _advisory_meta(SubagentDispatchMode.HOST_DECIDES, runtime_backend="gemini")
+
+    assert meta["question_advisory_dispatch_mode"] == "host_decides"
+    assert meta["question_advisory_host_action"] == "dispatch_subagents_if_supported"
+    assert meta["question_advisory_delivery_mode"] == "inline_host"
+    assert meta["question_advisory_execution_preference"] == "parallel"
+    assert meta["question_advisory_fallback_strategy"] == "sequential"
+    assert "did not declare whether" in meta["subagent_orchestration_instruction"]
+
+    text = append_question_advisory_dispatch("Session sess-render\n\nQ?", meta)
+    assert "dispatch_subagents_if_supported" in text
+    assert "when available" in text
+    assert "otherwise process every payload below sequentially" in text
 
 
 def test_question_advisory_sequential_runtime_emits_processing_contract() -> None:

--- a/tests/unit/mcp/tools/test_lateral_think_handler.py
+++ b/tests/unit/mcp/tools/test_lateral_think_handler.py
@@ -16,6 +16,15 @@ import json
 
 import pytest
 
+from ouroboros.mcp.host_context import (
+    DispatchAuthority,
+    HostCapabilitySource,
+    HostFamily,
+    HostIdentityStatus,
+    HostSubagentCapability,
+    MCPHostContext,
+    use_mcp_host_context,
+)
 from ouroboros.mcp.tools.evaluation_handlers import LateralThinkHandler
 from ouroboros.mcp.tools.subagent import (
     continue_interview_after_lateral_persona_synthesis,
@@ -467,6 +476,92 @@ async def test_claude_code_runtime_emits_host_driven_spawn_directive() -> None:
     assert payload.meta["result_correlation_key"] == "context.persona"
     assert len(payload.meta["payloads"]) == 2
     assert "Host action — spawn subagents" in payload.text_content
+
+
+@pytest.mark.asyncio
+async def test_external_unknown_host_emits_capability_neutral_contract() -> None:
+    """A worker backend cannot make a capability claim about an MCP host."""
+    handler = LateralThinkHandler(agent_runtime_backend="gemini", opencode_mode=None)
+    host = MCPHostContext(
+        host_family=HostFamily.CLAUDE_CODE,
+        identity_status=HostIdentityStatus.KNOWN,
+        dispatch_authority=DispatchAuthority.MCP_HOST,
+    )
+
+    with use_mcp_host_context(host):
+        result = await handler.handle(
+            {
+                "problem_context": "stuck on X",
+                "current_approach": "tried Y",
+                "persona": "all",
+            }
+        )
+
+    assert result.is_ok
+    payload = result.unwrap()
+    assert payload.meta["dispatch_mode"] == "host_decides"
+    assert payload.meta["host_action"] == "dispatch_subagents_if_supported"
+    assert payload.meta["delivery_mode"] == "inline_host"
+    assert payload.meta["execution_preference"] == "parallel"
+    assert payload.meta["fallback_strategy"] == "sequential"
+    assert payload.meta["host_capability"] == "undeclared"
+    assert "no native parallel subagent primitive" not in payload.text_content
+    assert "did not declare whether parallel subagents are available" in payload.text_content
+
+
+@pytest.mark.asyncio
+async def test_external_declared_parallel_overrides_sequential_worker() -> None:
+    handler = LateralThinkHandler(agent_runtime_backend="gemini", opencode_mode=None)
+    host = MCPHostContext(
+        host_family=HostFamily.CODEX,
+        identity_status=HostIdentityStatus.KNOWN,
+        subagent_capability=HostSubagentCapability.PARALLEL,
+        capability_source=HostCapabilitySource.MCP_EXTENSION,
+        dispatch_authority=DispatchAuthority.MCP_HOST,
+    )
+
+    with use_mcp_host_context(host):
+        result = await handler.handle(
+            {
+                "problem_context": "stuck on X",
+                "current_approach": "tried Y",
+                "personas": ["researcher", "simplifier"],
+            }
+        )
+
+    assert result.is_ok
+    assert result.unwrap().meta["dispatch_mode"] == "host_driven"
+    assert result.unwrap().meta["host_action"] == "spawn_subagents"
+
+
+@pytest.mark.asyncio
+async def test_external_declared_sequential_overrides_host_driven_worker() -> None:
+    handler = LateralThinkHandler(agent_runtime_backend="claude", opencode_mode=None)
+    host = MCPHostContext(
+        host_family=HostFamily.CLAUDE_CODE,
+        identity_status=HostIdentityStatus.KNOWN,
+        subagent_capability=HostSubagentCapability.SEQUENTIAL,
+        capability_source=HostCapabilitySource.MCP_EXTENSION,
+        dispatch_authority=DispatchAuthority.MCP_HOST,
+    )
+
+    with use_mcp_host_context(host):
+        result = await handler.handle(
+            {
+                "problem_context": "stuck on X",
+                "current_approach": "tried Y",
+                "personas": ["researcher", "simplifier"],
+            }
+        )
+
+    assert result.is_ok
+    payload = result.unwrap()
+    assert payload.meta["dispatch_mode"] == "sequential"
+    assert payload.meta["host_action"] == "process_payloads_sequentially"
+    assert (
+        "selected execution authority has no native parallel"
+        in payload.meta["subagent_orchestration_instruction"]
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_capabilities.py
+++ b/tests/unit/orchestrator/test_capabilities.py
@@ -4646,7 +4646,7 @@ def test_lateral_persona_panel_metadata_is_structured_without_prose_parsing() ->
     panel = lateral.metadata.orchestration["lateral_panel"]
     assert panel["panel_id"] == "lateral_persona_panel.v1"
     assert panel["mcp_tool"] == "ouroboros_lateral_think"
-    assert panel["dispatch_modes"] == ["plugin", "sequential"]
+    assert panel["dispatch_modes"] == ["plugin", "host_driven", "host_decides", "sequential"]
     assert panel["legacy_dispatch_modes"] == ["inline_fallback"]
     assert panel["parallel_preference"] == "parallel_when_runtime_supports_subagents"
     assert panel["sequential_fallback"] == {

--- a/tests/unit/test_claude_plugin_skill_guide.py
+++ b/tests/unit/test_claude_plugin_skill_guide.py
@@ -17,14 +17,14 @@ def test_claude_plugin_interview_skill_includes_lateral_review_dispatch() -> Non
     skill_path = Path(".claude-plugin") / "skills" / "interview" / "SKILL.md"
     skill_text = skill_path.read_text(encoding="utf-8")
 
-    assert "question_advisory_subagents` is present you MUST fan out" in skill_text
-    assert "Run the advisory lanes through your runtime's native subagent mechanism" in skill_text
+    assert "question_advisory_subagents` is present you MUST process every" in skill_text
+    assert 'dispatch_mode="host_decides"' in skill_text
     assert "Task/Agent" in skill_text
-    assert "spawn one Codex subagent per payload" in skill_text
-    assert "runtimes without a parallel primitive" in skill_text
-    assert 'dispatch_mode="sequential"' in skill_text
-    assert "a reinforcing cue for host-driven runtimes" in skill_text
-    assert "as a prerequisite" in skill_text
+    assert "one native" in skill_text
+    assert "dispatch_subagents_if_supported" in skill_text
+    assert "process_payloads_sequentially" in skill_text
+    assert "host action selects the execution strategy" in skill_text
+    assert "Never reconstruct" in skill_text and "prompts from prose" in skill_text
     assert "`run_lateral_review`" in skill_text
     assert "**Milestone lateral-review dispatch**" in skill_text
     assert "meta.lateral_review_tool_args" in skill_text

--- a/tests/unit/test_claude_plugin_skill_guide.py
+++ b/tests/unit/test_claude_plugin_skill_guide.py
@@ -32,20 +32,19 @@ def test_claude_plugin_interview_skill_includes_lateral_review_dispatch() -> Non
     assert "Main-session direct-answer assistance" in skill_text
 
 
-def test_claude_plugin_unstuck_skill_includes_sequential_dispatch_contract() -> None:
+def test_claude_plugin_unstuck_skill_includes_host_capability_contract() -> None:
     skill_path = Path(".claude-plugin") / "skills" / "unstuck" / "SKILL.md"
     skill_text = skill_path.read_text(encoding="utf-8")
 
     assert (
-        '{"dispatch_mode": "sequential", "legacy_dispatch_mode": "inline_fallback", '
-        '"persona_count": N, "payloads": [...]}'
+        '{"dispatch_mode": "host_decides", "host_action": "dispatch_subagents_if_supported"'
     ) in skill_text
-    assert (
-        'Debate response (`dispatch_mode = "sequential"`; '
-        '`legacy_dispatch_mode = "inline_fallback"` may also be present)'
-    ) in skill_text
+    assert '"execution_preference": "parallel"' in skill_text
+    assert '"fallback_strategy": "sequential"' in skill_text
+    assert "capability-neutral `host_decides`" in skill_text
     assert "##### Debate, constrained runtime without sub-agent dispatch" in skill_text
     assert 'dispatch_mode="sequential"' in skill_text
+    assert 'dispatch_mode="host_decides"' in skill_text
     assert "result_correlation_key" in skill_text
-    assert 'legacy_dispatch_mode="inline_fallback"` as compatibility' in skill_text
+    assert 'legacy_dispatch_mode="inline_fallback"' in skill_text
     assert 'Debate response (`dispatch_mode = "inline_fallback"`)' not in skill_text

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -605,6 +605,63 @@ class TestCapture:
         assert sent[0]["properties"]["phase"] == "completion"
         assert sent[0]["properties"]["ok"] is False
 
+    def test_subagent_dispatch_event_keeps_only_closed_values(
+        self, sent: list[dict[str, Any]]
+    ) -> None:
+        telemetry.capture_subagent_dispatch(
+            {
+                "phase": "emitted",
+                "fanout_kind": "lateral_persona_panel",
+                "payload_count": 5,
+                "invocation_surface": "mcp_host",
+                "dispatch_authority": "mcp_host",
+                "host_family": "claude_code",
+                "host_identity_status": "known",
+                "host_capability": "undeclared",
+                "capability_source": "none",
+                "delivery_mode": "inline_host",
+                "execution_preference": "parallel",
+                "fallback_strategy": "sequential",
+                "configured_worker_backend": "gemini",
+                "host_worker_mismatch": True,
+                "decision_reason": "host_capability_undeclared",
+                "contract_version": "v2",
+                "fanout_reentry_available": True,
+                "fanout_id": "fanout_private",
+                "prompt": "/private/repo/secret",
+            }
+        )
+        telemetry.flush(timeout=2.0)
+
+        assert len(sent) == 1
+        event = sent[0]
+        assert event["event"] == "subagent_dispatch"
+        props = event["properties"]
+        assert props["host_family"] == "claude_code"
+        assert props["configured_worker_backend"] == "gemini"
+        assert props["host_worker_mismatch"] is True
+        assert "fanout_id" not in props
+        assert "prompt" not in props
+        assert "private" not in str(props)
+
+    def test_subagent_dispatch_folds_custom_backend_and_rejects_open_enums(
+        self, sent: list[dict[str, Any]]
+    ) -> None:
+        telemetry.capture_subagent_dispatch(
+            {
+                "phase": "emitted",
+                "fanout_kind": "private_customer_fanout",
+                "host_family": "private-client-name",
+                "configured_worker_backend": "private-backend",
+            }
+        )
+        telemetry.flush(timeout=2.0)
+
+        props = sent[0]["properties"]
+        assert props["configured_worker_backend"] == "other"
+        assert "fanout_kind" not in props
+        assert "host_family" not in props
+
     def test_non_ouroboros_tool_skipped(self, sent: list[dict[str, Any]]) -> None:
         telemetry.capture_tool_call("some_other_tool", ok=True)
         telemetry.flush(timeout=2.0)


### PR DESCRIPTION
## Problem

`ouroboros_lateral_think` and question advisory fan-out inferred the calling MCP host's subagent capability from the configured worker/REFLECT backend. A Claude Code host connected to a server with a Gemini worker could therefore receive a false `process_payloads_sequentially` instruction. Mapping an unknown host to Claude would create the opposite false claim.

## Solution

- Preserve and normalize request-scoped MCP `clientInfo` and client capabilities instead of discarding SDK context.
- Advertise and consume the `io.ouroboros/subagents` MCP capability extension.
- Separate MCP host dispatch authority from internal worker-runtime routing.
- Add a capability-neutral `host_decides` contract when the host declares no authoritative subagent capability:
  - prefer native parallel fan-out when available;
  - use the same payloads sequentially otherwise.
- Keep explicit parallel, explicit sequential, internal runtime, and confirmed OpenCode passive-bridge paths deterministic.
- Apply the contract consistently to lateral, interview advisory, PM advisory, structured metadata, visible directives, and the text-only Base64 compatibility block.

## Telemetry

Add an allowlisted `subagent_dispatch` PostHog event for:

- `phase=emitted`: normalized host family/capability, authority, delivery mode, preference/fallback, worker mismatch, bounded payload count, and re-entry availability.
- `phase=submitted`: completion status and bounded expected/received/undispatched counts.

Raw client names, client versions, fanout/session IDs, prompts, contexts, outputs, paths, and custom backend names are never sent. Custom values fold to closed `other`/`other_known`/`unknown` enums. `TELEMETRY.md` documents the exact property allowlist.

## Checks passed

- [x] Ruff lint on changed Python files
- [x] Ruff format on changed Python files
- [x] Mypy on 13 changed source files
- [x] Pytest: 476 related tests passed
- [x] MCP-extra adapter tests: 2 passed

## Test plan

- Unknown and identity-known/capability-undeclared MCP hosts emit `host_decides`.
- Declared parallel and sequential capabilities override mismatched worker backends.
- Server-composed Claude-host/Gemini-REFLECT mismatch no longer emits a false sequential claim.
- External hosts do not inherit an OpenCode worker's passive bridge; confirmed OpenCode plugin identity remains passive.
- SDK request context reaches the handler boundary.
- Emitted/submitted telemetry is privacy-safe and excludes identifiers/content.
- Shipped skill and Claude plugin mirror describe the same contract.

Closes #2189