### PR TITLE
fix(verification): read every occurrence before calling a constant verified

### DIFF
--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -6,7 +6,7 @@ by scanning project files with regex patterns. T3/T4 are skipped.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import glob
 import logging
 import os
@@ -34,6 +34,7 @@ MAX_FILE_SIZE = 50 * 1024  # 50KB per file
 MAX_FILES_PER_HINT = 100
 MAX_PATTERN_LENGTH = 200  # Limit LLM-generated regex length to reduce ReDoS risk
 MAX_SCALAR_LENGTH = 4096
+MAX_OCCURRENCES_PER_FILE = 64  # Bound the agreement scan over an untrusted pattern
 
 # Whether a pattern can match the empty string is decided by *reading* it, never
 # by running it. Running it is what a hostile pattern is waiting for: `(?:)
@@ -628,7 +629,20 @@ def _skip_inline_space(text: str, index: int) -> int:
 
 
 def _scan_scalar(text: str, index: int) -> tuple[str, int] | None:
-    """Read one bounded scalar without truncating quoted source values."""
+    """Read one bounded scalar without truncating quoted source values.
+
+    An unquoted scan stops at a bracket it did not open, and now also at one it
+    would have to: a scalar is a value written whole, and `(` or `[` is the
+    start of something whose end is somewhere this does not look. Without that,
+    a value wrapped across lines the way a formatter wraps one --
+
+        WARMUP_FRAMES = (
+            10
+        )
+
+    -- scanned to the line end and returned `(`, which then reached the
+    comparison as what the file says the constant is.
+    """
     index = _skip_inline_space(text, index)
     if index >= len(text) or text[index] in "\r\n":
         return None
@@ -664,7 +678,7 @@ def _scan_scalar(text: str, index: int) -> tuple[str, int] | None:
     while (
         index < len(text)
         and index - start <= MAX_SCALAR_LENGTH
-        and text[index] not in "\"'\r\n\t ,;)]}{"
+        and text[index] not in "\"'\r\n\t ,;([)]}{\\="
     ):
         index += 1
     if index == start or index - start > MAX_SCALAR_LENGTH:
@@ -691,31 +705,149 @@ def _has_complete_scalar_terminator(text: str, index: int, operator: str | None)
     return text[index] in ",;)]}"
 
 
-def _extract_following_scalar(content: str, index: int) -> str:
-    """Extract a direct, assigned, or parenthesized scalar at index."""
+class _UnreadBinding:
+    """An occurrence that binds a value the scanner could not read.
+
+    Distinct from ``None``, which is an occurrence that binds nothing at all.
+    Both are failures to read, but only one of them is a place where the file
+    says what the constant is: `X: int = 3`, `X = int("3")`, `X = 3 if c else 4`
+    and `X = ""` are declarations, and the scanner reading none of them does not
+    make them prose. Spelling them the same way is what let a declaration go
+    missing from the comparison rather than unsettle it.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostic only
+        return "<unread binding>"
+
+
+UNREAD_BINDING = _UnreadBinding()
+
+Reading = str | _UnreadBinding | None
+
+
+def _binds_at(content: str, index: int) -> bool:
+    """Whether a value is written at index, readable or not.
+
+    The three shapes are the ones the scanner itself looks for: an assignment or
+    mapping operator after the match, a parenthesized argument after it, and an
+    operator the pattern consumed and left behind it — `NAME\\s*=\\s*` is one of
+    the shapes the extractor's own prompt asks the model for.
+
+    One closing quote may stand between the match and the operator, because a
+    quoted key is a binding written the way JSON, YAML and every settings dict
+    write one. A quote with no operator after it is still nothing bound: prose
+    that names the constant in quotes reaches the same place and stops here.
+
+    Failing all three, an operator anywhere later on the same physical line is
+    taken as one too, because a declaration is free to put a type, a modifier or
+    a default between the name and the operator — `NAME int = 10`, `NAME ?= 10`,
+    `NAME: int = 10` — and requiring adjacency read every one of them as prose.
+    Prose that happens to carry an operator is then called a binding it cannot
+    read, which costs the criterion its verdict and never its soundness; a
+    declaration read as prose costs the opposite, and vanishes from the very
+    agreement this scanner exists to compute.
+    """
+    at = _skip_inline_space(content, index)
+    if at < len(content) and content[at] in "\"'":
+        at = _skip_inline_space(content, at + 1)
+    if at < len(content) and content[at] in "=:(":
+        return True
+    if _preceding_assignment_operator(content, index) is not None:
+        return True
+    line_end = content.find("\n", index)
+    rest = content[index:] if line_end == -1 else content[index:line_end]
+    return "=" in rest or ":" in rest
+
+
+def _extract_following_scalar(content: str, index: int) -> Reading:
+    """Extract a direct, assigned, or parenthesized scalar at index.
+
+    Three outcomes, because there are three things that can be at an occurrence
+    and only one of them is a value. A string is what was read. ``None`` is
+    prose — a mention with nothing bound to it, which settles nothing and has to
+    settle nothing. ``UNREAD_BINDING`` is a declaration this scanner cannot
+    parse, which settles nothing either but is not free of consequence: the file
+    says what the constant is there, so no reading taken elsewhere can be called
+    what the candidates agree on.
+
+    A scalar scanned as blank is one of those declarations. `X = ""` and
+    `X = " "` reach the scanner and the strings they yield are the one thing
+    every file holds anyway, so reading one settles no criterion — but the
+    binding is still written, so it counts as one that went unread rather than
+    as prose.
+    """
+    scanned = _scan_following_scalar(content, index)
+    if scanned is not None and scanned.strip():
+        return scanned
+    return UNREAD_BINDING if _binds_at(content, index) else None
+
+
+def _scan_following_scalar(content: str, index: int) -> str | None:
+    """Scan a direct, assigned, or parenthesized scalar at index, blanks and all."""
     index = _skip_inline_space(content, index)
     if index < len(content) and content[index] in "=:":
         operator = content[index]
         scanned = _scan_scalar(content, index + 1)
         if scanned is None:
-            return ""
+            return None
         value, end = scanned
-        return value if _has_complete_scalar_terminator(content, end, operator) else ""
+        return value if _has_complete_scalar_terminator(content, end, operator) else None
     if index < len(content) and content[index] == "(":
         scanned = _scan_scalar(content, index + 1)
         if scanned is None:
-            return ""
+            return None
         value, end = scanned
         end = _skip_inline_space(content, end)
         if end >= len(content) or content[end] != ")":
-            return ""
-        return value if _has_complete_scalar_terminator(content, end + 1, None) else ""
+            return None
+        return value if _has_complete_scalar_terminator(content, end + 1, None) else None
     scanned = _scan_scalar(content, index)
     if scanned is None:
-        return ""
+        return None
     value, end = scanned
     operator = _preceding_assignment_operator(content, index)
-    return value if _has_complete_scalar_terminator(content, end, operator) else ""
+    return value if _has_complete_scalar_terminator(content, end, operator) else None
+
+
+@dataclass
+class _Readings:
+    """What a pattern found at its occurrences, and the file each was found in.
+
+    Distinctness is judged on the stripped value, because that is what the
+    comparison judges equality on. Occurrences that read the same value are one
+    reading however many there are; two that read different values are a
+    disagreement however far apart they sit.
+
+    An occurrence that binds a value the scanner could not read is kept too, as
+    the file it was written in. It contributes no value to compare and it cannot
+    be made to agree with one, so a single one of them decides the outcome on
+    its own — which is why it is recorded rather than dropped.
+
+    Both of those settle the outcome, and nothing read afterwards can unsettle
+    it, so collection stops there.
+    """
+
+    values: list[tuple[str, str]] = field(default_factory=list)
+    seen: set[str] = field(default_factory=set)
+    unread_in: str | None = None
+
+    @property
+    def settled(self) -> bool:
+        """Whether no further occurrence could change the outcome."""
+        return self.unread_in is not None or len(self.values) > 1
+
+    def add(self, reading: Reading, file_path: str) -> None:
+        if reading is None or self.settled:
+            return
+        if isinstance(reading, _UnreadBinding):
+            self.unread_in = file_path
+            return
+        if reading.strip() in self.seen:
+            return
+        self.seen.add(reading.strip())
+        self.values.append((reading, file_path))
 
 
 @dataclass
@@ -897,6 +1029,91 @@ class SpecVerifier:
             detail=detail,
         )
 
+    def _verdict_from_readings(
+        self,
+        assertion: SpecAssertion,
+        readings: _Readings,
+        first_match_in: str,
+    ) -> SpecVerificationResult:
+        """Compare the expected value against what the candidates read as.
+
+        Every occurrence of the pattern is read, in every candidate file, rather
+        than the first match in the first file that had one. Taking the first
+        was a choice among readings that nothing here gives grounds for: a
+        constant is routinely written twice, once in a comment above the
+        declaration and once in the declaration itself, and which of the two
+        `search` returns is decided by line order. Whichever way that fell, the
+        verdict was reported as what the source says — a decoy comment above a
+        contradicting declaration minted a PASS, and one above an agreeing
+        declaration minted a DISCREPANCY. The same held between files: a
+        mention in the first file the glob happened to yield settled a criterion
+        about a constant bound differently in the file that declares it.
+
+        So the readings have to agree. Where they do, the candidates say one
+        thing and the comparison is about that thing. Where they disagree there
+        is no single value they can be said to hold, and that is missing
+        evidence rather than counter-evidence: UNVERIFIABLE, not DISCREPANCY.
+
+        An occurrence that binds a value this scanner cannot read has the same
+        effect for the same reason. It is a place the file states the constant,
+        so a reading taken anywhere else is not what the candidates agree on —
+        it is only what was legible. Dropping such an occurrence would put the
+        conflation this method exists to remove back one level up, with an
+        unread declaration and a bare mention spelled the same way.
+
+        This does not make a comment unreadable — nothing here can tell source
+        from prose in a file whose language it does not know. It removes the
+        silent preference between them, so a disagreeing comment costs the
+        verdict its authority instead of deciding it.
+        """
+        if readings.unread_in is not None:
+            return SpecVerificationResult(
+                assertion=assertion,
+                file_path=readings.unread_in,
+                outcome=VerificationOutcome.UNVERIFIABLE,
+                detail=(
+                    f"Pattern matched a binding in {os.path.basename(readings.unread_in)} "
+                    "whose value could not be read; nothing read elsewhere can stand for it"
+                ),
+            )
+        if not readings.values:
+            # Every occurrence landed on prose, a comment, or a bare mention —
+            # somewhere no value follows it. Nothing was read, so there is
+            # nothing here that agrees with the expected value or contradicts it.
+            return SpecVerificationResult(
+                assertion=assertion,
+                file_path=first_match_in,
+                outcome=VerificationOutcome.UNVERIFIABLE,
+                detail=(
+                    f"Pattern matched in {os.path.basename(first_match_in)} "
+                    "but no value follows the match to compare"
+                ),
+            )
+        if len(readings.values) > 1:
+            (first, first_in), (second, second_in) = readings.values[0], readings.values[1]
+            return SpecVerificationResult(
+                assertion=assertion,
+                file_path=first_in,
+                outcome=VerificationOutcome.UNVERIFIABLE,
+                detail=(
+                    f"Pattern reads '{first}' in {os.path.basename(first_in)} and "
+                    f"'{second}' in {os.path.basename(second_in)}; no single value to compare"
+                ),
+            )
+
+        actual, found_in = readings.values[0]
+        verified = assertion.expected_value.strip() == actual.strip()
+        return SpecVerificationResult(
+            assertion=assertion,
+            outcome=(VerificationOutcome.VERIFIED if verified else VerificationOutcome.DISCREPANCY),
+            actual_value=actual,
+            file_path=found_in,
+            detail=(
+                f"Expected '{assertion.expected_value}', found '{actual}' "
+                f"in {os.path.basename(found_in)}"
+            ),
+        )
+
     def _verify_constant(self, assertion: SpecAssertion) -> SpecVerificationResult:
         """Verify a T1 constant/config assertion by searching source files."""
         if not assertion.pattern:
@@ -925,41 +1142,55 @@ class SpecVerifier:
             )
 
         readable_files = 0
+        first_match_in: str | None = None
+        readings = _Readings()
         for file_path in files:
             content = self._read_file(file_path)
             if content is None:
                 continue
             readable_files += 1
 
-            match = pattern.search(content)
-            if match:
-                # Extract the value after the pattern
-                actual = self._extract_value_after_match(content, match)
-                if assertion.expected_value:
-                    verified = assertion.expected_value.strip() == actual.strip()
-                    return SpecVerificationResult(
-                        assertion=assertion,
-                        outcome=(
-                            VerificationOutcome.VERIFIED
-                            if verified
-                            else VerificationOutcome.DISCREPANCY
-                        ),
-                        actual_value=actual,
-                        file_path=file_path,
-                        detail=(
-                            f"Expected '{assertion.expected_value}', "
-                            f"found '{actual}' in {os.path.basename(file_path)}"
-                        ),
-                    )
-                else:
-                    # Pattern found, no expected value to check
-                    return SpecVerificationResult(
-                        assertion=assertion,
-                        outcome=VerificationOutcome.VERIFIED,
-                        actual_value=actual,
-                        file_path=file_path,
-                        detail=f"Pattern found in {os.path.basename(file_path)}",
-                    )
+            # Lazily, and no further than the outcome depends on: the pattern is
+            # untrusted model output, so every byte scanned after the answer is
+            # settled is work an author of the pattern chose.
+            occurrences = pattern.finditer(content)
+            first_occurrence = next(occurrences, None)
+            if first_occurrence is None:
+                continue
+            if not assertion.expected_value:
+                # Pattern found, no expected value to check
+                first_reading = self._extract_value_after_match(content, first_occurrence)
+                return SpecVerificationResult(
+                    assertion=assertion,
+                    outcome=VerificationOutcome.VERIFIED,
+                    actual_value=first_reading if isinstance(first_reading, str) else "",
+                    file_path=file_path,
+                    detail=f"Pattern found in {os.path.basename(file_path)}",
+                )
+            if first_match_in is None:
+                first_match_in = file_path
+            readings.add(self._extract_value_after_match(content, first_occurrence), file_path)
+            read_here = 1
+            while not readings.settled:
+                if read_here >= MAX_OCCURRENCES_PER_FILE:
+                    # The cap was reached with the readings still agreeing. What
+                    # the rest of the file says is unknown, and unknown cannot be
+                    # part of an agreement, so it counts as a binding gone unread.
+                    readings.add(UNREAD_BINDING, file_path)
+                    break
+                occurrence = next(occurrences, None)
+                if occurrence is None:
+                    break
+                readings.add(self._extract_value_after_match(content, occurrence), file_path)
+                read_here += 1
+            if readings.settled:
+                # Readings that differ, or a binding that could not be read, already
+                # settle it, and stopping here keeps both the work and the reported
+                # detail bounded.
+                break
+
+        if first_match_in is not None:
+            return self._verdict_from_readings(assertion, readings, first_match_in)
 
         if readable_files == 0:
             return SpecVerificationResult(
@@ -1082,7 +1313,7 @@ class SpecVerifier:
         except (OSError, PermissionError):
             return None
 
-    def _extract_value_after_match(self, content: str, match: re.Match) -> str:
+    def _extract_value_after_match(self, content: str, match: re.Match) -> Reading:
         """Extract the value immediately following a regex match.
 
         Handles common patterns:
@@ -1090,5 +1321,8 @@ class SpecVerifier:
         - VAR: 10
         - VAR(10)
         - "value"
+
+        Returns ``None`` when nothing is bound at the match, and
+        ``UNREAD_BINDING`` when something is bound there that this cannot read.
         """
         return _extract_following_scalar(content, match.end())

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -17,6 +18,7 @@ import pytest
 
 from ouroboros.core.types import Result
 from ouroboros.providers.base import CompletionResponse
+from ouroboros.verification import verifier as verifier_module
 from ouroboros.verification.extractor import AssertionExtractor
 from ouroboros.verification.models import (
     ACVerificationReport,
@@ -27,6 +29,12 @@ from ouroboros.verification.models import (
     VerificationTier,
 )
 from ouroboros.verification.verifier import SpecVerifier
+
+# `MAX_OCCURRENCES_PER_FILE` is read off the module rather than imported by name on
+# purpose. The proof that a regression test is a regression is running it against the
+# verifier from before the fix, and a module-level import of a name that fix introduces
+# makes this whole file unimportable there -- one missing constant then hides the
+# baseline result for every test in it, not just the one that needs it.
 
 # -- Model Tests --
 
@@ -725,6 +733,406 @@ class TestSpecVerifier:
         assert summary.verified_count == 0
         assert summary.failed_count == 1
         assert summary.discrepancy_count == 1
+
+    def _warmup_assertion(self, pattern: str, expected: str = "10") -> SpecAssertion:
+        return SpecAssertion(
+            ac_index=0,
+            ac_text="Warmup frames should be 10",
+            tier=VerificationTier.T1_CONSTANT,
+            pattern=pattern,
+            expected_value=expected,
+            file_hint="*.py",
+        )
+
+    def test_t1_a_mention_beside_the_declaration_is_read_as_the_declaration(self) -> None:
+        """A match that reads no value does not outvote one that reads the value.
+
+        The pattern lands twice: once in the comment, where nothing assignable
+        follows, and once on the declaration. Taking the first used to report
+        DISCREPANCY — the source contradicts the criterion — about a file that
+        satisfies it one line down. The comment reads nothing, so it is nothing
+        to weigh, and the file has exactly one value in it.
+        """
+        project = self._create_project(
+            {
+                "config.py": (
+                    "# WARMUP_FRAMES controls how many frames we discard\nWARMUP_FRAMES = 10\n"
+                ),
+            }
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (self._warmup_assertion(r"WARMUP_FRAMES"),), agent_results={0: True}
+        )
+
+        result = summary.reports[0].results[0]
+        assert result.outcome is VerificationOutcome.VERIFIED
+        assert result.actual_value == "10"
+        assert summary.confirmed_discrepancy_count == 0
+        assert summary.override_approval is None
+        assert summary.reports[0].verified_pass is True
+
+    def test_t1_a_mention_with_no_declaration_anywhere_is_unverifiable(self) -> None:
+        """Prose that names the constant is not source that contradicts it.
+
+        Nothing in this file assigns anything, so no reading is available at
+        all. Strict mode still refuses to approve — absence of evidence is
+        blocking — but it is recorded as absence rather than as a source that
+        disagrees with the expectation.
+        """
+        project = self._create_project(
+            {"config.py": "# WARMUP_FRAMES controls how many frames we discard\n"}
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (self._warmup_assertion(r"WARMUP_FRAMES"),), agent_results={0: True}
+        )
+
+        result = summary.reports[0].results[0]
+        assert result.outcome is VerificationOutcome.UNVERIFIABLE
+        assert summary.confirmed_discrepancy_count == 0
+        assert summary.unverifiable_count == 1
+        assert summary.verified_count == 0
+        assert summary.override_approval is False
+
+    def test_t1_a_decoy_comment_cannot_outrank_the_declaration_it_contradicts(self) -> None:
+        """The value the criterion wants, written in a comment above a different one.
+
+        This is the pattern shape the extractor's own prompt asks the model for,
+        so the comment match lands directly on a readable scalar. Reading only
+        the first occurrence reported VERIFIED — "found '10' in config.py" —
+        while what the interpreter binds is 3. Two readings that disagree are
+        not a value the file holds.
+        """
+        project = self._create_project({"config.py": "# WARMUP_FRAMES = 10\nWARMUP_FRAMES = 3\n"})
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (self._warmup_assertion(r"WARMUP_FRAMES\s*=\s*"),), agent_results={0: True}
+        )
+
+        result = summary.reports[0].results[0]
+        assert result.outcome is VerificationOutcome.UNVERIFIABLE
+        assert summary.verified_count == 0
+        assert summary.override_approval is False
+
+    def test_t1_a_decoy_comment_cannot_contradict_the_declaration_that_meets_it(self) -> None:
+        """The same shape, opposite polarity, and the worse of the two.
+
+        Here the declaration does meet the criterion and the stale comment above
+        it does not. Reading only the first occurrence reported DISCREPANCY,
+        which blocks in strict and non-strict mode alike and is never withdrawn
+        by ``_demoted_from_overturning`` — a verdict that the source contradicts
+        a criterion the source meets.
+        """
+        project = self._create_project({"config.py": "# WARMUP_FRAMES = 3\nWARMUP_FRAMES = 10\n"})
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (self._warmup_assertion(r"WARMUP_FRAMES\s*=\s*"),), agent_results={0: True}
+        )
+
+        result = summary.reports[0].results[0]
+        assert result.outcome is VerificationOutcome.UNVERIFIABLE
+        assert summary.confirmed_discrepancy_count == 0
+        assert summary.override_approval is False
+
+    def test_t1_a_mention_in_one_file_cannot_settle_a_constant_bound_in_another(self) -> None:
+        """Which file the glob yields first is not a fact about the criterion.
+
+        The same choice rule ran between files as within one: the first file
+        with a match decided the verdict and the rest were never opened. A
+        criterion about a constant declared in ``settings.py`` was answered from
+        a note in whichever file sorted ahead of it, and the file that declares
+        it went unread.
+        """
+        project = self._create_project(
+            {
+                "a_notes.py": "# agreed default:\n# MAX_RETRIES = 5\n",
+                "settings.py": "MAX_RETRIES = 1\n",
+            }
+        )
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Retries should be 5",
+            tier=VerificationTier.T1_CONSTANT,
+            pattern=r"MAX_RETRIES\s*=\s*",
+            expected_value="5",
+            file_hint="*.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        result = summary.reports[0].results[0]
+        assert result.outcome is VerificationOutcome.UNVERIFIABLE
+        assert summary.verified_count == 0
+        assert summary.override_approval is False
+
+    def test_t1_expected_value_of_only_spaces_cannot_be_met_by_a_blank_reading(
+        self,
+    ) -> None:
+        """A scalar that is only whitespace is not a value the criterion can meet.
+
+        ``TOKEN = ""`` does reach the scanner and does yield a string, and an
+        expectation of only spaces strips to the same nothing that string does,
+        so the comparison used to return VERIFIED for a file whose constant is
+        empty. Blank space is the one thing every file holds, so reading one
+        settles no criterion and is spelled the same way as reading nothing.
+        """
+        project = self._create_project({"config.py": 'WARMUP_FRAMES = ""\n'})
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (self._warmup_assertion(r"WARMUP_FRAMES\s*=\s*", expected="   "),),
+            agent_results={0: True},
+        )
+
+        assert summary.verified_count == 0
+        assert summary.unverifiable_count == 1
+        assert summary.override_approval is False
+
+    @pytest.mark.parametrize(
+        ("label", "declaration"),
+        [
+            ("call", 'WARMUP_FRAMES = int("3")'),
+            ("expression", "WARMUP_FRAMES = 1 + 2"),
+            ("conditional", "WARMUP_FRAMES = 3 if RELEASE else 10"),
+            ("annotated", "WARMUP_FRAMES: int = 3"),
+            ("quoted key", '{"WARMUP_FRAMES": 3}'),
+            ("blank", 'WARMUP_FRAMES = ""'),
+        ],
+    )
+    def test_t1_a_declaration_the_scanner_cannot_read_is_not_a_bare_mention(
+        self, label: str, declaration: str
+    ) -> None:
+        """A binding that yields no reading still costs a decoy its authority.
+
+        Requiring the readings to agree is only worth something if a
+        declaration takes part in the agreement. These six are ordinary
+        Python, and the scanner reads a value from none of them: it bounds a
+        scalar, and a call, an expression, a conditional, a type annotation, a
+        quoted key and a blank string are not that. Counting the miss as
+        nothing-was-written puts an unread declaration and a bare mention back
+        under one spelling, and the decoy beside it becomes the file's only
+        reading — unanimous with itself, and VERIFIED against a file the
+        interpreter binds to 3.
+
+        UNVERIFIABLE is the whole of the claim: the constant is stated here in
+        a form this cannot read, so nothing read elsewhere is what the
+        candidates say.
+        """
+        project = self._create_project({"config.py": f"{declaration}\n# WARMUP_FRAMES = 10\n"})
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (self._warmup_assertion(r"WARMUP_FRAMES"),), agent_results={0: True}
+        )
+
+        result = summary.reports[0].results[0]
+        assert result.outcome is VerificationOutcome.UNVERIFIABLE, label
+        assert result.actual_value == "", label
+        assert summary.verified_count == 0, label
+        assert summary.override_approval is False, label
+
+    def test_t1_an_unread_declaration_in_one_file_unsettles_a_reading_in_another(
+        self,
+    ) -> None:
+        """The same holds across files, where no comment is needed at all.
+
+        ``settings.py`` states the constant in a form the scanner cannot read
+        and ``a_notes.py`` states it in one it can. Dropping the unreadable
+        occurrence leaves the note as the sole reading, and the criterion is
+        answered out of the file that does not declare it.
+        """
+        project = self._create_project(
+            {
+                "a_notes.py": "# agreed default:\n# MAX_RETRIES = 5\n",
+                "settings.py": 'MAX_RETRIES = int("1")\n',
+            }
+        )
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Retries should be 5",
+            tier=VerificationTier.T1_CONSTANT,
+            pattern=r"MAX_RETRIES\s*=\s*",
+            expected_value="5",
+            file_hint="*.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        result = summary.reports[0].results[0]
+        assert result.outcome is VerificationOutcome.UNVERIFIABLE
+        assert summary.verified_count == 0
+        assert summary.override_approval is False
+
+    def test_t1_prose_naming_the_constant_in_quotes_is_still_prose(self) -> None:
+        """The quoted-key allowance must not swallow a mention in prose.
+
+        A quoted name may be a binding — JSON, YAML and every settings dict
+        write one that way — so one closing quote is allowed to stand between
+        the match and the operator. Nothing follows the quote here, so this
+        occurrence binds nothing and the declaration below is read normally.
+        """
+        project = self._create_project(
+            {"config.py": '# the "WARMUP_FRAMES" knob\nWARMUP_FRAMES = 10\n'}
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (self._warmup_assertion(r"WARMUP_FRAMES"),), agent_results={0: True}
+        )
+
+        result = summary.reports[0].results[0]
+        assert result.outcome is VerificationOutcome.VERIFIED
+        assert result.actual_value == "10"
+        assert summary.override_approval is None
+        assert summary.reports[0].verified_pass is True
+
+    @pytest.mark.parametrize(("opening", "closing"), [("(", ")"), ("[", "]")])
+    def test_t1_a_value_wrapped_across_lines_is_not_read_as_its_bracket(
+        self, opening: str, closing: str
+    ) -> None:
+        """A scalar is a value written whole, so a bracket is not one.
+
+        A formatter wrapping a value across lines used to make the scan stop at
+        the line end and return the bracket, which reached the comparison as what
+        the file says the constant is -- a DISCREPANCY manufactured out of
+        punctuation. The declaration is real, so this is a binding that went
+        unread, not prose.
+        """
+        project = self._create_project(
+            {"config.py": f"WARMUP_FRAMES = {opening}\n    10\n{closing}\n"}
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (self._warmup_assertion(r"WARMUP_FRAMES"),), agent_results={0: True}
+        )
+
+        result = summary.reports[0].results[0]
+        assert result.outcome is VerificationOutcome.UNVERIFIABLE
+        assert result.actual_value == ""
+        assert summary.override_approval is False
+
+    def test_t1_a_line_continuation_is_not_the_value_it_continues(self) -> None:
+        """The same assignment laid out two ways cannot get two verdicts.
+
+        `(` and `[` were added to the stop set because a scalar is a value
+        written whole; `\\` continues a line for exactly the same reason and was
+        left in, so the scan returned the backslash as what the file says the
+        constant is. That reaches the comparison as a DISCREPANCY made out of
+        punctuation -- the arm that blocks in strict and non-strict mode alike
+        and that nothing withdraws -- against a file the interpreter binds to 10.
+        """
+        project = self._create_project({"config.py": "WARMUP_FRAMES = \\\n    10\n"})
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (self._warmup_assertion(r"WARMUP_FRAMES"),), agent_results={0: True}
+        )
+
+        result = summary.reports[0].results[0]
+        assert result.outcome is VerificationOutcome.UNVERIFIABLE
+        assert result.actual_value == ""
+        assert summary.override_approval is False
+
+    def test_t1_an_operator_inside_the_scalar_is_not_part_of_the_value(self) -> None:
+        """A value is what follows the operator, not the operator written twice.
+
+        An annotated assignment spelled without spaces puts the whole of
+        `:int=10` where the scalar was expected. Only the leading `:` was
+        skipped, so `int=10` was read as what the file says the constant is and
+        compared against `10` -- a DISCREPANCY made out of the declaration's own
+        syntax, in the arm that blocks in strict and non-strict mode alike. `=`
+        joins the stop set, which cannot truncate an ordinary `X = 10` because
+        the scan starts after that operator; a token that carries an operator of
+        its own is a binding this cannot read.
+        """
+        project = self._create_project({"config.py": "WARMUP_FRAMES:int=10\n"})
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (self._warmup_assertion(r"WARMUP_FRAMES"),), agent_results={0: True}
+        )
+
+        result = summary.reports[0].results[0]
+        assert result.outcome is VerificationOutcome.UNVERIFIABLE
+        assert result.actual_value == ""
+        assert summary.override_approval is False
+
+    @pytest.mark.parametrize(
+        "declaration",
+        [
+            "WARMUP_FRAMES ?= 10",
+            "WARMUP_FRAMES += 10",
+            "const WARMUP_FRAMES int = 10",
+            "WARMUP_FRAMES, FPS = 10, 30",
+        ],
+    )
+    def test_t1_a_declaration_is_not_prose_because_a_token_precedes_its_operator(
+        self, declaration: str
+    ) -> None:
+        """A declaration that took part in no agreement is a declaration dropped.
+
+        Requiring the operator to sit adjacent to the name read every one of
+        these as prose -- the bucket that settles nothing -- so the stale comment
+        above became the file's sole unanimous reading and minted VERIFIED
+        against a file that declares 10. Prose carrying an operator is merely
+        unreadable, which costs a verdict; a declaration read as prose costs
+        soundness.
+        """
+        project = self._create_project({"config.py": f"# WARMUP_FRAMES = 99\n{declaration}\n"})
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (self._warmup_assertion(r"WARMUP_FRAMES", expected="99"),),
+            agent_results={0: True},
+        )
+
+        result = summary.reports[0].results[0]
+        assert result.outcome is not VerificationOutcome.VERIFIED
+        assert result.actual_value == ""
+        assert summary.override_approval is not True
+
+    def test_t1_the_occurrence_scan_stops_once_the_readings_settle(self) -> None:
+        """Every byte scanned after the outcome is fixed is attacker-chosen work.
+
+        The agreement scan reads occurrences of an untrusted model pattern, and
+        reading them all eagerly meant a pattern that settles the outcome in its
+        first two matches still scanned the whole file. With a backtracking
+        alternative in the tail that is exponential: the eager scan took 64.3 s
+        on this input and roughly quadruples per two characters, so the bound is
+        what keeps the verdict reachable at all.
+        """
+        project = self._create_project(
+            {"config.py": "WARMUP_FRAMES = 3\nWARMUP_FRAMES = 9\n" + "x" * 30 + "\n"}
+        )
+        assertion = self._warmup_assertion(r"WARMUP_FRAMES\s*=\s*|(x+x+)+y", expected="3")
+
+        started = time.monotonic()
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+        elapsed = time.monotonic() - started
+
+        assert summary.reports[0].results[0].outcome is VerificationOutcome.UNVERIFIABLE
+        assert elapsed < 10.0
+
+    def test_t1_more_occurrences_than_the_scan_reads_is_not_agreement(self) -> None:
+        """A cap that returned VERIFIED would agree with a file it stopped reading.
+
+        The scan is bounded, so a file can hold occurrences it never looked at.
+        What those say is unknown, and unknown cannot be part of an agreement --
+        the same rule the unreadable binding already obeys -- so reaching the cap
+        has to unsettle the criterion rather than let the readings so far stand.
+        """
+        cap = verifier_module.MAX_OCCURRENCES_PER_FILE
+        occurrences = "\n".join(["WARMUP_FRAMES = 10"] * (cap + 1))
+        project = self._create_project({"config.py": occurrences + "\n"})
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (self._warmup_assertion(r"WARMUP_FRAMES"),), agent_results={0: True}
+        )
+
+        result = summary.reports[0].results[0]
+        assert result.outcome is VerificationOutcome.UNVERIFIABLE
+        assert summary.override_approval is False
 
     def test_t1_pattern_not_found(self) -> None:
         """T1: pattern not in any file → verification fails."""


### PR DESCRIPTION
## What

`_verify_constant` decided a T1 constant from the **first** regex match in the first
readable file, and read a failed extraction as the empty string. Both halves put a
value into the verdict that the file does not hold.

Refs #1991.

## The four shapes, all reproduced

`WARMUP_FRAMES` with `expected_value="10"`, against the pattern shapes
`extractor.py`'s own prompt asks the model for:

| file                                                | interpreter binds | reported before            | reported now   |
| --------------------------------------------------- | ----------------- | -------------------------- | -------------- |
| `# WARMUP_FRAMES controls …` / `WARMUP_FRAMES = 10` | `10`              | DISCREPANCY, `found ''`    | VERIFIED, `10` |
| `# WARMUP_FRAMES controls …` (no declaration)       | —                 | DISCREPANCY, `found ''`    | UNVERIFIABLE   |
| `# WARMUP_FRAMES = 10` / `WARMUP_FRAMES = 3`        | `3`               | **VERIFIED**, `found '10'` | UNVERIFIABLE   |
| `# WARMUP_FRAMES = 3` / `WARMUP_FRAMES = 10`        | `10`              | DISCREPANCY, `found '3'`   | UNVERIFIABLE   |

Row 1 is the manufactured FAIL: the scanner asserts the source contradicts a criterion
the source meets, and `_demoted_from_overturning` does not help — it withdraws authority
only from a VERIFIED, never from a DISCREPANCY overturning an agent PASS.

Row 3 is the manufactured PASS this module has been closing since #1837 / #2065, arriving
by a different route: a stale comment above the declaration, and `search` returning the
comment because it is written first.

Row 4 is the worse of the two directions. DISCREPANCY blocks in strict _and_ non-strict
mode, and nothing withdraws it.

**Between files, the same rule needs no comment to go wrong.** The first file the glob
yielded with a match settled the criterion and the rest were never opened:

| files                                                                | interpreter binds | reported before                         | reported now |
| -------------------------------------------------------------------- | ----------------- | --------------------------------------- | ------------ |
| `a_notes.py`: `# MAX_RETRIES = 5` + `settings.py`: `MAX_RETRIES = 1` | `1`               | **VERIFIED**, `found '5' in a_notes.py` | UNVERIFIABLE |

And a sixth: a scalar that scans as blank (`X = ""`) satisfied an `expected_value` of only
spaces, because both strip to nothing. `extractor.py:253` rejects blank `expected_value`
for T1, so that one is not reachable from the LLM path today; it is the same defect from
the other side and closes with the others.

## The change

Every occurrence of the pattern is read, in every candidate file, and the readings have
to agree. Where they agree the candidates say one thing and the comparison is about that
thing. Where they disagree there is no single value they can be said to hold — missing
evidence, not counter-evidence, so **UNVERIFIABLE**.

Agreement is only worth something if the declaration takes part in it, so an occurrence
is one of three things rather than two:

| at the occurrence        | example                    | counts as                                                                            |
| ------------------------ | -------------------------- | ------------------------------------------------------------------------------------ |
| a scalar this can read   | `WARMUP_FRAMES = 3`        | a reading, compared as before                                                        |
| nothing bound at all     | `# WARMUP_FRAMES controls` | prose — settles nothing                                                              |
| a binding it cannot read | `WARMUP_FRAMES = int("3")` | a place the file states it, and no reading elsewhere can stand for it → UNVERIFIABLE |

The third row is the one that matters. The forms it covers are ordinary Python, not
exotica — `int("3")`, `1 + 2`, `3 if c else 10`, `X: int = 3`, `{"X": 3}`, `X = ""` —
and dropping them would have put this PR's own conflation back one level up, with an
unread declaration and a bare mention spelled `None` alike. A stale comment beside such
a declaration would then be the file's only reading, unanimous with itself, and VERIFIED
against a file the interpreter binds to 3.

### Punctuation reaching the comparison as a value

A scalar is a value written whole, so the scan stops at a bracket it did not open — but
it did not stop at the characters that most often stand where a value was going to be,
so an assignment a formatter wrapped across lines

```python
WARMUP_FRAMES = (          WARMUP_FRAMES = \
    10                         10
)
```

scanned to the line end and returned `(` — and its backslash sibling returned `\` — as
what the file says the constant is: a DISCREPANCY made out of punctuation, in the arm
that blocks in strict and non-strict mode alike. `(`, `[` and `\` join the stop set, so
both are a binding that could not be read — UNVERIFIABLE. The same assignment laid out
three ways gets one verdict. Present on the merge base; found while probing this branch.

An annotated assignment written without spaces went wrong from the other end: only the
leading `:` of `WARMUP_FRAMES:int=10` was skipped, so `int=10` reached the comparison as
the value — DISCREPANCY again. `=` joins the stop set too. It cannot truncate an ordinary
`X = 10`, because the scan begins after that operator; what it stops is a token carrying
an operator of its own, which is a binding this cannot read rather than a value.

### A declaration is not prose because a token precedes its operator

Deciding whether a value is bound at an occurrence was stricter than the declarations
people write. Requiring the operator to sit against the name read every form with a
type, a modifier or a second target in between as **prose** — the bucket that settles
nothing — so a stale comment above such a line became the file's sole unanimous reading:

| declaration           | interpreter binds | reported before      | reported now |
| --------------------- | ----------------- | -------------------- | ------------ |
| `NAME ?= 10`          | `10`              | **VERIFIED**, `'99'` | UNVERIFIABLE |
| `NAME += 10`          | `10`              | **VERIFIED**, `'99'` | UNVERIFIABLE |
| `const NAME int = 10` | `10`              | **VERIFIED**, `'99'` | UNVERIFIABLE |
| `NAME, FPS = 10, 30`  | `10`              | **VERIFIED**, `'99'` | UNVERIFIABLE |

An operator anywhere later on the same physical line now counts as one. Prose that
happens to carry an operator is then called a binding that could not be read, which
costs a criterion its verdict; a declaration called prose costs soundness.

**What that costs, stated plainly.** A comment that names the constant and carries a `=`
or `:` further along the same line — `# WARMUP_FRAMES controls warmup; see FPS = 30` —
is now unreadable rather than prose, so a criterion resting on it goes UNVERIFIABLE
where it used to be VERIFIED. The plain documentation comment with no operator
(`# WARMUP_FRAMES controls the warmup`) is unaffected and still lets the declaration
below it be read. This is deliberately the cheap side of the asymmetry, and it is the
narrower of the two remedies available: the alternative — treating every occurrence
whose scalar cannot be read as an unread binding unconditionally — costs more
availability, and a character-alphabet heuristic for "what a declaration head looks
like" would buy some of it back by accreting exactly the kind of special case the rest
of this change removes.

### Reading every occurrence, without reading every byte a pattern points at

The pattern is model output bounded only by `MAX_PATTERN_LENGTH`, whose comment already
names ReDoS. The occurrence scan is lazy and stops as soon as the readings settle — on a
file whose first two occurrences disagree and whose tail backtracks, 64.3 s of
attacker-chosen work becomes 0.00 s — and stops at `MAX_OCCURRENCES_PER_FILE` regardless,
recording a binding gone unread so that a cap can never be mistaken for agreement.

**What is not closed:** a pattern that simply does not match still scans the whole file
and backtracks. Measured identical on the merge base (4.1 s against 4.1 s at the same
input), so this branch neither introduces nor widens it.

### Not a guard

This removes a choice rule rather than adding a guard. There is no new allow-list and no
new special case; `_verify_constant` lost the arbitrary preference it had for whichever
match came first, within a file and between files alike.

### What it does not do

It does not let the scanner tell source from prose. Nothing here can, in a file whose
language it does not know, so a criterion whose constant appears _only_ inside a comment,
with nothing anywhere to disagree with it, still reads that comment — and a pattern that
never matches the declaration at all (`WARMUP_FRAMES\s*=\s*` against `#define`, YAML, or
an annotated assignment) still never sees it. Both are unchanged from the merge base.
What is gone is the silent preference between two readings that disagree, and the silent
disappearance of a declaration that could not be read.

The branch with no `expected_value` is untouched: VERIFIED there rests on the pattern
matching rather than on any value, `""` genuinely means "empty", and `\A\Z` against a
named empty file depends on it. `actual_value` stays `str` so persisted payloads keep
their shape.

## Tests

Twenty-four regression cases in `tests/unit/test_verification.py`, each verified red against
the merge-base verifier producing exactly the verdict in the tables above:

- `test_t1_a_mention_beside_the_declaration_is_read_as_the_declaration`
- `test_t1_a_mention_with_no_declaration_anywhere_is_unverifiable`
- `test_t1_a_decoy_comment_cannot_outrank_the_declaration_it_contradicts`
- `test_t1_a_decoy_comment_cannot_contradict_the_declaration_that_meets_it`
- `test_t1_a_mention_in_one_file_cannot_settle_a_constant_bound_in_another`
- `test_t1_expected_value_of_only_spaces_cannot_be_met_by_a_blank_reading`
- `test_t1_a_declaration_the_scanner_cannot_read_is_not_a_bare_mention` (6 params —
  call, expression, conditional, annotated, quoted key, blank)
- `test_t1_an_unread_declaration_in_one_file_unsettles_a_reading_in_another`
- `test_t1_prose_naming_the_constant_in_quotes_is_still_prose` — the quoted-key
  allowance must not swallow a mention in prose
- `test_t1_a_value_wrapped_across_lines_is_not_read_as_its_bracket` (2 params — `()`, `[]`)
- `test_t1_a_line_continuation_is_not_the_value_it_continues`
- `test_t1_an_operator_inside_the_scalar_is_not_part_of_the_value`
- `test_t1_a_declaration_is_not_prose_because_a_token_precedes_its_operator` (4 params —
  `?=`, `+=`, intervening type, multiple targets)
- `test_t1_the_occurrence_scan_stops_once_the_readings_settle` — a bound, not a timing
  preference: measured at 64.3 s against this branch's 0.00 s, and quadrupling per two
  characters of input
- `test_t1_more_occurrences_than_the_scan_reads_is_not_agreement`

`tests/unit/test_verification.py`: 358 passed. Full suite: 21097 passed, 6 failed — each
of the six re-run with this branch's `src/` reverted to `origin/main` and still red there,
so none of them is this branch's. They are `uv` reaching the network, the macOS launcher
variables (`PYTHONEXECUTABLE`, `__PYVENV_LAUNCHER__`), a 100k-row sqlite walk, and a wheel
build — this environment (macOS + 3.14), not `src/ouroboros/verification/`. CI is the
authority on whether they are red there too. `ruff format`, `ruff check`, `mypy`, and the
`module-size`, `auto-boundary` and `max-turns-envelope` gate scripts run clean locally
against `origin/main` as baseline.
