### PR TITLE
fix(mcp): offer recent findings to contracted lanes

### DIFF
--- a/.claude-plugin/skills/pm/SKILL.md
+++ b/.claude-plugin/skills/pm/SKILL.md
@@ -98,6 +98,31 @@ from memory, so it is the last one to skip evidence on.
 Apply this to **every** MCP response that carries a question, including the one
 Step 2 returned and any question re-shown on resume.
 
+**Batched turns (RFC #2222).** A response may carry one to three questions at
+once: `meta.question_batch` lists them and `meta.question_advisories` carries
+one advisory envelope per question, each with its own
+`question_advisory_subagents` and `question_advisory_fanout_id`. Treat every
+batch member exactly as a single question is treated below, with these batch
+mechanics:
+
+- **Dispatch all envelopes' payloads in one wave** — one subagent per payload
+  across all questions, in a single parallel batch. Never leave a question's
+  lanes undispatched: every question shown keeps its evidence.
+- **Submit results per envelope** — each question's lanes correlate by its own
+  envelope's `question_advisory_fanout_id` and
+  `question_advisory_result_correlation_key`; one
+  `ouroboros_submit_fanout_results` call per envelope.
+- **Relay answers one at a time**, each with `last_question` set to that
+  member's exact question text. Members may be answered in any order; the
+  server re-lists what is still pending after each. An unanswered member stays
+  pending — never auto-answer, auto-defer, or decide-later it on the user's
+  behalf.
+- A response that lists pending members without `question_advisories` is a
+  re-display: its lanes already ran, do not dispatch them again.
+- Skip sentinels are per member: `answer="[decide_later]"` /
+  `answer="[deferred]"` are honoured only for the member whose classification
+  allows it, always with that member's `last_question`.
+
 **A. Show alerts** (if present in `meta`):
 - `meta.deferred_this_round` → print `[DEV → deferred] "question"`
 - `meta.decide_later_this_round` → print `[DEV → decide-later] "question"`
@@ -147,11 +172,17 @@ having two lanes instead of six:
 
 Write the line in the language the user is speaking.
 
-**Do not go to step A3 or B while the lanes are still running.** Step B is where
+**Do not go to step B while the lanes are still running.** Step B is where
 you ask the user, and asking before the evidence arrives is the exact failure
 this mechanism exists to prevent: the PM decides without the two things they
 could not have looked up themselves. Waiting is for lanes still in flight: one
 that came back empty, broke its contract, or could not be spawned has returned.
+
+**Stub payloads.** A payload's `prompt` may be a short stub telling its child
+to fetch the full brief from the store (`ouroboros_fetch_artifact`) — pass it
+unchanged exactly like any payload. A child that replies exactly
+`UNDISPATCHED` could not receive its brief: submit that lane as
+`{ "key": <lane id>, "undispatched": true }`.
 
 **Submitting results back.** Correlate by
 `meta.question_advisory_result_correlation_key` (`context.lane_id`) and call
@@ -176,11 +207,10 @@ and a reply can be accepted while one of them never ran. Where the block would
 have carried that lane, write that it did not run.
 
 There are two lanes and both are required: `code_context` and `data_context`.
-A `code_context` lane that carries a policy returns `answer_prefix:
-"[from-code]"` and a `user_confirmation_prompt` — that is a step, described in
-A3 below, not the answer. `data_context` has no prefix at all: measurements are
-shown beside the question and the answer is the user's own words. Never skip
-asking the user because a lane answered clearly.
+Both are **evidence-only** (RFC #2222): what a lane finds is shown beside the
+question and sent nowhere — the published fan-out is already its record, and
+the interview records only what the user writes. Never skip asking the user
+because a lane answered clearly, and never send a lane's finding as an answer.
 
 **Synthesize into the evidence block.** This is what
 `synthesis_contract.output_shape = "evidence_beside_question"` means, and it is a
@@ -190,17 +220,24 @@ above the question, then ask the question unchanged:
 ```
 Evidence (examined: billing-api, storefront)
 
-What the code does today
-  · [billing-api] src/billing/lapse.py  — access continues to period end
-  · [storefront]  src/checkout.ts       — access is revoked immediately
+What the system does today
+  · [billing-api] access continues to the end of the paid period
+  · [storefront]  access is revoked immediately
     ! These two repositories implement this differently.
 
 Measured — active subscriptions by plan, last 90 days
   · standard 12,480 / premium 3,120
 ```
 
-Write the block in the language the user is speaking. The labels above are
-placeholders for its shape, not text to copy.
+**The screen speaks product language; the store keeps the citations
+(RFC #2222 decision 4).** Each code claim is rendered from its lane-authored
+`plain_statement` — never from `policy_claim`, and never paraphrased by you.
+No file paths, no class names, no flag values on screen. The `path` +
+`policy_claim` citations stay in the published fan-out, fetchable by its
+contract id — they are displayed nowhere and recorded nowhere else. The lane
+writes `plain_statement` in the question's language, so no translation is
+yours to do. The labels above are placeholders for the block's shape, not
+text to copy.
 
 **What this block is not.** It carries no answer options, no recommendation, no
 ranking, and no "therefore …" sentence. The moment it proposes an answer it has
@@ -238,55 +275,15 @@ Rules for building it:
   something the record does not contain. Offer to register the repository
   instead, so the next question can be answered against it.
 
-**A3. Record a confirmed finding — its own turn, before you prompt for an answer.**
+**A3. Findings are evidence, never answers (RFC #2222).**
 
-Only when some `code_context` entry came back carrying a `policy_claims` item.
-That answer also carries `answer_prefix: "[from-code]"` and a
-`user_confirmation_prompt`, and there is no prefix that skips this step:
-`[from-code][auto-confirmed]` is not a value the contract can hold, so a lane
-cannot declare itself pre-confirmed.
-
-1. Show the evidence block (A2) and ask the lane's `user_confirmation_prompt`
-   through `AskUserQuestion`. Ask it as it is: the user is confirming that this
-   is what the code does, not deciding what it should do.
-2. If they say it is wrong, or they would rather just answer, **send nothing**
-   and go to B. A question answered with no finding recorded is an accurate
-   account of how that decision was made, not a degraded one.
-3. If they confirm, send it as the answer with its prefix, composed from the
-   `examined` entries so every claim keeps the repository it was read in:
-
-```
-Tool: ouroboros_pm_interview
-Arguments:
-  session_id: <meta.session_id>
-  last_question: <meta.question>
-  answer: |
-    [from-code] billing-api src/billing/lapse.py: access continues to period end.
-    [from-code] storefront src/checkout.ts: access is revoked immediately.
-```
-
-Send `meta.question`, never the response text — the text carries the fan-out
-directive. Omitting it files the finding under a placeholder question, and
-since the answer slot is withheld by design, the finding is then lost from
-both slots.
-
-4. The server records it as an **adopted fact**: the round is marked
-   `observation`, requirement extraction reads a withheld-note in its place, and
-   it does not count toward the decisions that complete the interview. The
-   response carries the **next** question, generated with the finding in view —
-   that is the question the user answers in their own words, from step 3-A.
-
-**Why it takes the round rather than riding beside the answer.** It was built
-the other way first, with a second parameter for findings. Two entrances meant
-two sets of rules for one payload, and they stopped agreeing: the same class of
-silent loss reappeared at a new address for six review rounds. One entrance is
-what closed it, and it is what `ouroboros_interview` always did.
-
-**What this does not license.** The finding is never sent unconfirmed to save a
-turn. What holds if you do is downstream and weaker than the user's eyes: the
-`[from-code]` prefix keeps it out of requirement extraction and out of the
-completion count, so an unconfirmed forward costs the user a question turn and
-puts nothing false in the PRD. That is a floor, not a permission.
+There is no recording step. A finding's durable record is the published
+fan-out itself — addressable by contract id, re-offered to later lanes through
+recent findings — so sending it again as an answer would duplicate the store
+and spend a question turn on it. Do not send `[from-code]` answers, do not ask
+the user to "confirm" a finding as a separate turn, and do not paste findings
+into any answer payload. The evidence block is the finding's whole appearance;
+the user answers the question in their own words, with the evidence in view.
 
 **B. Show content + get user input** (once A2's lanes have returned):
 
@@ -309,6 +306,11 @@ Then check: does `meta.ask_user_question` exist?
   Do NOT modify it. Do NOT add options. Do NOT rephrase the question.
 
 - **NO** → This is an interview question. Use `AskUserQuestion` with `meta.question`.
+  - **Batched turn**: put every pending member into ONE `AskUserQuestion` call —
+    one entry per member (the tool takes up to 4). Each member keeps its own
+    options, built by the same rules below from its own entry in
+    `meta.question_batch`; a skip option follows that member's own
+    `classification`, never another member's.
   - If `meta.skip_eligible == true`: add a skip option based on `meta.classification`:
     - `classification == "decide_later"` → add option `{"label": "Decide later", "description": "Skip — will be recorded as an open item in the PRD"}`
     - `classification == "deferred"` → add option `{"label": "Defer to dev", "description": "Skip — this technical decision will be deferred to the development phase"}`
@@ -321,6 +323,11 @@ Then check: does `meta.ask_user_question` exist?
 If the user chose "Decide later" → send `answer="[decide_later]"`.
 If the user chose "Defer to dev" → send `answer="[deferred]"`.
 Otherwise → send the user's answer through the Refine gate below.
+
+On a batched turn: one call per answered member, each with that member's exact
+question text as `last_question`, each through its own Refine gate. The server
+answers each call with what is still pending; only the call that resolves the
+last member returns the next turn's question(s).
 
 **Refine gate — structure it, mark whose it is, then have the user confirm.**
 
@@ -353,8 +360,9 @@ nothing they said is the failure this labelling exists to make visible.
 
 **No codebase-context section, and no lane findings.** The regular interview
 adds one, because there the main session inspects code itself. Here it does not.
-A lane's finding is recorded by step A3, on its own turn, as an adopted fact.
-Putting it in this payload would record it as part of the user's decision.
+A lane's finding lives in the published fan-out and on the screen beside the
+question — putting it in this payload would record it as part of the user's
+decision, which it is not (A3).
 
 **Then confirm — this is the gate, and it is what licenses the structuring
 above.** One `AskUserQuestion` before sending:
@@ -387,17 +395,15 @@ Tool: ouroboros_pm_interview
 Arguments:
   session_id: <meta.session_id>
   last_question: <meta.question>
-  <meta.response_param>: <the refined answer, or "[decide_later]" / "[deferred]">
+  answer: <the refined answer, or "[decide_later]" / "[deferred]">
 ```
 
 Ignored while the server holds the question unanswered; required otherwise —
 plugin mode never persists the child's questions, and an answer with no pending
 question is refused without it.
 
-There is no second parameter carrying findings. The tool has exactly the fields
-the regular interview has, and a finding travels the same way any adopted fact
-travels there — see **A3. Record a confirmed finding** above, which is a separate
-turn taken *before* the user answers, not something appended to this call.
+There is no parameter carrying findings, second or otherwise: findings never
+travel as answers (A3). Every call on this parameter is the user's own words.
 
 **D. Check completion:**
 

--- a/.claude-plugin/skills/pm/SKILL.md
+++ b/.claude-plugin/skills/pm/SKILL.md
@@ -180,11 +180,13 @@ this mechanism exists to prevent: the PM decides without the two things they
 could not have looked up themselves. Waiting is for lanes still in flight: one
 that came back empty, broke its contract, or could not be spawned has returned.
 
-**Stub payloads.** A payload's `prompt` may be a short stub telling its child
-to fetch the full brief from the store (`ouroboros_fetch_artifact`) — pass it
-unchanged exactly like any payload. A child that replies exactly
-`UNDISPATCHED` could not receive its brief: submit that lane as
-`{ "key": <lane id>, "undispatched": true }`.
+**Stub payloads.** A payload's `prompt` may be a compact stub: it carries the
+lane's answer schema, where it may look, and the findings it may reuse, and
+points at `ouroboros_fetch_artifact` for the prose that explains them. Pass it
+unchanged exactly like any payload — the child fetches for itself, and a fetch
+it cannot make does not stop it. A child that replies exactly `UNDISPATCHED`
+could not work at all: submit that lane as
+`{ "key": <lane id>, "undispatched": true }` rather than as an empty finding.
 
 **Submitting results back.** Correlate by
 `meta.question_advisory_result_correlation_key` (`context.lane_id`) and call

--- a/.claude-plugin/skills/pm/SKILL.md
+++ b/.claude-plugin/skills/pm/SKILL.md
@@ -114,9 +114,11 @@ batch mechanics:
   `ouroboros_submit_fanout_results` call per envelope.
 - **Relay the turn's answers together** in one call:
   `answers: [{question, answer}, ...]`, one entry per question the turn asked,
-  each naming its own exact question text. A turn is recorded whole — collect
-  every answer first, and never auto-answer, auto-defer, or decide-later one on
-  the user's behalf to complete the set.
+  each naming its own exact question text. One call records the turn, so
+  collect every answer first — and never auto-answer, auto-defer, or
+  decide-later one on the user's behalf to complete the set. The server does
+  not check that you sent them all: whatever you leave out is **abandoned**,
+  not remembered.
 - The server keeps nothing between calls. A call that arrives without the
   turn's answers plans a **new** turn from the transcript rather than restoring
   the old one, so a turn you abandon is a turn the user will be asked again.

--- a/.claude-plugin/skills/pm/SKILL.md
+++ b/.claude-plugin/skills/pm/SKILL.md
@@ -96,14 +96,14 @@ from memory, so it is the last one to skip evidence on.
 ### Step 3: Loop
 
 Apply this to **every** MCP response that carries a question, including the one
-Step 2 returned and any question re-shown on resume.
+Step 2 returned and any question a resume plans anew.
 
 **Batched turns (RFC #2222).** A response may carry one to three questions at
 once: `meta.question_batch` lists them and `meta.question_advisories` carries
 one advisory envelope per question, each with its own
 `question_advisory_subagents` and `question_advisory_fanout_id`. Treat every
-batch member exactly as a single question is treated below, with these batch
-mechanics:
+question of the turn exactly as a single question is treated below, with these
+batch mechanics:
 
 - **Dispatch all envelopes' payloads in one wave** — one subagent per payload
   across all questions, in a single parallel batch. Never leave a question's
@@ -112,16 +112,16 @@ mechanics:
   envelope's `question_advisory_fanout_id` and
   `question_advisory_result_correlation_key`; one
   `ouroboros_submit_fanout_results` call per envelope.
-- **Relay answers one at a time**, each with `last_question` set to that
-  member's exact question text. Members may be answered in any order; the
-  server re-lists what is still pending after each. An unanswered member stays
-  pending — never auto-answer, auto-defer, or decide-later it on the user's
-  behalf.
-- A response that lists pending members without `question_advisories` is a
-  re-display: its lanes already ran, do not dispatch them again.
-- Skip sentinels are per member: `answer="[decide_later]"` /
-  `answer="[deferred]"` are honoured only for the member whose classification
-  allows it, always with that member's `last_question`.
+- **Relay the turn's answers together** in one call:
+  `answers: [{question, answer}, ...]`, one entry per question the turn asked,
+  each naming its own exact question text. A turn is recorded whole — collect
+  every answer first, and never auto-answer, auto-defer, or decide-later one on
+  the user's behalf to complete the set.
+- The server keeps nothing between calls. A call that arrives without the
+  turn's answers plans a **new** turn from the transcript rather than restoring
+  the old one, so a turn you abandon is a turn the user will be asked again.
+- Skip sentinels are per question: give that question the answer
+  `"[decide_later]"` or `"[deferred]"` in its own entry.
 
 **A. Show alerts** (if present in `meta`):
 - `meta.deferred_this_round` → print `[DEV → deferred] "question"`
@@ -306,11 +306,11 @@ Then check: does `meta.ask_user_question` exist?
   Do NOT modify it. Do NOT add options. Do NOT rephrase the question.
 
 - **NO** → This is an interview question. Use `AskUserQuestion` with `meta.question`.
-  - **Batched turn**: put every pending member into ONE `AskUserQuestion` call —
-    one entry per member (the tool takes up to 4). Each member keeps its own
+  - **Batched turn**: put every question of the turn into ONE `AskUserQuestion`
+    call — one entry per question (the tool takes up to 4). Each keeps its own
     options, built by the same rules below from its own entry in
-    `meta.question_batch`; a skip option follows that member's own
-    `classification`, never another member's.
+    `meta.question_batch`; a skip option follows that question's own
+    `classification`, never another's.
   - If `meta.skip_eligible == true`: add a skip option based on `meta.classification`:
     - `classification == "decide_later"` → add option `{"label": "Decide later", "description": "Skip — will be recorded as an open item in the PRD"}`
     - `classification == "deferred"` → add option `{"label": "Defer to dev", "description": "Skip — this technical decision will be deferred to the development phase"}`
@@ -324,10 +324,10 @@ If the user chose "Decide later" → send `answer="[decide_later]"`.
 If the user chose "Defer to dev" → send `answer="[deferred]"`.
 Otherwise → send the user's answer through the Refine gate below.
 
-On a batched turn: one call per answered member, each with that member's exact
-question text as `last_question`, each through its own Refine gate. The server
-answers each call with what is still pending; only the call that resolves the
-last member returns the next turn's question(s).
+On a batched turn: run each answer through its own Refine gate, then send them
+in one call as `answers: [{question, answer}, ...]` — the question text exactly
+as the turn asked it. The call that carries the turn returns the next turn's
+question(s).
 
 **Refine gate — structure it, mark whose it is, then have the user confirm.**
 

--- a/skills/pm/SKILL.md
+++ b/skills/pm/SKILL.md
@@ -98,6 +98,31 @@ from memory, so it is the last one to skip evidence on.
 Apply this to **every** MCP response that carries a question, including the one
 Step 2 returned and any question re-shown on resume.
 
+**Batched turns (RFC #2222).** A response may carry one to three questions at
+once: `meta.question_batch` lists them and `meta.question_advisories` carries
+one advisory envelope per question, each with its own
+`question_advisory_subagents` and `question_advisory_fanout_id`. Treat every
+batch member exactly as a single question is treated below, with these batch
+mechanics:
+
+- **Dispatch all envelopes' payloads in one wave** — one subagent per payload
+  across all questions, in a single parallel batch. Never leave a question's
+  lanes undispatched: every question shown keeps its evidence.
+- **Submit results per envelope** — each question's lanes correlate by its own
+  envelope's `question_advisory_fanout_id` and
+  `question_advisory_result_correlation_key`; one
+  `ouroboros_submit_fanout_results` call per envelope.
+- **Relay answers one at a time**, each with `last_question` set to that
+  member's exact question text. Members may be answered in any order; the
+  server re-lists what is still pending after each. An unanswered member stays
+  pending — never auto-answer, auto-defer, or decide-later it on the user's
+  behalf.
+- A response that lists pending members without `question_advisories` is a
+  re-display: its lanes already ran, do not dispatch them again.
+- Skip sentinels are per member: `answer="[decide_later]"` /
+  `answer="[deferred]"` are honoured only for the member whose classification
+  allows it, always with that member's `last_question`.
+
 **A. Show alerts** (if present in `meta`):
 - `meta.deferred_this_round` → print `[DEV → deferred] "question"`
 - `meta.decide_later_this_round` → print `[DEV → decide-later] "question"`
@@ -147,11 +172,17 @@ having two lanes instead of six:
 
 Write the line in the language the user is speaking.
 
-**Do not go to step A3 or B while the lanes are still running.** Step B is where
+**Do not go to step B while the lanes are still running.** Step B is where
 you ask the user, and asking before the evidence arrives is the exact failure
 this mechanism exists to prevent: the PM decides without the two things they
 could not have looked up themselves. Waiting is for lanes still in flight: one
 that came back empty, broke its contract, or could not be spawned has returned.
+
+**Stub payloads.** A payload's `prompt` may be a short stub telling its child
+to fetch the full brief from the store (`ouroboros_fetch_artifact`) — pass it
+unchanged exactly like any payload. A child that replies exactly
+`UNDISPATCHED` could not receive its brief: submit that lane as
+`{ "key": <lane id>, "undispatched": true }`.
 
 **Submitting results back.** Correlate by
 `meta.question_advisory_result_correlation_key` (`context.lane_id`) and call
@@ -176,11 +207,10 @@ and a reply can be accepted while one of them never ran. Where the block would
 have carried that lane, write that it did not run.
 
 There are two lanes and both are required: `code_context` and `data_context`.
-A `code_context` lane that carries a policy returns `answer_prefix:
-"[from-code]"` and a `user_confirmation_prompt` — that is a step, described in
-A3 below, not the answer. `data_context` has no prefix at all: measurements are
-shown beside the question and the answer is the user's own words. Never skip
-asking the user because a lane answered clearly.
+Both are **evidence-only** (RFC #2222): what a lane finds is shown beside the
+question and sent nowhere — the published fan-out is already its record, and
+the interview records only what the user writes. Never skip asking the user
+because a lane answered clearly, and never send a lane's finding as an answer.
 
 **Synthesize into the evidence block.** This is what
 `synthesis_contract.output_shape = "evidence_beside_question"` means, and it is a
@@ -190,17 +220,24 @@ above the question, then ask the question unchanged:
 ```
 Evidence (examined: billing-api, storefront)
 
-What the code does today
-  · [billing-api] src/billing/lapse.py  — access continues to period end
-  · [storefront]  src/checkout.ts       — access is revoked immediately
+What the system does today
+  · [billing-api] access continues to the end of the paid period
+  · [storefront]  access is revoked immediately
     ! These two repositories implement this differently.
 
 Measured — active subscriptions by plan, last 90 days
   · standard 12,480 / premium 3,120
 ```
 
-Write the block in the language the user is speaking. The labels above are
-placeholders for its shape, not text to copy.
+**The screen speaks product language; the store keeps the citations
+(RFC #2222 decision 4).** Each code claim is rendered from its lane-authored
+`plain_statement` — never from `policy_claim`, and never paraphrased by you.
+No file paths, no class names, no flag values on screen. The `path` +
+`policy_claim` citations stay in the published fan-out, fetchable by its
+contract id — they are displayed nowhere and recorded nowhere else. The lane
+writes `plain_statement` in the question's language, so no translation is
+yours to do. The labels above are placeholders for the block's shape, not
+text to copy.
 
 **What this block is not.** It carries no answer options, no recommendation, no
 ranking, and no "therefore …" sentence. The moment it proposes an answer it has
@@ -238,55 +275,15 @@ Rules for building it:
   something the record does not contain. Offer to register the repository
   instead, so the next question can be answered against it.
 
-**A3. Record a confirmed finding — its own turn, before you prompt for an answer.**
+**A3. Findings are evidence, never answers (RFC #2222).**
 
-Only when some `code_context` entry came back carrying a `policy_claims` item.
-That answer also carries `answer_prefix: "[from-code]"` and a
-`user_confirmation_prompt`, and there is no prefix that skips this step:
-`[from-code][auto-confirmed]` is not a value the contract can hold, so a lane
-cannot declare itself pre-confirmed.
-
-1. Show the evidence block (A2) and ask the lane's `user_confirmation_prompt`
-   through `AskUserQuestion`. Ask it as it is: the user is confirming that this
-   is what the code does, not deciding what it should do.
-2. If they say it is wrong, or they would rather just answer, **send nothing**
-   and go to B. A question answered with no finding recorded is an accurate
-   account of how that decision was made, not a degraded one.
-3. If they confirm, send it as the answer with its prefix, composed from the
-   `examined` entries so every claim keeps the repository it was read in:
-
-```
-Tool: ouroboros_pm_interview
-Arguments:
-  session_id: <meta.session_id>
-  last_question: <meta.question>
-  answer: |
-    [from-code] billing-api src/billing/lapse.py: access continues to period end.
-    [from-code] storefront src/checkout.ts: access is revoked immediately.
-```
-
-Send `meta.question`, never the response text — the text carries the fan-out
-directive. Omitting it files the finding under a placeholder question, and
-since the answer slot is withheld by design, the finding is then lost from
-both slots.
-
-4. The server records it as an **adopted fact**: the round is marked
-   `observation`, requirement extraction reads a withheld-note in its place, and
-   it does not count toward the decisions that complete the interview. The
-   response carries the **next** question, generated with the finding in view —
-   that is the question the user answers in their own words, from step 3-A.
-
-**Why it takes the round rather than riding beside the answer.** It was built
-the other way first, with a second parameter for findings. Two entrances meant
-two sets of rules for one payload, and they stopped agreeing: the same class of
-silent loss reappeared at a new address for six review rounds. One entrance is
-what closed it, and it is what `ouroboros_interview` always did.
-
-**What this does not license.** The finding is never sent unconfirmed to save a
-turn. What holds if you do is downstream and weaker than the user's eyes: the
-`[from-code]` prefix keeps it out of requirement extraction and out of the
-completion count, so an unconfirmed forward costs the user a question turn and
-puts nothing false in the PRD. That is a floor, not a permission.
+There is no recording step. A finding's durable record is the published
+fan-out itself — addressable by contract id, re-offered to later lanes through
+recent findings — so sending it again as an answer would duplicate the store
+and spend a question turn on it. Do not send `[from-code]` answers, do not ask
+the user to "confirm" a finding as a separate turn, and do not paste findings
+into any answer payload. The evidence block is the finding's whole appearance;
+the user answers the question in their own words, with the evidence in view.
 
 **B. Show content + get user input** (once A2's lanes have returned):
 
@@ -309,6 +306,11 @@ Then check: does `meta.ask_user_question` exist?
   Do NOT modify it. Do NOT add options. Do NOT rephrase the question.
 
 - **NO** → This is an interview question. Use `AskUserQuestion` with `meta.question`.
+  - **Batched turn**: put every pending member into ONE `AskUserQuestion` call —
+    one entry per member (the tool takes up to 4). Each member keeps its own
+    options, built by the same rules below from its own entry in
+    `meta.question_batch`; a skip option follows that member's own
+    `classification`, never another member's.
   - If `meta.skip_eligible == true`: add a skip option based on `meta.classification`:
     - `classification == "decide_later"` → add option `{"label": "Decide later", "description": "Skip — will be recorded as an open item in the PRD"}`
     - `classification == "deferred"` → add option `{"label": "Defer to dev", "description": "Skip — this technical decision will be deferred to the development phase"}`
@@ -321,6 +323,11 @@ Then check: does `meta.ask_user_question` exist?
 If the user chose "Decide later" → send `answer="[decide_later]"`.
 If the user chose "Defer to dev" → send `answer="[deferred]"`.
 Otherwise → send the user's answer through the Refine gate below.
+
+On a batched turn: one call per answered member, each with that member's exact
+question text as `last_question`, each through its own Refine gate. The server
+answers each call with what is still pending; only the call that resolves the
+last member returns the next turn's question(s).
 
 **Refine gate — structure it, mark whose it is, then have the user confirm.**
 
@@ -353,8 +360,9 @@ nothing they said is the failure this labelling exists to make visible.
 
 **No codebase-context section, and no lane findings.** The regular interview
 adds one, because there the main session inspects code itself. Here it does not.
-A lane's finding is recorded by step A3, on its own turn, as an adopted fact.
-Putting it in this payload would record it as part of the user's decision.
+A lane's finding lives in the published fan-out and on the screen beside the
+question — putting it in this payload would record it as part of the user's
+decision, which it is not (A3).
 
 **Then confirm — this is the gate, and it is what licenses the structuring
 above.** One `AskUserQuestion` before sending:
@@ -387,17 +395,15 @@ Tool: ouroboros_pm_interview
 Arguments:
   session_id: <meta.session_id>
   last_question: <meta.question>
-  <meta.response_param>: <the refined answer, or "[decide_later]" / "[deferred]">
+  answer: <the refined answer, or "[decide_later]" / "[deferred]">
 ```
 
 Ignored while the server holds the question unanswered; required otherwise —
 plugin mode never persists the child's questions, and an answer with no pending
 question is refused without it.
 
-There is no second parameter carrying findings. The tool has exactly the fields
-the regular interview has, and a finding travels the same way any adopted fact
-travels there — see **A3. Record a confirmed finding** above, which is a separate
-turn taken *before* the user answers, not something appended to this call.
+There is no parameter carrying findings, second or otherwise: findings never
+travel as answers (A3). Every call on this parameter is the user's own words.
 
 **D. Check completion:**
 

--- a/skills/pm/SKILL.md
+++ b/skills/pm/SKILL.md
@@ -180,11 +180,13 @@ this mechanism exists to prevent: the PM decides without the two things they
 could not have looked up themselves. Waiting is for lanes still in flight: one
 that came back empty, broke its contract, or could not be spawned has returned.
 
-**Stub payloads.** A payload's `prompt` may be a short stub telling its child
-to fetch the full brief from the store (`ouroboros_fetch_artifact`) — pass it
-unchanged exactly like any payload. A child that replies exactly
-`UNDISPATCHED` could not receive its brief: submit that lane as
-`{ "key": <lane id>, "undispatched": true }`.
+**Stub payloads.** A payload's `prompt` may be a compact stub: it carries the
+lane's answer schema, where it may look, and the findings it may reuse, and
+points at `ouroboros_fetch_artifact` for the prose that explains them. Pass it
+unchanged exactly like any payload — the child fetches for itself, and a fetch
+it cannot make does not stop it. A child that replies exactly `UNDISPATCHED`
+could not work at all: submit that lane as
+`{ "key": <lane id>, "undispatched": true }` rather than as an empty finding.
 
 **Submitting results back.** Correlate by
 `meta.question_advisory_result_correlation_key` (`context.lane_id`) and call

--- a/skills/pm/SKILL.md
+++ b/skills/pm/SKILL.md
@@ -114,9 +114,11 @@ batch mechanics:
   `ouroboros_submit_fanout_results` call per envelope.
 - **Relay the turn's answers together** in one call:
   `answers: [{question, answer}, ...]`, one entry per question the turn asked,
-  each naming its own exact question text. A turn is recorded whole — collect
-  every answer first, and never auto-answer, auto-defer, or decide-later one on
-  the user's behalf to complete the set.
+  each naming its own exact question text. One call records the turn, so
+  collect every answer first — and never auto-answer, auto-defer, or
+  decide-later one on the user's behalf to complete the set. The server does
+  not check that you sent them all: whatever you leave out is **abandoned**,
+  not remembered.
 - The server keeps nothing between calls. A call that arrives without the
   turn's answers plans a **new** turn from the transcript rather than restoring
   the old one, so a turn you abandon is a turn the user will be asked again.

--- a/skills/pm/SKILL.md
+++ b/skills/pm/SKILL.md
@@ -96,14 +96,14 @@ from memory, so it is the last one to skip evidence on.
 ### Step 3: Loop
 
 Apply this to **every** MCP response that carries a question, including the one
-Step 2 returned and any question re-shown on resume.
+Step 2 returned and any question a resume plans anew.
 
 **Batched turns (RFC #2222).** A response may carry one to three questions at
 once: `meta.question_batch` lists them and `meta.question_advisories` carries
 one advisory envelope per question, each with its own
 `question_advisory_subagents` and `question_advisory_fanout_id`. Treat every
-batch member exactly as a single question is treated below, with these batch
-mechanics:
+question of the turn exactly as a single question is treated below, with these
+batch mechanics:
 
 - **Dispatch all envelopes' payloads in one wave** — one subagent per payload
   across all questions, in a single parallel batch. Never leave a question's
@@ -112,16 +112,16 @@ mechanics:
   envelope's `question_advisory_fanout_id` and
   `question_advisory_result_correlation_key`; one
   `ouroboros_submit_fanout_results` call per envelope.
-- **Relay answers one at a time**, each with `last_question` set to that
-  member's exact question text. Members may be answered in any order; the
-  server re-lists what is still pending after each. An unanswered member stays
-  pending — never auto-answer, auto-defer, or decide-later it on the user's
-  behalf.
-- A response that lists pending members without `question_advisories` is a
-  re-display: its lanes already ran, do not dispatch them again.
-- Skip sentinels are per member: `answer="[decide_later]"` /
-  `answer="[deferred]"` are honoured only for the member whose classification
-  allows it, always with that member's `last_question`.
+- **Relay the turn's answers together** in one call:
+  `answers: [{question, answer}, ...]`, one entry per question the turn asked,
+  each naming its own exact question text. A turn is recorded whole — collect
+  every answer first, and never auto-answer, auto-defer, or decide-later one on
+  the user's behalf to complete the set.
+- The server keeps nothing between calls. A call that arrives without the
+  turn's answers plans a **new** turn from the transcript rather than restoring
+  the old one, so a turn you abandon is a turn the user will be asked again.
+- Skip sentinels are per question: give that question the answer
+  `"[decide_later]"` or `"[deferred]"` in its own entry.
 
 **A. Show alerts** (if present in `meta`):
 - `meta.deferred_this_round` → print `[DEV → deferred] "question"`
@@ -306,11 +306,11 @@ Then check: does `meta.ask_user_question` exist?
   Do NOT modify it. Do NOT add options. Do NOT rephrase the question.
 
 - **NO** → This is an interview question. Use `AskUserQuestion` with `meta.question`.
-  - **Batched turn**: put every pending member into ONE `AskUserQuestion` call —
-    one entry per member (the tool takes up to 4). Each member keeps its own
+  - **Batched turn**: put every question of the turn into ONE `AskUserQuestion`
+    call — one entry per question (the tool takes up to 4). Each keeps its own
     options, built by the same rules below from its own entry in
-    `meta.question_batch`; a skip option follows that member's own
-    `classification`, never another member's.
+    `meta.question_batch`; a skip option follows that question's own
+    `classification`, never another's.
   - If `meta.skip_eligible == true`: add a skip option based on `meta.classification`:
     - `classification == "decide_later"` → add option `{"label": "Decide later", "description": "Skip — will be recorded as an open item in the PRD"}`
     - `classification == "deferred"` → add option `{"label": "Defer to dev", "description": "Skip — this technical decision will be deferred to the development phase"}`
@@ -324,10 +324,10 @@ If the user chose "Decide later" → send `answer="[decide_later]"`.
 If the user chose "Defer to dev" → send `answer="[deferred]"`.
 Otherwise → send the user's answer through the Refine gate below.
 
-On a batched turn: one call per answered member, each with that member's exact
-question text as `last_question`, each through its own Refine gate. The server
-answers each call with what is still pending; only the call that resolves the
-last member returns the next turn's question(s).
+On a batched turn: run each answer through its own Refine gate, then send them
+in one call as `answers: [{question, answer}, ...]` — the question text exactly
+as the turn asked it. The call that carries the turn returns the next turn's
+question(s).
 
 **Refine gate — structure it, mark whose it is, then have the user confirm.**
 

--- a/src/ouroboros/bigbang/pm_interview.py
+++ b/src/ouroboros/bigbang/pm_interview.py
@@ -706,8 +706,10 @@ Apply this canonical PM routing policy:
         turn, and companions are an optimization the turn must not fail on.
         What counts as malformed is not decided here — the companion's routing
         fields go through the primary's own classification parser, so a
-        wrong-typed ``decide_later`` is rejected in a batch exactly as it is in
-        a single-question turn.
+        wrong-typed ``decide_later`` is refused by the same rule in both. What
+        follows the refusal differs, because the two questions do: the primary
+        falls back to a plain planning question, since the turn must have one,
+        while a companion is dropped, since the turn is whole without it.
         """
         turn_result = await self.plan_next_turn(state)
         if turn_result.is_err:
@@ -747,13 +749,19 @@ Apply this canonical PM routing policy:
                 # answer. Dropping loses one companion; coercing loses an answer.
                 log.warning("pm.companion_classification_rejected", error=str(exc))
                 continue
+            reframes_before = dict(self._reframe_map)
             shown_question = self._apply_classification(classification)
             shown_identity = normalize_question_text(shown_question)
             if shown_identity in seen_identities:
                 # _apply_classification already recorded routing state for a
-                # question this batch will not carry — undo both traces.
+                # question this batch will not carry — undo both traces. The
+                # map is restored, not popped: a companion whose own text
+                # differs but which reframes onto the primary's shown question
+                # overwrites the primary's entry, and popping that key would
+                # take the primary's original question with it — leaving the
+                # PM's answer to a reframed question with nothing to bundle.
                 self.classifications.pop()
-                self._reframe_map.pop(shown_question, None)
+                self._reframe_map = reframes_before
                 continue
             seen_identities.add(normalize_question_text(question_text))
             seen_identities.add(shown_identity)

--- a/src/ouroboros/bigbang/pm_interview.py
+++ b/src/ouroboros/bigbang/pm_interview.py
@@ -704,6 +704,10 @@ Apply this canonical PM routing policy:
 
         A malformed companion entry is dropped silently: the primary is the
         turn, and companions are an optimization the turn must not fail on.
+        What counts as malformed is not decided here — the companion's routing
+        fields go through the primary's own classification parser, so a
+        wrong-typed ``decide_later`` is rejected in a batch exactly as it is in
+        a single-question turn.
         """
         turn_result = await self.plan_next_turn(state)
         if turn_result.is_err:
@@ -734,17 +738,15 @@ Apply this canonical PM routing policy:
             if normalize_question_text(question_text) in seen_identities:
                 continue
             try:
-                category = QuestionCategory(str(raw.get("category") or "planning"))
-            except ValueError:
-                category = QuestionCategory.PLANNING
-            classification = ClassificationResult(
-                original_question=question_text,
-                category=category,
-                reframed_question=str(raw.get("reframed_question") or "").strip() or question_text,
-                reasoning=str(raw.get("reasoning") or "Companion question."),
-                defer_to_dev=bool(raw.get("defer_to_dev")),
-                decide_later=bool(raw.get("decide_later")),
-            )
+                classification = self.classifier._parse_response(json.dumps(raw), question_text)
+            except (KeyError, TypeError, ValueError) as exc:
+                # Same parser, same strictness as the primary: a routing field
+                # of the wrong type is malformed, not a value to coerce.
+                # ``bool("false")`` is True, and a companion routed that way
+                # would offer a skip that discards a question the PM must
+                # answer. Dropping loses one companion; coercing loses an answer.
+                log.warning("pm.companion_classification_rejected", error=str(exc))
+                continue
             shown_question = self._apply_classification(classification)
             shown_identity = normalize_question_text(shown_question)
             if shown_identity in seen_identities:

--- a/src/ouroboros/bigbang/pm_interview.py
+++ b/src/ouroboros/bigbang/pm_interview.py
@@ -205,6 +205,21 @@ class PMInterviewTurnPlan:
     raw_payload: dict[str, Any]
 
 
+#: What a round holds when the user asked to leave the decision open.
+#:
+#: A skip is recorded, not skipped: the round exists so the question is not
+#: asked again, and it says the decision is open rather than answered. These
+#: are named because two runtimes write them — the engine below, and the
+#: plugin path that has no engine to reach — and a second spelling of one
+#: sentence is a transcript whose meaning depends on which runtime took the
+#: call.
+DECIDE_LATER_PLACEHOLDER = "[Decide later] To be determined — user chose to decide later."
+DEFERRED_PLACEHOLDER = (
+    "[Deferred to development phase] This technical decision will be addressed "
+    "during the development interview."
+)
+
+
 @dataclass
 class PMInterviewEngine:
     """PM interview engine — wraps InterviewEngine via composition.
@@ -906,7 +921,7 @@ Apply this canonical PM routing policy:
 
         return await self.record_response(
             state,
-            user_response="[Decide later] To be determined — user chose to decide later.",
+            user_response=DECIDE_LATER_PLACEHOLDER,
             question=question,
         )
 
@@ -938,9 +953,7 @@ Apply this canonical PM routing policy:
 
         return await self.record_response(
             state,
-            user_response="[Deferred to development phase] "
-            "This technical decision will be addressed during the "
-            "development interview.",
+            user_response=DEFERRED_PLACEHOLDER,
             question=question,
         )
 

--- a/src/ouroboros/bigbang/pm_interview.py
+++ b/src/ouroboros/bigbang/pm_interview.py
@@ -64,6 +64,7 @@ from ouroboros.core.json_utils import extract_json_payload
 from ouroboros.core.owner_only import write_owner_only
 from ouroboros.core.pm_snapshot import refresh_pm_snapshot_worktrees
 from ouroboros.core.types import Result
+from ouroboros.orchestrator.capabilities.question_text import normalize_question_text
 from ouroboros.providers.base import (
     CompletionConfig,
     LLMAdapter,
@@ -135,6 +136,15 @@ Respond ONLY with valid JSON in this exact format:
 # enforce. It is shed last so tight budgets drop the supporting paragraphs
 # before the policy itself.
 _PM_CONTRACT_MARKER = "contract between the PM and the developers"
+
+#: Ceiling on questions per PM turn (RFC #2222 decision 1) — a target the
+#: generator may stay under, never a quota to pad toward.
+MAX_QUESTIONS_PER_TURN = 3
+
+#: Mirrors the planner's closure-mode activation ("Overall ambiguity <= 0.25
+#: activates closure mode ... do not open a new topic"). A companion is by
+#: definition a second topic, so at or below this score the batch is one.
+_CLOSURE_MODE_AMBIGUITY = 0.25
 
 
 def _decision_only_view(state: InterviewState) -> InterviewState:
@@ -626,6 +636,13 @@ Also include these PM routing fields in the same JSON object:
 "defer_to_dev": false|true, "decide_later": false|true,
 "placeholder_response": "string".
 
+Optionally add "companion_questions": up to {MAX_QUESTIONS_PER_TURN - 1} extra
+questions asked in the same turn, each an object with the same routing fields
+plus "question". Include one only when it targets a different unresolved
+clarity dimension and no answer to another question in this turn could change
+how it should be asked. In closure mode, or when unsure, include none. Never
+rephrase the primary question as a companion.
+
 Apply this canonical PM routing policy:
 {classification_policy_prompt()}
 """
@@ -661,6 +678,98 @@ Apply this canonical PM routing policy:
                 raw_payload=turn.raw_payload,
             )
         )
+
+    async def plan_next_turns(
+        self,
+        state: InterviewState,
+    ) -> Result[list[PMInterviewTurnPlan], ProviderError | ValidationError]:
+        """Plan one PM turn of one to three questions (RFC #2222 decision 1).
+
+        One planner call: the primary question travels exactly as
+        :meth:`plan_next_turn` produces it, and companions ride the same JSON
+        payload under ``companion_questions``. Each companion is classified and
+        applied through the same ``_apply_classification`` path as the primary,
+        so reframe tracking and skip routing do not know batch members apart.
+
+        What is enforced here rather than trusted to the generator:
+
+        * **Closure mode is single-question.** At or below the planner's
+          closure threshold the batch is the primary alone — a companion is a
+          second topic, and closure mode forbids opening one.
+        * **No duplicate question identities in one batch.** Fan-out isolation
+          keys on the normalized question text, so a companion that normalizes
+          to an already-included question is dropped, not dispatched.
+        * **The ceiling.** At most ``MAX_QUESTIONS_PER_TURN`` questions leave,
+          however many the payload carried.
+
+        A malformed companion entry is dropped silently: the primary is the
+        turn, and companions are an optimization the turn must not fail on.
+        """
+        turn_result = await self.plan_next_turn(state)
+        if turn_result.is_err:
+            return Result.err(turn_result.error)
+        primary = turn_result.value
+        plans = [primary]
+
+        ambiguity = primary.ambiguity
+        if ambiguity is not None and ambiguity.overall_score <= _CLOSURE_MODE_AMBIGUITY:
+            return Result.ok(plans)
+
+        seen_identities = {
+            normalize_question_text(primary.question),
+            normalize_question_text(primary.classification.original_question),
+        }
+        raw_companions = primary.raw_payload.get("companion_questions")
+        if not isinstance(raw_companions, list):
+            return Result.ok(plans)
+
+        for raw in raw_companions:
+            if len(plans) >= MAX_QUESTIONS_PER_TURN:
+                break
+            if not isinstance(raw, dict):
+                continue
+            question_text = str(raw.get("question") or "").strip()
+            if not question_text:
+                continue
+            if normalize_question_text(question_text) in seen_identities:
+                continue
+            try:
+                category = QuestionCategory(str(raw.get("category") or "planning"))
+            except ValueError:
+                category = QuestionCategory.PLANNING
+            classification = ClassificationResult(
+                original_question=question_text,
+                category=category,
+                reframed_question=str(raw.get("reframed_question") or "").strip() or question_text,
+                reasoning=str(raw.get("reasoning") or "Companion question."),
+                defer_to_dev=bool(raw.get("defer_to_dev")),
+                decide_later=bool(raw.get("decide_later")),
+            )
+            shown_question = self._apply_classification(classification)
+            shown_identity = normalize_question_text(shown_question)
+            if shown_identity in seen_identities:
+                # _apply_classification already recorded routing state for a
+                # question this batch will not carry — undo both traces.
+                self.classifications.pop()
+                self._reframe_map.pop(shown_question, None)
+                continue
+            seen_identities.add(normalize_question_text(question_text))
+            seen_identities.add(shown_identity)
+            plans.append(
+                PMInterviewTurnPlan(
+                    question=shown_question,
+                    ambiguity=None,
+                    classification=classification,
+                    raw_payload=dict(raw),
+                )
+            )
+
+        log.info(
+            "pm.turn_batch_planned",
+            interview_id=state.interview_id,
+            batch_size=len(plans),
+        )
+        return Result.ok(plans)
 
     async def ask_next_question(
         self,
@@ -953,6 +1062,13 @@ Apply this canonical PM routing policy:
         pending = meta.get("pending_reframe")
         if pending and isinstance(pending, dict):
             self._reframe_map[pending["reframed"]] = pending["original"]
+        # A batched turn can hold several pending reframes at once (RFC #2222);
+        # the full map is persisted beside the legacy single entry.
+        pending_map = meta.get("pending_reframes")
+        if isinstance(pending_map, dict):
+            for reframed, original in pending_map.items():
+                if isinstance(reframed, str) and isinstance(original, str):
+                    self._reframe_map[reframed] = original
 
         # Reinstall PM steering wrapper for resumed sessions
         self._install_pm_steering()

--- a/src/ouroboros/bigbang/pm_interview.py
+++ b/src/ouroboros/bigbang/pm_interview.py
@@ -711,6 +711,7 @@ Apply this canonical PM routing policy:
         falls back to a plain planning question, since the turn must have one,
         while a companion is dropped, since the turn is whole without it.
         """
+        self._begin_turn()
         turn_result = await self.plan_next_turn(state)
         if turn_result.is_err:
             return Result.err(turn_result.error)
@@ -781,11 +782,30 @@ Apply this canonical PM routing policy:
         )
         return Result.ok(plans)
 
+    def _begin_turn(self) -> None:
+        """Drop the previous turn's reframe routing before a new one is planned.
+
+        A reframe maps a *shown* question back to the technical one it came
+        from, and that mapping means something only while the turn that
+        produced it is the turn on the wire. A host abandons a turn simply by
+        not answering it (RFC #2222 revision 4) and the next call plans a fresh
+        one — so a mapping that outlived its turn would attach itself to
+        whatever later question happens to be displayed with the same text, and
+        that decision would be recorded under a technical question nobody was
+        asked.
+
+        This is the same removal the pending list got, at the one address it
+        had left: what is persisted describes the turn being planned now, and
+        planning replaces it rather than adding to it.
+        """
+        self._reframe_map = {}
+
     async def ask_next_question(
         self,
         state: InterviewState,
     ) -> Result[str, ProviderError | ValidationError]:
         """Generate and classify the next question using the legacy two-call path."""
+        self._begin_turn()
         question_result = await self.inner.ask_next_question(state)
         if question_result.is_err:
             return question_result

--- a/src/ouroboros/mcp/tools/fanout_handler.py
+++ b/src/ouroboros/mcp/tools/fanout_handler.py
@@ -283,8 +283,13 @@ class FetchArtifactHandler:
                 MCPToolParameter(
                     name="contract_id",
                     type=ToolInputType.STRING,
-                    description="The contract_id from a disposable artifact envelope.",
-                    required=True,
+                    description=(
+                        "The contract_id from a disposable artifact envelope. Omit it "
+                        "and pass lane_id alone to list instead: that lane's own "
+                        "recent findings in this project, newest first, as "
+                        "contract_ids to read back with this same tool."
+                    ),
+                    required=False,
                 ),
                 MCPToolParameter(
                     name="lane_id",
@@ -305,13 +310,49 @@ class FetchArtifactHandler:
         self,
         arguments: dict[str, Any],
     ) -> Result[MCPToolResult, MCPServerError]:
-        """Fetch one verified body without requiring shell access."""
+        """Fetch one verified body, or list what a lane published recently."""
         contract_id = str(arguments.get("contract_id") or "").strip()
         if not contract_id:
-            return Result.err(
-                MCPToolError(
-                    "contract_id is required",
-                    tool_name="ouroboros_fetch_artifact",
+            # A lane on its own is the listing: which of its own findings exist
+            # to be read. Sending that list in every prompt spent a fifth of it
+            # on identifiers nothing could choose between, and a lane that
+            # wants none of them paid for it anyway. The window and the cap are
+            # the query's, not the caller's, so a wider read cannot be asked
+            # for (RFC Q00/ouroboros#2167).
+            lane = str(arguments.get("lane_id") or "").strip()
+            if not lane:
+                return Result.err(
+                    MCPToolError(
+                        "pass a contract_id to read one artifact, or a lane_id alone "
+                        "to list what that lane published here recently",
+                        tool_name="ouroboros_fetch_artifact",
+                    )
+                )
+            if self.disposable_memory is None:
+                return Result.err(
+                    MCPToolError(
+                        "artifact fetch requires a configured project artifact service",
+                        tool_name="ouroboros_fetch_artifact",
+                    )
+                )
+            from ouroboros.mcp.tools.recent_findings import recent_findings_by_lane
+
+            found = await asyncio.to_thread(
+                recent_findings_by_lane,
+                self.disposable_memory.artifact_store,
+                lanes={lane},
+            )
+            listing = {"lane_id": lane, "recent": found.get(lane, [])}
+            return Result.ok(
+                MCPToolResult(
+                    content=(
+                        MCPContentItem(
+                            type=ContentType.TEXT,
+                            text=json.dumps(listing, ensure_ascii=False, sort_keys=True),
+                        ),
+                    ),
+                    is_error=False,
+                    meta=listing,
                 )
             )
         if self.disposable_memory is None:

--- a/src/ouroboros/mcp/tools/pm_batch.py
+++ b/src/ouroboros/mcp/tools/pm_batch.py
@@ -3,7 +3,8 @@
 A batched turn puts one to three questions on the table at once. What this
 module owns is everything that is *about the batch* rather than about one
 question: where pending members live, how an incoming answer is matched to its
-member, and how a batched turn renders to the host.
+member, how a batched turn renders to the host, and the answer lock a turn with
+several answerable questions is the first shape to need.
 
 Batch pending state lives in PM meta, never as core question-only rounds. The
 engine's ``record_answer`` fills the *trailing* unanswered round and overwrites
@@ -15,6 +16,9 @@ every member is recorded question-and-answer together at answer time.
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 
 import structlog
@@ -31,6 +35,33 @@ ADVISORY_PROMPT_BUNDLE_KIND = "advisory_prompt_bundle"
 #: host submits that lane as ``undispatched`` — a lane without its brief has
 #: no contract to answer under, and guessing one is worse than absence.
 UNDISPATCHED_SENTINEL = "UNDISPATCHED"
+
+
+@asynccontextmanager
+async def interview_answer_lock(
+    locks: dict[str, asyncio.Lock],
+    session_id: str,
+) -> AsyncIterator[None]:
+    """Hold one interview's answer lock for a whole record call.
+
+    Recording an answer reads the interview state and PM meta, then writes
+    both. Two answers that interleave therefore both report success while the
+    second write carries a state that never saw the first: the user's words are
+    gone and their question comes back as still pending.
+
+    A batched turn is the first shape where this is reachable in ordinary use —
+    a host holding three answerable questions can send two answers as parallel
+    tool calls — but the read-modify-write is shared by every answer path, so
+    the lock is taken around the whole call rather than around the batch
+    branch. Locks are keyed by interview and live on the handler, which the
+    server builds once at startup; the same idiom as the execution handler's
+    ``_idempotency_locks``.
+
+    The scope is one server process, which is the scope of the state directory
+    it owns.
+    """
+    async with locks.setdefault(session_id, asyncio.Lock()):
+        yield
 
 
 def pending_batch_entries(meta: dict[str, Any] | None) -> list[dict[str, Any]]:

--- a/src/ouroboros/mcp/tools/pm_batch.py
+++ b/src/ouroboros/mcp/tools/pm_batch.py
@@ -43,16 +43,6 @@ ADVISORY_PROMPT_BUNDLE_KIND = "advisory_prompt_bundle"
 #: the store still knows what to look at and what shape to answer in.
 UNDISPATCHED_SENTINEL = "UNDISPATCHED"
 
-#: How many of the offered findings a stub lists.
-#:
-#: The offer set is bounded by attention (twenty, in ``recent_findings``); this
-#: bounds the *prompt*, which is a different question. An entry carries an id
-#: and a time and nothing else, so past the first few a child is choosing
-#: between identifiers it cannot tell apart — twenty of them was a fifth of the
-#: prompt spent on a choice it has no way to make. The rest are named as
-#: withheld rather than dropped, and it may ask for them.
-_STUB_FINDINGS_SHOWN = 5
-
 
 @asynccontextmanager
 async def interview_answer_lock(
@@ -435,35 +425,17 @@ def _payload_stub(
     lane_id = context.get("lane_id")
     schema_json = _lean_schema(contract)
     offered = [e for e in findings if isinstance(e, dict)] if findings else []
+    # The ids do not travel. Twenty of them was a fifth of the prompt spent on
+    # identifiers nothing could choose between, and a lane wanting none of them
+    # paid for it anyway. The tool answers the same question on request, and
+    # the window and the cap stay its own.
     if offered:
-        shown = offered[:_STUB_FINDINGS_SHOWN]
-        # To the minute. Sub-second precision and a UTC offset decide nothing
-        # here and were a line of noise per entry.
-        listing = "\n".join(
-            f"   - `{e.get('contract_id')}` — {str(e.get('published_at') or '')[:16]}"
-            for e in shown
-        )
-        withheld = len(offered) - len(shown)
-        # Said, not silently dropped: a truncation nobody mentions reads as
-        # "this is all there was", which is the confusion the whole mechanism
-        # exists to prevent.
-        rest = (
-            f"\n   {withheld} older one{'' if withheld == 1 else 's'} from today are not"
-            " listed; ask for them if these leave the question open."
-            if withheld > 0
-            else ""
-        )
-        # Recency is the only thing separating these entries, so it is the only
-        # thing the instruction may lean on. Telling a child to pick the ones
-        # whose subject fits would name a signal the offer does not carry, and
-        # listing all twenty would spend a fifth of the prompt on identifiers
-        # it cannot choose between. These are a head start, not a checklist.
-        reuse = f"""2. **Read what this lane already found here.** `ouroboros_fetch_artifact`
-   takes a `contract_id` below plus `lane_id: {lane_id}` (load the tool via
-   your runtime's tool discovery if deferred). Newest first, and recency is
-   all you can tell them apart by. Use what helps, investigate the rest
-   yourself, and if what you read answers the question, stop there.
-{listing}{rest}"""
+        reuse = f"""2. **Read what this lane already found here.** Call
+   `ouroboros_fetch_artifact` with `lane_id: {lane_id}` and no `contract_id`
+   (load the tool via your runtime's tool discovery if deferred): it lists
+   what this lane published here in the last day, newest first. Read the ones
+   you want back with the same tool, passing a `contract_id` from that list
+   and the same `lane_id`. If what you read answers the question, stop there."""
     else:
         reuse = """2. **Nothing has been found here yet** for this lane, so there is nothing to
    reuse. Go to 3."""

--- a/src/ouroboros/mcp/tools/pm_batch.py
+++ b/src/ouroboros/mcp/tools/pm_batch.py
@@ -292,16 +292,25 @@ def _lean_schema(contract: Any) -> str | None:
 #: not appear — is stated beside it, and only what a wrong answer would be
 #: rejected for.
 #:
+#: **Every value in them is deliberately fictional**, and the identifiers are
+#: chosen so that copying one wholesale fails: ``example-repo-a1b2c3d4`` is in
+#: no roster, so an answer carrying it is rejected at submission. An example
+#: whose values looked real would be the one thing this mechanism exists to
+#: prevent — a fabricated claim, correctly shaped, reaching the PM as evidence.
+#: Wrong-and-refused and invented-and-accepted are not the same failure, and
+#: the example is written to fail the first way.
+#:
 #: ``tests/unit/mcp/tools/test_pm_handler_batch.py`` validates every example
-#: against the contract it is keyed to, so an example cannot drift from it.
+#: against the contract it is keyed to, so an example cannot drift from it, and
+#: checks that its identifiers are none of the ones a lane is actually given.
 _ANSWER_EXAMPLES: dict[str, tuple[dict[str, Any], dict[str, Any], str]] = {
     "pm_code_context_answer.v2": (
         {
-            "question_identity": "pm-question:a48ab92c1bae912e",
+            "question_identity": "pm-question:0000000000000000",
             "lane_id": "code_context",
             "examined": [
                 {
-                    "repo_id": "podo-backend-2f0e5f7e",
+                    "repo_id": "example-repo-a1b2c3d4",
                     "policy_claims": [
                         {
                             "path": "src/main/java/com/example/booking/ReminderScheduler.java",
@@ -316,11 +325,11 @@ _ANSWER_EXAMPLES: dict[str, tuple[dict[str, Any], dict[str, Any], str]] = {
                         }
                     ],
                 },
-                {"repo_id": "podo-app-cf98ca21", "policy_claims": []},
+                {"repo_id": "example-app-e5f6a7b8", "policy_claims": []},
             ],
         },
         {
-            "question_identity": "pm-question:a48ab92c1bae912e",
+            "question_identity": "pm-question:0000000000000000",
             "lane_id": "code_context",
             "examined": [],
             "nothing_examined_reason": "not_a_policy_question",
@@ -337,13 +346,13 @@ _ANSWER_EXAMPLES: dict[str, tuple[dict[str, Any], dict[str, Any], str]] = {
     ),
     "data_evidence_answer.v1": (
         {
-            "question_identity": "pm-question:a48ab92c1bae912e",
+            "question_identity": "pm-question:0000000000000000",
             "lane_id": "data_context",
             "data_needed": True,
             "read_requests": [
                 {
                     "operation": "read",
-                    "tool_name": "podo_mysql_query",
+                    "tool_name": "example_metrics_tool",
                     "metric": "trial bookings that reached the lesson",
                     "aggregation": "count",
                     "filters": [{"field": "status", "comparator": "eq", "value": "COMPLETED"}],
@@ -354,7 +363,7 @@ _ANSWER_EXAMPLES: dict[str, tuple[dict[str, Any], dict[str, Any], str]] = {
             ],
         },
         {
-            "question_identity": "pm-question:a48ab92c1bae912e",
+            "question_identity": "pm-question:0000000000000000",
             "lane_id": "data_context",
             "data_needed": False,
             "no_evidence_reason": "not_a_measurement",
@@ -395,6 +404,10 @@ Nothing to report is its own answer, not an empty version of the one above:
 ```json
 {json.dumps(empty, ensure_ascii=False, indent=2)}
 ```
+**Every value above is invented.** Take the identity from the Session block,
+the identifiers from 3, and every claim from what you actually read — an
+answer shaped like this one but not read from anywhere is the one thing that
+must never reach the PM.
 {notes}
 
 """

--- a/src/ouroboros/mcp/tools/pm_batch.py
+++ b/src/ouroboros/mcp/tools/pm_batch.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+import json
 from typing import Any
 
 import structlog
@@ -33,9 +34,13 @@ log = structlog.get_logger()
 #: recent-findings reuse query never offers a brief as a finding.
 ADVISORY_PROMPT_BUNDLE_KIND = "advisory_prompt_bundle"
 
-#: What a lane child replies when it cannot fetch its externalized brief. The
-#: host submits that lane as ``undispatched`` — a lane without its brief has
-#: no contract to answer under, and guessing one is worse than absence.
+#: What a lane child replies when it cannot do its work at all. The host
+#: submits that lane as ``undispatched``, which is the honest record: a lane
+#: that reports nothing found would be read as having found nothing.
+#:
+#: A failed brief fetch is no longer one of those cases. The stub carries the
+#: schema, the roster and the offered findings, so a child that cannot reach
+#: the store still knows what to look at and what shape to answer in.
 UNDISPATCHED_SENTINEL = "UNDISPATCHED"
 
 
@@ -251,12 +256,137 @@ def batch_turn_meta_and_text(
     return response_meta, "\n".join(lines)
 
 
-def _payload_stub(payload: dict[str, Any], bundle_id: str) -> str:
-    """Render the compact prompt a child receives when its brief is stored."""
+def _without_prose(node: Any) -> Any:
+    """Return a JSON Schema with its human-facing text removed.
+
+    What the child needs from the schema is the shape it must produce — field
+    names, required lists, enum literals, ``additionalProperties``. The
+    descriptions explain that shape to a reader who has the brief; they are two
+    thirds of its bytes and none of its meaning here.
+    """
+    if isinstance(node, dict):
+        return {k: _without_prose(v) for k, v in node.items() if k not in ("description", "title")}
+    if isinstance(node, list):
+        return [_without_prose(item) for item in node]
+    return node
+
+
+def _lean_schema(contract: Any) -> str | None:
+    """Return the child-facing schema of one lane's contract, or ``None``."""
+    schema = contract.get("response_model_schema") if isinstance(contract, dict) else None
+    if not isinstance(schema, dict):
+        return None
+    return json.dumps(_without_prose(schema), ensure_ascii=False, separators=(",", ":"))
+
+
+def _no_op_literals(schema_json: str) -> str:
+    """Return the empty-state reason literals this lane's schema admits.
+
+    Read out of the schema rather than listed here: a lane's reasons are its
+    contract's to name, and a copy in this module would be a second list to
+    keep in step.
+    """
+    try:
+        schema = json.loads(schema_json)
+    except ValueError:
+        return ""
+    found: list[str] = []
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if (
+                    key.endswith("_reason")
+                    and isinstance(value, dict)
+                    and isinstance(value.get("enum"), list)
+                ):
+                    found.append(f"`{key}`: {', '.join(str(v) for v in value['enum'])}")
+                walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(schema)
+    return found[0] if found else ""
+
+
+def _investigation_step(roster: Any, schema_json: str | None) -> str:
+    """Return step 3 — where this lane may look when reuse was not enough.
+
+    Which of the two it is comes from the lane's own answer shape rather than
+    its name: a lane whose answer carries ``repo_id`` is bounded by the roster,
+    and one that carries none measures what the host exposes. The roster
+    travels with the request, so a lane that cannot cite a repository must not
+    be handed one — it would be told to read what it has no way to report.
+    """
+    cites_repos = bool(schema_json) and '"repo_id"' in (schema_json or "")
+    entries = [e for e in roster if isinstance(e, dict) and e.get("repo_id")] if roster else []
+    if not cites_repos:
+        return """3. **Still not enough?** Find the data tools this host exposes and call them —
+   registering one is the willingness to have it called. An empty tool search
+   is where you start looking, never where you stop, and a store is only
+   unreachable once a call to it has actually failed."""
+    if not entries:
+        return """3. **No repository was given to you.** That is the whole answer — report the
+   empty state and say so. Reading whatever is at hand would produce evidence
+   nothing can check."""
+    listing = "\n".join(f"   - `{e['repo_id']}` — {e.get('path')}" for e in entries)
+    return f"""3. **Still not enough?** Read these repositories:
+{listing}
+   Where you look is open; what you cite is not. Every `repo_id` you report must
+   be one of the above — anything else is rejected at submission."""
+
+
+def _payload_stub(
+    payload: dict[str, Any],
+    bundle_id: str,
+    *,
+    contract: Any = None,
+    roster: Any = None,
+    findings: Any = None,
+) -> str:
+    """Render the compact prompt a child receives when its brief is stored.
+
+    Compact, not partial. What the child cannot do without travels here — the
+    answer schema, where it may look, what it has already found — and only what
+    explains those to a reader stays behind the fetch. A stub that carried none
+    of it made one fetch the single point of failure for the whole lane: no
+    schema, no roster, no rules, and nothing to do but say so.
+    """
     context = payload.get("context") or {}
     lane_id = context.get("lane_id")
+    schema_json = _lean_schema(contract)
+    offered = [e for e in findings if isinstance(e, dict)] if findings else []
+    if offered:
+        reuse = "\n".join(
+            f"   - contract_id: `{e.get('contract_id')}`, lane_id: `{e.get('lane_id', lane_id)}`"
+            for e in offered
+        )
+    else:
+        reuse = "   - none published yet — go to 3."
+    no_op = _no_op_literals(schema_json) if schema_json else ""
+    no_op_hint = f" ({no_op})" if no_op else ""
+    # Named only where the shape has the field: the data lane reports
+    # measurements, which are already in the PM's language.
+    plain_rule = (
+        " Each claim also carries a `plain_statement`: one sentence in the"
+        " question's own language, no paths or identifiers."
+        if schema_json and '"plain_statement"' in schema_json
+        else ""
+    )
+    answer_section = (
+        f"""## Answer
+Your final message is this JSON and nothing else — no prose around it:
+```json
+{schema_json}
+```
+"""
+        if schema_json
+        else ""
+    )
     return f"""## Task
-You are an Ouroboros PM interview advisory subagent — lane {lane_id}.
+You are an Ouroboros PM interview advisory subagent — lane {lane_id}. You gather
+evidence the PM reads before answering; you never answer for them.
 
 ## PM Question
 {context.get("question")}
@@ -265,15 +395,21 @@ You are an Ouroboros PM interview advisory subagent — lane {lane_id}.
 - session_id: {context.get("session_id")}
 - question_identity: {context.get("question_identity")}
 
-## Your Brief
-The full brief (rules, repository roster, answer contract) is stored, not
-inlined. Fetch it with the MCP tool `ouroboros_fetch_artifact` (load it via
-your runtime's tool discovery if deferred):
-- contract_id: `{bundle_id}`
-- lane_id: `{lane_id}`
-Follow the fetched brief exactly — it defines your answer contract, and your
-final message is only what its Output section specifies.
-If the fetch fails, reply with exactly `{UNDISPATCHED_SENTINEL}` and nothing else."""
+## Order of work
+1. **Does this question need this lane at all?** If not, answer the empty
+   state{no_op_hint} and stop. Do not investigate to prove it.
+2. **Read what this lane already found here** — `ouroboros_fetch_artifact` with
+   each pair below (load the tool via your runtime's tool discovery if
+   deferred). If that answers the question, stop there.
+{reuse}
+{_investigation_step(roster, schema_json)}
+
+{answer_section}Describe, never prescribe: what you find is an input to the PM's decision, not
+the decision. If two sources disagree, carry both — the disagreement is what the
+PM most needs.{plain_rule}
+
+Full brief (rules, worked examples, field descriptions): `ouroboros_fetch_artifact`
+with contract_id `{bundle_id}`, lane_id `{lane_id}`."""
 
 
 async def externalize_advisory_payloads(meta: dict[str, Any], findings_store: Any) -> None:
@@ -287,6 +423,13 @@ async def externalize_advisory_payloads(meta: dict[str, Any], findings_store: An
     surgery. After this, the response carries the questions and fetchable
     references; the briefs sit in the same store the children already fetch
     findings from.
+
+    What travels is decided by what a child cannot work without: the answer
+    schema (stripped of its descriptions), the roster it may cite, and the
+    findings it may reuse all ride the stub, and the fetch carries only what
+    explains them. The first shape of this put everything behind the fetch, and
+    a lane that could not reach the store had no schema, no roster and no rules
+    — one call away from having nothing to do.
 
     Fail-open on every edge: no store, no fanout id, or a publish that fails
     leaves the full prompts inline — today's behavior, oversized but whole.
@@ -330,11 +473,26 @@ async def externalize_advisory_payloads(meta: dict[str, Any], findings_store: An
             error=str(exc),
         )
         return
+    request = meta.get("question_advisory_request")
+    request = request if isinstance(request, dict) else {}
+    contracts = {
+        str(lane.get("lane_id")): lane.get("answer_contract")
+        for lane in (request.get("lanes") or [])
+        if isinstance(lane, dict) and lane.get("lane_id")
+    }
+    by_lane = request.get("recent_findings")
+    by_lane = by_lane if isinstance(by_lane, dict) else {}
     for payload in payloads:
         if isinstance(payload, dict) and payload.get("prompt"):
-            payload["prompt"] = _payload_stub(payload, bundle_id)
-    request = meta.get("question_advisory_request")
-    if isinstance(request, dict):
+            lane_id = str((payload.get("context") or {}).get("lane_id") or "")
+            payload["prompt"] = _payload_stub(
+                payload,
+                bundle_id,
+                contract=contracts.get(lane_id),
+                roster=request.get("repository_roster"),
+                findings=by_lane.get(lane_id),
+            )
+    if request:
         capability = request.get("mcp_tool_capability")
         if isinstance(capability, dict) and capability.get("tool_name"):
             # The only field any wire consumer reads; the rest is fetchable

--- a/src/ouroboros/mcp/tools/pm_batch.py
+++ b/src/ouroboros/mcp/tools/pm_batch.py
@@ -358,12 +358,26 @@ def _payload_stub(
     schema_json = _lean_schema(contract)
     offered = [e for e in findings if isinstance(e, dict)] if findings else []
     if offered:
-        reuse = "\n".join(
-            f"   - contract_id: `{e.get('contract_id')}`, lane_id: `{e.get('lane_id', lane_id)}`"
-            for e in offered
+        listing = "\n".join(
+            f"   - `{e.get('contract_id')}` — published {e.get('published_at')}" for e in offered
+        )
+        # Newest first, and named as a shelf to choose from. Told to fetch each
+        # in turn, a child would spend its whole budget before it started —
+        # these are a head start, not a checklist.
+        reuse = (
+            f"""2. **Read what this lane already found here.** `ouroboros_fetch_artifact`
+   takes a `contract_id` below plus `lane_id: {lane_id}` (load the tool via
+   your runtime's tool discovery if deferred). Newest first — open the ones
+   whose subject looks like this question, not all of them. Use what helps and
+   investigate the rest yourself; if what you read answers the question, stop
+   there.
+{listing}"""
+            if offered
+            else ""
         )
     else:
-        reuse = "   - none published yet — go to 3."
+        reuse = """2. **Nothing has been found here yet** for this lane, so there is nothing to
+   reuse. Go to 3."""
     no_op = _no_op_literals(schema_json) if schema_json else ""
     no_op_hint = f" ({no_op})" if no_op else ""
     # Named only where the shape has the field: the data lane reports
@@ -398,9 +412,6 @@ evidence the PM reads before answering; you never answer for them.
 ## Order of work
 1. **Does this question need this lane at all?** If not, answer the empty
    state{no_op_hint} and stop. Do not investigate to prove it.
-2. **Read what this lane already found here** — `ouroboros_fetch_artifact` with
-   each pair below (load the tool via your runtime's tool discovery if
-   deferred). If that answers the question, stop there.
 {reuse}
 {_investigation_step(roster, schema_json)}
 

--- a/src/ouroboros/mcp/tools/pm_batch.py
+++ b/src/ouroboros/mcp/tools/pm_batch.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import structlog
 
+from ouroboros.core.types import Result
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 
 log = structlog.get_logger()
@@ -51,14 +52,25 @@ async def interview_answer_lock(
 
     A batched turn is the first shape where this is reachable in ordinary use —
     a host holding three answerable questions can send two answers as parallel
-    tool calls — but the read-modify-write is shared by every answer path, so
-    the lock is taken around the whole call rather than around the batch
-    branch. Locks are keyed by interview and live on the handler, which the
-    server builds once at startup; the same idiom as the execution handler's
-    ``_idempotency_locks``.
+    tool calls — but the read-modify-write is shared by the in-process batch
+    and single-question paths alike, so the lock is taken once around the call
+    rather than around the batch branch. Locks are keyed by interview and live
+    on the handler, which the server builds once at startup; the same idiom as
+    the execution handler's ``_idempotency_locks``.
 
-    The scope is one server process, which is the scope of the state directory
-    it owns.
+    The call without an answer is deliberately not exempted, though it looks
+    read-only and holding the lock through the next turn's generation — a real
+    LLM call — makes a timed-out host's retry queue behind it. It only reads
+    while something is pending: with no pending batch and no unanswered round
+    it plans the next turn and persists it, which is the same read-modify-write
+    under another name. Queuing that retry is the point; letting it plan
+    concurrently is the defect this closes.
+
+    What this does not cover, so it is not mistaken for more: the plugin
+    dispatch branch records answers on its own path, and a data directory is a
+    user-global location that several server processes can open at once. An
+    ``asyncio.Lock`` orders coroutines in one process; it does not order
+    processes.
     """
     async with locks.setdefault(session_id, asyncio.Lock()):
         yield
@@ -153,10 +165,35 @@ async def record_member_answer(
     ``[decide_later]`` sent for a passthrough member records as a plain answer
     rather than silently discarding data, exactly as the single-question guard
     does with the last classification.
+
+    A member whose decision is already in the interview state is not recorded
+    again. Two files carry one turn — the state holds the decisions, the PM
+    meta holds who is still pending — and the state is written first, so a
+    failed or interrupted meta write leaves a member marked pending whose
+    answer is already durable. The host sees an error and retries, and without
+    this the retry would put a second round under the same question. Reading
+    the decision back from the state is what makes the retry idempotent: the
+    caller goes on to persist the pending list without this member, so the
+    retry repairs the metadata instead of duplicating the decision.
+
+    The comparison is deliberately narrow — the same answer, or a sentinel,
+    which carries no words of the user's to lose. A question repeated verbatim
+    later in the interview and answered differently is a new decision and is
+    recorded as one.
     """
     question = str(member.get("question"))
     classification = member.get("classification")
     stripped = answer.strip()
+    sentinel = (stripped == "[decide_later]" and classification == "decide_later") or (
+        stripped == "[deferred]" and classification == "deferred"
+    )
+    recorded = next(
+        (r for r in state.rounds if r.question == question and r.user_response is not None),
+        None,
+    )
+    if recorded is not None and (sentinel or recorded.user_response == answer):
+        log.info("pm.batch_member_already_recorded", question=question[:100])
+        return Result.ok(state)
     skipped = False
     if stripped == "[decide_later]" and classification == "decide_later":
         result = await engine.skip_as_decide_later(state, question)

--- a/src/ouroboros/mcp/tools/pm_batch.py
+++ b/src/ouroboros/mcp/tools/pm_batch.py
@@ -43,6 +43,16 @@ ADVISORY_PROMPT_BUNDLE_KIND = "advisory_prompt_bundle"
 #: the store still knows what to look at and what shape to answer in.
 UNDISPATCHED_SENTINEL = "UNDISPATCHED"
 
+#: How many of the offered findings a stub lists.
+#:
+#: The offer set is bounded by attention (twenty, in ``recent_findings``); this
+#: bounds the *prompt*, which is a different question. An entry carries an id
+#: and a time and nothing else, so past the first few a child is choosing
+#: between identifiers it cannot tell apart — twenty of them was a fifth of the
+#: prompt spent on a choice it has no way to make. The rest are named as
+#: withheld rather than dropped, and it may ask for them.
+_STUB_FINDINGS_SHOWN = 5
+
 
 @asynccontextmanager
 async def interview_answer_lock(
@@ -426,24 +436,34 @@ def _payload_stub(
     schema_json = _lean_schema(contract)
     offered = [e for e in findings if isinstance(e, dict)] if findings else []
     if offered:
+        shown = offered[:_STUB_FINDINGS_SHOWN]
         # To the minute. Sub-second precision and a UTC offset decide nothing
-        # here and are twenty lines of it.
+        # here and were a line of noise per entry.
         listing = "\n".join(
             f"   - `{e.get('contract_id')}` — {str(e.get('published_at') or '')[:16]}"
-            for e in offered
+            for e in shown
+        )
+        withheld = len(offered) - len(shown)
+        # Said, not silently dropped: a truncation nobody mentions reads as
+        # "this is all there was", which is the confusion the whole mechanism
+        # exists to prevent.
+        rest = (
+            f"\n   {withheld} older one{'' if withheld == 1 else 's'} from today are not"
+            " listed; ask for them if these leave the question open."
+            if withheld > 0
+            else ""
         )
         # Recency is the only thing separating these entries, so it is the only
         # thing the instruction may lean on. Telling a child to pick the ones
         # whose subject fits would name a signal the offer does not carry, and
-        # telling it to fetch each in turn would spend the budget before the
-        # work started. These are a head start, not a checklist.
+        # listing all twenty would spend a fifth of the prompt on identifiers
+        # it cannot choose between. These are a head start, not a checklist.
         reuse = f"""2. **Read what this lane already found here.** `ouroboros_fetch_artifact`
    takes a `contract_id` below plus `lane_id: {lane_id}` (load the tool via
-   your runtime's tool discovery if deferred). They are newest first and that
-   is all you can tell them apart by, so start at the top and open a few
-   rather than all of them. Use what helps, investigate the rest yourself, and
-   if what you read answers the question, stop there.
-{listing}"""
+   your runtime's tool discovery if deferred). Newest first, and recency is
+   all you can tell them apart by. Use what helps, investigate the rest
+   yourself, and if what you read answers the question, stop there.
+{listing}{rest}"""
     else:
         reuse = """2. **Nothing has been found here yet** for this lane, so there is nothing to
    reuse. Go to 3."""

--- a/src/ouroboros/mcp/tools/pm_batch.py
+++ b/src/ouroboros/mcp/tools/pm_batch.py
@@ -1,17 +1,19 @@
-"""Batched PM turns (RFC #2222): pending state, member routing, responses.
+"""Batched PM turns (RFC #2222): a turn is asked whole and answered whole.
 
 A batched turn puts one to three questions on the table at once. What this
-module owns is everything that is *about the batch* rather than about one
-question: where pending members live, how an incoming answer is matched to its
-member, how a batched turn renders to the host, and the answer lock a turn with
-several answerable questions is the first shape to need.
+module owns is everything that is *about the turn* rather than about one
+question: how a turn renders to the host, how its answers come back, and how
+they are recorded.
 
-Batch pending state lives in PM meta, never as core question-only rounds. The
-engine's ``record_answer`` fills the *trailing* unanswered round and overwrites
-its question text, so two pending rounds in core state would let an
-out-of-order answer destroy a question silently. One entry per pending
-question, each carrying the classification its skip sentinel is guarded by;
-every member is recorded question-and-answer together at answer time.
+**A turn is atomic** (RFC #2222 revision 4). Nothing is persisted when a turn
+is asked — no question-only round, no pending-member list — and a turn's
+answers arrive together, so a round is written only when it is whole. That is
+what removes the seam three review rounds kept finding: a pending list beside
+the transcript is one fact in two places, and an interleaved write, an
+interrupted one, or a question whose text recurs each turned that gap into a
+lost or duplicated decision. There is no gap to guard now. A call that carries
+no answers is a host that lost its turn; the next turn is planned from the
+transcript rather than restored.
 """
 
 from __future__ import annotations
@@ -24,7 +26,6 @@ from typing import Any
 import structlog
 
 from ouroboros.core.types import Result
-from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 
 log = structlog.get_logger()
 
@@ -45,26 +46,22 @@ async def interview_answer_lock(
 ) -> AsyncIterator[None]:
     """Hold one interview's answer lock for a whole record call.
 
-    Recording an answer reads the interview state and PM meta, then writes
-    both. Two answers that interleave therefore both report success while the
-    second write carries a state that never saw the first: the user's words are
-    gone and their question comes back as still pending.
+    A turn is one write now, but two calls for one interview can still be in
+    flight — a host that retried, two sessions on one id. Each reads the
+    interview state and writes it back, so interleaved they both report success
+    while the later write carries a state that never saw the earlier one, and
+    those decisions are gone.
 
-    A batched turn is the first shape where this is reachable in ordinary use —
-    a host holding three answerable questions can send two answers as parallel
-    tool calls — but the read-modify-write is shared by the in-process batch
-    and single-question paths alike, so the lock is taken once around the call
-    rather than around the batch branch. Locks are keyed by interview and live
-    on the handler, which the server builds once at startup; the same idiom as
-    the execution handler's ``_idempotency_locks``.
+    The call carrying no answers is not exempted. It looks read-only and it
+    holds the lock through the next turn's generation, a real LLM call, so a
+    timed-out host's retry queues behind it — but it plans a turn and persists
+    what that costs, which is the same read-modify-write under another name.
+    Queuing the retry is the point; letting it plan concurrently is the defect
+    this closes.
 
-    The call without an answer is deliberately not exempted, though it looks
-    read-only and holding the lock through the next turn's generation — a real
-    LLM call — makes a timed-out host's retry queue behind it. It only reads
-    while something is pending: with no pending batch and no unanswered round
-    it plans the next turn and persists it, which is the same read-modify-write
-    under another name. Queuing that retry is the point; letting it plan
-    concurrently is the defect this closes.
+    Locks are keyed by interview and live on the handler, which the server
+    builds once at startup; the same idiom as the execution handler's
+    ``_idempotency_locks``.
 
     What this does not cover, so it is not mistaken for more: the plugin
     dispatch branch records answers on its own path, and a data directory is a
@@ -76,18 +73,81 @@ async def interview_answer_lock(
         yield
 
 
-def pending_batch_entries(meta: dict[str, Any] | None) -> list[dict[str, Any]]:
-    """Return the still-unanswered members of a batched turn."""
-    entries = (meta or {}).get("pending_batch")
-    if not isinstance(entries, list):
-        return []
-    return [
-        entry for entry in entries if isinstance(entry, dict) and str(entry.get("question") or "")
-    ]
+def turn_answers(
+    answers: Any,
+    answer: str | None,
+    last_question: str | None,
+) -> tuple[list[tuple[str, str]], str | None]:
+    """Normalize one call's answers into ``(question, answer)`` pairs.
+
+    A turn's answers arrive together (RFC #2222 decision 2), so this is the
+    only shape the recorder ever sees: each pair carries its own question and
+    nothing is matched against anything the server remembered. ``answers`` is
+    the batch spelling — a list of ``{question, answer}`` — and
+    ``answer``/``last_question`` is the single-question one.
+
+    An answer without its question is refused rather than filed against
+    whatever round happens to be last. Nothing is persisted when a turn is
+    asked, so there is no remembered question to fall back on, and guessing
+    would write a decision under a question nobody was looking at.
+
+    Returns ``(pairs, error)``; an empty pair list with no error means this
+    call carries no answers, which is a reconnect and plans a fresh turn.
+    """
+    if isinstance(answers, list) and answers:
+        pairs: list[tuple[str, str]] = []
+        for entry in answers:
+            if not isinstance(entry, dict):
+                return [], "Each item of 'answers' must be an object with 'question' and 'answer'."
+            question = str(entry.get("question") or "").strip()
+            text = entry.get("answer")
+            if not question or not isinstance(text, str) or not text.strip():
+                return [], (
+                    "Each item of 'answers' needs a non-empty 'question' and 'answer'. "
+                    "Every answer names the question it belongs to."
+                )
+            pairs.append((question, text))
+        return pairs, None
+    if answer:
+        if not last_question:
+            return [], (
+                "Pass the question this answer belongs to as 'last_question', or send the "
+                "turn's answers together as 'answers': [{question, answer}]."
+            )
+        return [(last_question, answer)], None
+    return [], None
+
+
+async def record_turn_answers(engine: Any, state: Any, pairs: list[tuple[str, str]]) -> Any:
+    """Record a turn's answers, each as a whole question-and-answer round.
+
+    A skip sentinel is honoured wherever it arrives. The server no longer
+    keeps a record of which questions it offered as skippable — that record
+    was the pending state this design removed — so there is nothing to check
+    the sentinel against. Honouring it costs a deferral recorded for a
+    question that may not have been offered as deferrable; refusing it would
+    write a control token into the transcript as though the PM had typed it.
+    The first loses no words of the user's, the second invents some.
+    """
+    for question, answer in pairs:
+        stripped = answer.strip()
+        skipped = stripped in ("[decide_later]", "[deferred]")
+        if stripped == "[decide_later]":
+            result = await engine.skip_as_decide_later(state, question)
+        elif stripped == "[deferred]":
+            result = await engine.skip_as_deferred(state, question)
+        else:
+            result = await engine.record_response(state, answer, question)
+        if result.is_err:
+            return result
+        state = result.value
+        if skipped:
+            state.clear_stored_ambiguity()
+    return Result.ok(state)
 
 
 def batch_entries_for_turns(turns: list[Any]) -> list[dict[str, Any]]:
-    """Project planned turns into persistable pending-batch entries."""
+    """Project planned turns into the entries a turn's response shows."""
     return [
         {
             "question": turn.question,
@@ -96,37 +156,6 @@ def batch_entries_for_turns(turns: list[Any]) -> list[dict[str, Any]]:
         }
         for turn in turns
     ]
-
-
-def resolve_batch_member(
-    pending_batch: list[dict[str, Any]],
-    last_question: str | None,
-) -> tuple[dict[str, Any] | None, str | None]:
-    """Match an incoming answer to its pending member.
-
-    Returns ``(member, None)`` on a match and ``(None, error_message)`` when
-    the answer cannot be filed — several members pending and none named, or a
-    named question that is not one of them. Refusing is what keeps an answer
-    from being recorded under a question the user was not looking at.
-    """
-    pending_list = "\n".join(f"- {e.get('question')}" for e in pending_batch)
-    if last_question:
-        target = next(
-            (e for e in pending_batch if e.get("question") == last_question),
-            None,
-        )
-        if target is None:
-            return None, (
-                "last_question does not match any pending question of this "
-                f"turn. Pending:\n{pending_list}"
-            )
-        return target, None
-    if len(pending_batch) == 1:
-        return pending_batch[0], None
-    return None, (
-        "Several questions from this turn are pending. Pass the question this "
-        f"answer belongs to as 'last_question'. Pending:\n{pending_list}"
-    )
 
 
 def skip_hint_suffix(classification: str | None, session_id: str) -> str:
@@ -153,148 +182,24 @@ def skip_hint_suffix(classification: str | None, session_id: str) -> str:
     return ""
 
 
-async def record_member_answer(
-    engine: Any,
-    state: Any,
-    member: dict[str, Any],
-    answer: str,
-) -> Any:
-    """Record one batch member's answer, honouring its own skip sentinel.
-
-    The sentinel is guarded by the *member's* classification — a
-    ``[decide_later]`` sent for a passthrough member records as a plain answer
-    rather than silently discarding data, exactly as the single-question guard
-    does with the last classification.
-
-    A member whose decision is already in the interview state is not recorded
-    again. Two files carry one turn — the state holds the decisions, the PM
-    meta holds who is still pending — and the state is written first, so a
-    failed or interrupted meta write leaves a member marked pending whose
-    answer is already durable. The host sees an error and retries, and without
-    this the retry would put a second round under the same question. Reading
-    the decision back from the state is what makes the retry idempotent: the
-    caller goes on to persist the pending list without this member, so the
-    retry repairs the metadata instead of duplicating the decision.
-
-    The comparison is deliberately narrow — the same answer, or a sentinel,
-    which carries no words of the user's to lose. A question repeated verbatim
-    later in the interview and answered differently is a new decision and is
-    recorded as one.
-    """
-    question = str(member.get("question"))
-    classification = member.get("classification")
-    stripped = answer.strip()
-    sentinel = (stripped == "[decide_later]" and classification == "decide_later") or (
-        stripped == "[deferred]" and classification == "deferred"
-    )
-    recorded = next(
-        (r for r in state.rounds if r.question == question and r.user_response is not None),
-        None,
-    )
-    if recorded is not None and (sentinel or recorded.user_response == answer):
-        log.info("pm.batch_member_already_recorded", question=question[:100])
-        return Result.ok(state)
-    skipped = False
-    if stripped == "[decide_later]" and classification == "decide_later":
-        result = await engine.skip_as_decide_later(state, question)
-        skipped = True
-    elif stripped == "[deferred]" and classification == "deferred":
-        result = await engine.skip_as_deferred(state, question)
-        skipped = True
-    else:
-        result = await engine.record_response(state, answer, question)
-    if skipped and result.is_ok:
-        result.value.clear_stored_ambiguity()
-    return result
-
-
-def _batch_skip_hint(entry: dict[str, Any], session_id: str) -> str:
-    """Return the skip hint for one batch member, or an empty string."""
+def _batch_skip_hint(entry: dict[str, Any]) -> str:
+    """Return the skip hint for one question of a turn, or an empty string."""
     classification = entry.get("classification")
-    question = str(entry.get("question") or "")
     if classification == "decide_later":
-        return (
-            '  💡 May be skipped: pass answer="[decide_later]" with '
-            f'last_question="{question}" and session_id="{session_id}".'
-        )
+        return '  💡 May be skipped: give this question the answer "[decide_later]".'
     if classification == "deferred":
-        return (
-            '  💡 May be deferred to the dev phase: pass answer="[deferred]" '
-            f'with last_question="{question}" and session_id="{session_id}".'
-        )
+        return '  💡 May be deferred to the dev phase: answer it "[deferred]".'
     return ""
 
 
-def _numbered_questions(session_id: str, entries: list[dict[str, Any]]) -> list[str]:
+def _numbered_questions(entries: list[dict[str, Any]]) -> list[str]:
     lines: list[str] = []
     for index, entry in enumerate(entries, 1):
         lines.append(f"{index}. {entry.get('question')}")
-        hint = _batch_skip_hint(entry, session_id)
+        hint = _batch_skip_hint(entry)
         if hint:
             lines.append(hint)
     return lines
-
-
-def batch_pending_meta(
-    session_id: str,
-    remaining: list[dict[str, Any]],
-    *,
-    decide_later_count: int,
-) -> dict[str, Any]:
-    """Build the response meta for a turn whose batch is partially answered."""
-    first = remaining[0]
-    return {
-        "session_id": session_id,
-        "input_type": "freeText",
-        "response_param": "answer",
-        "question": first.get("question"),
-        "question_batch": [dict(entry) for entry in remaining],
-        "is_complete": False,
-        "interview_complete": False,
-        "classification": first.get("classification"),
-        "skip_eligible": bool(first.get("skip_eligible")),
-        "deferred_this_round": [],
-        "decide_later_this_round": [],
-        "new_deferred": [],
-        "new_decide_later": [],
-        "deferred_count": 0,
-        "decide_later_count": decide_later_count,
-    }
-
-
-def batch_pending_result(
-    session_id: str,
-    remaining: list[dict[str, Any]],
-    *,
-    decide_later_count: int,
-    diff: dict[str, Any] | None = None,
-) -> MCPToolResult:
-    """Render the still-pending members of a batch for the host.
-
-    Advisory lanes were dispatched when the batch was issued, so a re-display
-    carries none — dispatching again would multiply fan-outs for questions
-    whose lanes already ran.
-    """
-    meta = batch_pending_meta(session_id, remaining, decide_later_count=decide_later_count)
-    if diff:
-        meta["deferred_this_round"] = diff["new_deferred"]
-        meta["decide_later_this_round"] = diff["new_decide_later"]
-        meta.update(diff)
-    lines = [
-        f"Session {session_id}",
-        "",
-        f"{len(remaining)} question(s) from this turn still await an answer. "
-        "Answer each with its own call, passing the question text as "
-        "'last_question'. Evidence lanes for these questions were already "
-        "dispatched with the turn — do not dispatch them again.",
-        "",
-        *_numbered_questions(session_id, remaining),
-    ]
-    return MCPToolResult(
-        content=(MCPContentItem(type=ContentType.TEXT, text="\n".join(lines)),),
-        is_error=False,
-        meta=meta,
-    )
 
 
 def batch_turn_meta_and_text(
@@ -331,11 +236,13 @@ def batch_turn_meta_and_text(
     lines = [
         f"Session {session_id}",
         "",
-        f"This turn asks {len(batch_entries)} independent questions. Answer "
-        "each with its own call, passing the question text as "
-        "'last_question'. Answer in any order; unanswered ones stay pending.",
+        f"This turn asks {len(batch_entries)} independent questions. Put every "
+        "answer to the user, then send them back together in one call: "
+        f"'answers': [{{question, answer}}, ...] with session_id=\"{session_id}\". "
+        "The turn is recorded as a whole; a call that arrives without them "
+        "plans a new turn instead.",
         "",
-        *_numbered_questions(session_id, batch_entries),
+        *_numbered_questions(batch_entries),
     ]
     return response_meta, "\n".join(lines)
 
@@ -445,10 +352,8 @@ __all__ = [
     "ADVISORY_PROMPT_BUNDLE_KIND",
     "UNDISPATCHED_SENTINEL",
     "batch_entries_for_turns",
-    "batch_pending_meta",
-    "batch_pending_result",
+    "record_turn_answers",
+    "turn_answers",
     "batch_turn_meta_and_text",
     "externalize_advisory_payloads",
-    "pending_batch_entries",
-    "resolve_batch_member",
 ]

--- a/src/ouroboros/mcp/tools/pm_batch.py
+++ b/src/ouroboros/mcp/tools/pm_batch.py
@@ -295,34 +295,24 @@ def _lean_schema(contract: Any) -> str | None:
 #: shape before it. ``tests/unit/mcp/tools/test_pm_handler_batch.py`` checks
 #: that every field a contract requires is named here.
 _ANSWER_SPECS: dict[str, str] = {
-    "pm_code_context_answer.v2": """- `question_identity` and `lane_id` exactly as this task gives them.
-- `examined`: one entry per repository you opened — `repo_id` from 3 above and
-  `policy_claims`, each of them `{path, policy_claim, plain_statement}`. A
-  repository you read and found nothing in is an entry with no claims; one you
-  never opened has no entry at all.
-- Nothing examined: `examined: []` with `nothing_examined_reason` —
-  not_a_policy_question, no_repository_in_roster, roster_repository_not_readable.
-- `path` is relative to the repository, never absolute, never through `..`.
-- `plain_statement` says that claim once in the question's own language, with
-  no paths or identifiers in it — it is the part the PM reads.
-- At most 20 claims per repository; `policy_claim` ≤ 600 characters,
-  `plain_statement` ≤ 300. Any field not named here is rejected with the answer.""",
-    "data_evidence_answer.v1": """- `question_identity` and `lane_id` exactly as this task gives them.
-- Measured something: `data_needed: true` and `read_requests` (at most 5), each
-  with `operation: "read"`, `tool_name`, `metric`, `aggregation`,
-  `informs_decision`, and `values` carrying the number you actually read back.
-  Optional per request: `filters` of `{field, comparator, value}`, `time_window`,
-  `group_by`.
-- Nothing to measure: `data_needed: false` with `no_evidence_reason` —
-  not_a_measurement, answer_would_not_be_an_aggregate,
-  question_too_ambiguous_to_measure, no_data_store_described,
-  store_described_but_not_callable.
-- `aggregation` is one of count, distinct_count, sum, average, median, p90, p95,
-  p99, min, max, rate; `comparator` one of eq, neq, gt, gte, lt, lte.
-- Without `group_by` there is exactly one value; with it, up to 20 `{group,
-  value}` entries. A count or distinct_count value is a non-negative integer.
-- No rows, names or identifiers — an aggregate is what this lane may carry. Any
-  field not named here is rejected with the answer.""",
+    "pm_code_context_answer.v2": """- `question_identity` and `lane_id` exactly as given above.
+- `examined`: one entry per repository you opened — its `repo_id` from 3 and
+  `policy_claims` of `{path, policy_claim, plain_statement}`. Read and found
+  nothing: an entry with no claims. Never opened: no entry.
+- Opened nothing at all: `examined: []` with `nothing_examined_reason`.
+- `path` is relative to the repository.
+- `plain_statement`: that claim once, in the question's language, no paths or
+  identifiers.""",
+    "data_evidence_answer.v1": """- `question_identity` and `lane_id` exactly as given above.
+- Measured: `data_needed: true` and `read_requests`, each with
+  `operation: "read"`, `tool_name`, `metric`, `aggregation`,
+  `informs_decision`, and `values` — the numbers you read back. Optional:
+  `filters` of `{field, comparator, value}`, `time_window`, `group_by`.
+- Nothing to measure: `data_needed: false` with `no_evidence_reason`.
+- `aggregation`: count, distinct_count, sum, average, median, p90, p95, p99,
+  min, max, rate. `comparator`: eq, neq, gt, gte, lt, lte.
+- `values` is one entry, or one per group when you grouped.
+- You carry aggregates — never a row, a name, or an identifier.""",
 }
 
 
@@ -390,10 +380,9 @@ def _investigation_step(roster: Any, schema_json: str | None) -> str:
     cites_repos = bool(schema_json) and '"repo_id"' in (schema_json or "")
     entries = [e for e in roster if isinstance(e, dict) and e.get("repo_id")] if roster else []
     if not cites_repos:
-        return """3. **Still not enough?** Find the data tools this host exposes and call them —
-   registering one is the willingness to have it called. An empty tool search
-   is where you start looking, never where you stop, and a store is only
-   unreachable once a call to it has actually failed."""
+        return """3. **Still not enough?** Find and call the data tools this host exposes. An
+   empty tool search is where you start, not where you stop; a store counts as
+   unreachable only after a call to it failed."""
     if not entries:
         return """3. **No repository was given to you.** That is the whole answer — report the
    empty state and say so. Reading whatever is at hand would produce evidence
@@ -401,8 +390,7 @@ def _investigation_step(roster: Any, schema_json: str | None) -> str:
     listing = "\n".join(f"   - `{e['repo_id']}` — {e.get('path')}" for e in entries)
     return f"""3. **Still not enough?** Read these repositories:
 {listing}
-   Where you look is open; what you cite is not. Every `repo_id` you report must
-   be one of the above — anything else is rejected at submission."""
+   Look wherever you need to; cite only these."""
 
 
 def _payload_stub(
@@ -430,12 +418,10 @@ def _payload_stub(
     # paid for it anyway. The tool answers the same question on request, and
     # the window and the cap stay its own.
     if offered:
-        reuse = f"""2. **Read what this lane already found here.** Call
-   `ouroboros_fetch_artifact` with `lane_id: {lane_id}` and no `contract_id`
-   (load the tool via your runtime's tool discovery if deferred): it lists
-   what this lane published here in the last day, newest first. Read the ones
-   you want back with the same tool, passing a `contract_id` from that list
-   and the same `lane_id`. If what you read answers the question, stop there."""
+        reuse = f"""2. **Read what this lane already found here.** `ouroboros_fetch_artifact`
+   with `lane_id: {lane_id}` and no `contract_id` lists them, newest first
+   (load the tool via tool discovery if deferred); pass back a `contract_id`
+   from that list to read one. Stop there if it answers the question."""
     else:
         reuse = """2. **Nothing has been found here yet** for this lane, so there is nothing to
    reuse. Go to 3."""
@@ -443,8 +429,8 @@ def _payload_stub(
     no_op_hint = f" ({no_op})" if no_op else ""
     answer_section = _answer_section(contract, schema_json)
     return f"""## Task
-You are an Ouroboros PM interview advisory subagent — lane {lane_id}. You gather
-evidence the PM reads before answering; you never answer for them.
+You are an Ouroboros PM interview advisory subagent — lane {lane_id}. You
+gather evidence the PM reads before deciding; you never decide for them.
 
 ## PM Question
 {context.get("question")}
@@ -454,14 +440,13 @@ evidence the PM reads before answering; you never answer for them.
 - question_identity: {context.get("question_identity")}
 
 ## Order of work
-1. **Does this question need this lane at all?** If not, answer the empty
-   state{no_op_hint} and stop. Do not investigate to prove it.
+1. **Does this question need this lane?** If not, answer the empty
+   state{no_op_hint} and stop — do not investigate to prove it.
 {reuse}
 {_investigation_step(roster, schema_json)}
 
-{answer_section}Describe, never prescribe: what you find is an input to the PM's decision, not
-the decision. If two sources disagree, carry both — the disagreement is what the
-PM most needs.
+{answer_section}Describe, never prescribe. If two sources disagree, carry both — that
+disagreement is the finding.
 
 Full brief (rules and field descriptions): `ouroboros_fetch_artifact`
 with contract_id `{bundle_id}`, lane_id `{lane_id}`."""

--- a/src/ouroboros/mcp/tools/pm_batch.py
+++ b/src/ouroboros/mcp/tools/pm_batch.py
@@ -279,6 +279,127 @@ def _lean_schema(contract: Any) -> str | None:
     return json.dumps(_without_prose(schema), ensure_ascii=False, separators=(",", ":"))
 
 
+#: A worked answer per contract, in place of the contract's own schema.
+#:
+#: The schema is exact and nearly unreadable — a child reads ``oneOf`` branches
+#: and regex patterns to work out that ``path`` is repository-relative. One
+#: filled-in answer says the same thing in a quarter of the characters, and
+#: says the part regexes say worst: what a value looks like.
+#:
+#: Keyed by ``contract_id``, so a contract that changes version falls back to
+#: its schema rather than being described by an example written for the old
+#: one. What an example cannot show — bounds, enums, the rules about what may
+#: not appear — is stated beside it, and only what a wrong answer would be
+#: rejected for.
+#:
+#: ``tests/unit/mcp/tools/test_pm_handler_batch.py`` validates every example
+#: against the contract it is keyed to, so an example cannot drift from it.
+_ANSWER_EXAMPLES: dict[str, tuple[dict[str, Any], dict[str, Any], str]] = {
+    "pm_code_context_answer.v2": (
+        {
+            "question_identity": "pm-question:a48ab92c1bae912e",
+            "lane_id": "code_context",
+            "examined": [
+                {
+                    "repo_id": "podo-backend-2f0e5f7e",
+                    "policy_claims": [
+                        {
+                            "path": "src/main/java/com/example/booking/ReminderScheduler.java",
+                            "policy_claim": (
+                                "Three reminders fire at +6h, +3h and day+6 09:21 after a trial "
+                                "booking, keyed {userId}-{templateCode}, and are cancelled once "
+                                "the user books a class."
+                            ),
+                            "plain_statement": (
+                                "신청 직후 개입은 전부 시점 기반 리마인드이고, 예약하면 취소됩니다."
+                            ),
+                        }
+                    ],
+                },
+                {"repo_id": "podo-app-cf98ca21", "policy_claims": []},
+            ],
+        },
+        {
+            "question_identity": "pm-question:a48ab92c1bae912e",
+            "lane_id": "code_context",
+            "examined": [],
+            "nothing_examined_reason": "not_a_policy_question",
+        },
+        """- `path` is relative to the repository, never absolute and never through `..`.
+- `plain_statement` is the claim beside it said once, in the question's own
+  language, with no paths or identifiers in it — it is what the PM reads.
+- One entry per repository. A repository you read and found nothing in is an
+  entry with empty `policy_claims` — that is how "I looked and it is clean" is
+  said, and a repository you never opened has no entry at all.
+- At most 20 claims per repository; `policy_claim` ≤ 600 characters,
+  `plain_statement` ≤ 300.
+- No other fields. Anything the shape does not name is rejected with the answer.""",
+    ),
+    "data_evidence_answer.v1": (
+        {
+            "question_identity": "pm-question:a48ab92c1bae912e",
+            "lane_id": "data_context",
+            "data_needed": True,
+            "read_requests": [
+                {
+                    "operation": "read",
+                    "tool_name": "podo_mysql_query",
+                    "metric": "trial bookings that reached the lesson",
+                    "aggregation": "count",
+                    "filters": [{"field": "status", "comparator": "eq", "value": "COMPLETED"}],
+                    "time_window": "last 30 days",
+                    "informs_decision": "which of the two drop-offs is the larger one today",
+                    "values": [{"value": 1832}],
+                }
+            ],
+        },
+        {
+            "question_identity": "pm-question:a48ab92c1bae912e",
+            "lane_id": "data_context",
+            "data_needed": False,
+            "no_evidence_reason": "not_a_measurement",
+        },
+        """- At most 5 read requests, each carrying the value it actually read back.
+- `aggregation` is one of count, distinct_count, sum, average, median, p90,
+  p95, p99, min, max, rate; `comparator` one of eq, neq, gt, gte, lt, lte.
+- A count or distinct_count value is a non-negative integer.
+- Without `group_by` there is exactly one value; with it, up to 20 entries of
+  `{group, value}`.
+- No rows, names or identifiers — an aggregate is what this lane may carry.
+- No other fields. Anything the shape does not name is rejected with the answer.""",
+    ),
+}
+
+
+def _answer_section(contract: Any, schema_json: str | None) -> str:
+    """Return the ``## Answer`` block: a worked example, or the schema itself."""
+    contract_id = contract.get("contract_id") if isinstance(contract, dict) else None
+    example = _ANSWER_EXAMPLES.get(str(contract_id))
+    if example is None:
+        if not schema_json:
+            return ""
+        return f"""## Answer
+Your final message is this JSON and nothing else — no prose around it:
+```json
+{schema_json}
+```
+"""
+    answer, empty, notes = example
+    return f"""## Answer
+Your final message is one JSON object and nothing else — no prose around it,
+shaped like this:
+```json
+{json.dumps(answer, ensure_ascii=False, indent=2)}
+```
+Nothing to report is its own answer, not an empty version of the one above:
+```json
+{json.dumps(empty, ensure_ascii=False, indent=2)}
+```
+{notes}
+
+"""
+
+
 def _no_op_literals(schema_json: str) -> str:
     """Return the empty-state reason literals this lane's schema admits.
 
@@ -381,24 +502,7 @@ def _payload_stub(
    reuse. Go to 3."""
     no_op = _no_op_literals(schema_json) if schema_json else ""
     no_op_hint = f" ({no_op})" if no_op else ""
-    # Named only where the shape has the field: the data lane reports
-    # measurements, which are already in the PM's language.
-    plain_rule = (
-        " Each claim also carries a `plain_statement`: one sentence in the"
-        " question's own language, no paths or identifiers."
-        if schema_json and '"plain_statement"' in schema_json
-        else ""
-    )
-    answer_section = (
-        f"""## Answer
-Your final message is this JSON and nothing else — no prose around it:
-```json
-{schema_json}
-```
-"""
-        if schema_json
-        else ""
-    )
+    answer_section = _answer_section(contract, schema_json)
     return f"""## Task
 You are an Ouroboros PM interview advisory subagent — lane {lane_id}. You gather
 evidence the PM reads before answering; you never answer for them.
@@ -418,7 +522,7 @@ evidence the PM reads before answering; you never answer for them.
 
 {answer_section}Describe, never prescribe: what you find is an input to the PM's decision, not
 the decision. If two sources disagree, carry both — the disagreement is what the
-PM most needs.{plain_rule}
+PM most needs.
 
 Full brief (rules, worked examples, field descriptions): `ouroboros_fetch_artifact`
 with contract_id `{bundle_id}`, lane_id `{lane_id}`."""

--- a/src/ouroboros/mcp/tools/pm_batch.py
+++ b/src/ouroboros/mcp/tools/pm_batch.py
@@ -279,138 +279,51 @@ def _lean_schema(contract: Any) -> str | None:
     return json.dumps(_without_prose(schema), ensure_ascii=False, separators=(",", ":"))
 
 
-#: A worked answer per contract, in place of the contract's own schema.
+#: What each contract asks for, said in words instead of as its schema.
 #:
 #: The schema is exact and nearly unreadable — a child reads ``oneOf`` branches
-#: and regex patterns to work out that ``path`` is repository-relative. One
-#: filled-in answer says the same thing in a quarter of the characters, and
-#: says the part regexes say worst: what a value looks like.
+#: and regex patterns to work out that ``path`` is repository-relative. Naming
+#: the fields and their bounds says the same in a fraction of the characters.
+#:
+#: Deliberately not a filled-in example. An example is a claim already written
+#: in the answer's shape, and a child short on evidence has one in front of it
+#: that only needs its identifiers changed — the fabricated-but-well-formed
+#: finding is the one outcome this mechanism exists to prevent.
 #:
 #: Keyed by ``contract_id``, so a contract that changes version falls back to
-#: its schema rather than being described by an example written for the old
-#: one. What an example cannot show — bounds, enums, the rules about what may
-#: not appear — is stated beside it, and only what a wrong answer would be
-#: rejected for.
-#:
-#: **Every value in them is deliberately fictional**, and the identifiers are
-#: chosen so that copying one wholesale fails: ``example-repo-a1b2c3d4`` is in
-#: no roster, so an answer carrying it is rejected at submission. An example
-#: whose values looked real would be the one thing this mechanism exists to
-#: prevent — a fabricated claim, correctly shaped, reaching the PM as evidence.
-#: Wrong-and-refused and invented-and-accepted are not the same failure, and
-#: the example is written to fail the first way.
-#:
-#: ``tests/unit/mcp/tools/test_pm_handler_batch.py`` validates every example
-#: against the contract it is keyed to, so an example cannot drift from it, and
-#: checks that its identifiers are none of the ones a lane is actually given.
-_ANSWER_EXAMPLES: dict[str, tuple[dict[str, Any], dict[str, Any], str]] = {
-    "pm_code_context_answer.v2": (
-        {
-            "question_identity": "pm-question:0000000000000000",
-            "lane_id": "code_context",
-            "examined": [
-                {
-                    "repo_id": "example-repo-a1b2c3d4",
-                    "policy_claims": [
-                        {
-                            "path": "src/main/java/com/example/booking/ReminderScheduler.java",
-                            "policy_claim": (
-                                "Three reminders fire at +6h, +3h and day+6 09:21 after a trial "
-                                "booking, keyed {userId}-{templateCode}, and are cancelled once "
-                                "the user books a class."
-                            ),
-                            "plain_statement": (
-                                "신청 직후 개입은 전부 시점 기반 리마인드이고, 예약하면 취소됩니다."
-                            ),
-                        }
-                    ],
-                },
-                {"repo_id": "example-app-e5f6a7b8", "policy_claims": []},
-            ],
-        },
-        {
-            "question_identity": "pm-question:0000000000000000",
-            "lane_id": "code_context",
-            "examined": [],
-            "nothing_examined_reason": "not_a_policy_question",
-        },
-        """- `path` is relative to the repository, never absolute and never through `..`.
-- `plain_statement` is the claim beside it said once, in the question's own
-  language, with no paths or identifiers in it — it is what the PM reads.
-- One entry per repository. A repository you read and found nothing in is an
-  entry with empty `policy_claims` — that is how "I looked and it is clean" is
-  said, and a repository you never opened has no entry at all.
+#: rendering its schema rather than being described by text written for the
+#: shape before it. ``tests/unit/mcp/tools/test_pm_handler_batch.py`` checks
+#: that every field a contract requires is named here.
+_ANSWER_SPECS: dict[str, str] = {
+    "pm_code_context_answer.v2": """- `question_identity` and `lane_id` exactly as this task gives them.
+- `examined`: one entry per repository you opened — `repo_id` from 3 above and
+  `policy_claims`, each of them `{path, policy_claim, plain_statement}`. A
+  repository you read and found nothing in is an entry with no claims; one you
+  never opened has no entry at all.
+- Nothing examined: `examined: []` with `nothing_examined_reason` —
+  not_a_policy_question, no_repository_in_roster, roster_repository_not_readable.
+- `path` is relative to the repository, never absolute, never through `..`.
+- `plain_statement` says that claim once in the question's own language, with
+  no paths or identifiers in it — it is the part the PM reads.
 - At most 20 claims per repository; `policy_claim` ≤ 600 characters,
-  `plain_statement` ≤ 300.
-- No other fields. Anything the shape does not name is rejected with the answer.""",
-    ),
-    "data_evidence_answer.v1": (
-        {
-            "question_identity": "pm-question:0000000000000000",
-            "lane_id": "data_context",
-            "data_needed": True,
-            "read_requests": [
-                {
-                    "operation": "read",
-                    "tool_name": "example_metrics_tool",
-                    "metric": "trial bookings that reached the lesson",
-                    "aggregation": "count",
-                    "filters": [{"field": "status", "comparator": "eq", "value": "COMPLETED"}],
-                    "time_window": "last 30 days",
-                    "informs_decision": "which of the two drop-offs is the larger one today",
-                    "values": [{"value": 1832}],
-                }
-            ],
-        },
-        {
-            "question_identity": "pm-question:0000000000000000",
-            "lane_id": "data_context",
-            "data_needed": False,
-            "no_evidence_reason": "not_a_measurement",
-        },
-        """- At most 5 read requests, each carrying the value it actually read back.
-- `aggregation` is one of count, distinct_count, sum, average, median, p90,
-  p95, p99, min, max, rate; `comparator` one of eq, neq, gt, gte, lt, lte.
-- A count or distinct_count value is a non-negative integer.
-- Without `group_by` there is exactly one value; with it, up to 20 entries of
-  `{group, value}`.
-- No rows, names or identifiers — an aggregate is what this lane may carry.
-- No other fields. Anything the shape does not name is rejected with the answer.""",
-    ),
+  `plain_statement` ≤ 300. Any field not named here is rejected with the answer.""",
+    "data_evidence_answer.v1": """- `question_identity` and `lane_id` exactly as this task gives them.
+- Measured something: `data_needed: true` and `read_requests` (at most 5), each
+  with `operation: "read"`, `tool_name`, `metric`, `aggregation`,
+  `informs_decision`, and `values` carrying the number you actually read back.
+  Optional per request: `filters` of `{field, comparator, value}`, `time_window`,
+  `group_by`.
+- Nothing to measure: `data_needed: false` with `no_evidence_reason` —
+  not_a_measurement, answer_would_not_be_an_aggregate,
+  question_too_ambiguous_to_measure, no_data_store_described,
+  store_described_but_not_callable.
+- `aggregation` is one of count, distinct_count, sum, average, median, p90, p95,
+  p99, min, max, rate; `comparator` one of eq, neq, gt, gte, lt, lte.
+- Without `group_by` there is exactly one value; with it, up to 20 `{group,
+  value}` entries. A count or distinct_count value is a non-negative integer.
+- No rows, names or identifiers — an aggregate is what this lane may carry. Any
+  field not named here is rejected with the answer.""",
 }
-
-
-def _answer_section(contract: Any, schema_json: str | None) -> str:
-    """Return the ``## Answer`` block: a worked example, or the schema itself."""
-    contract_id = contract.get("contract_id") if isinstance(contract, dict) else None
-    example = _ANSWER_EXAMPLES.get(str(contract_id))
-    if example is None:
-        if not schema_json:
-            return ""
-        return f"""## Answer
-Your final message is this JSON and nothing else — no prose around it:
-```json
-{schema_json}
-```
-"""
-    answer, empty, notes = example
-    return f"""## Answer
-Your final message is one JSON object and nothing else — no prose around it,
-shaped like this:
-```json
-{json.dumps(answer, ensure_ascii=False, indent=2)}
-```
-Nothing to report is its own answer, not an empty version of the one above:
-```json
-{json.dumps(empty, ensure_ascii=False, indent=2)}
-```
-**Every value above is invented.** Take the identity from the Session block,
-the identifiers from 3, and every claim from what you actually read — an
-answer shaped like this one but not read from anywhere is the one thing that
-must never reach the PM.
-{notes}
-
-"""
 
 
 def _no_op_literals(schema_json: str) -> str:
@@ -442,6 +355,27 @@ def _no_op_literals(schema_json: str) -> str:
 
     walk(schema)
     return found[0] if found else ""
+
+
+def _answer_section(contract: Any, schema_json: str | None) -> str:
+    """Return the ``## Answer`` block: the contract said in words, or its schema."""
+    contract_id = contract.get("contract_id") if isinstance(contract, dict) else None
+    spec = _ANSWER_SPECS.get(str(contract_id))
+    if spec is None:
+        if not schema_json:
+            return ""
+        return f"""## Answer
+Your final message is this JSON and nothing else — no prose around it:
+```json
+{schema_json}
+```
+"""
+    return f"""## Answer
+Your final message is one JSON object and nothing else — no prose around it.
+
+{spec}
+
+"""
 
 
 def _investigation_step(roster: Any, schema_json: str | None) -> str:
@@ -537,7 +471,7 @@ evidence the PM reads before answering; you never answer for them.
 the decision. If two sources disagree, carry both — the disagreement is what the
 PM most needs.
 
-Full brief (rules, worked examples, field descriptions): `ouroboros_fetch_artifact`
+Full brief (rules and field descriptions): `ouroboros_fetch_artifact`
 with contract_id `{bundle_id}`, lane_id `{lane_id}`."""
 
 

--- a/src/ouroboros/mcp/tools/pm_batch.py
+++ b/src/ouroboros/mcp/tools/pm_batch.py
@@ -380,15 +380,16 @@ def _investigation_step(roster: Any, schema_json: str | None) -> str:
     cites_repos = bool(schema_json) and '"repo_id"' in (schema_json or "")
     entries = [e for e in roster if isinstance(e, dict) and e.get("repo_id")] if roster else []
     if not cites_repos:
-        return """3. **Not covered there?** Find and call the data tools this host exposes. An
-   empty tool search is where you start, not where you stop; a store counts as
-   unreachable only after a call to it failed."""
+        return """3. **Only if 2 turned up nothing that bears on this question**, find and call
+   the data tools this host exposes. An empty tool search is where you start,
+   not where you stop; a store counts as unreachable only after a call failed."""
     if not entries:
         return """3. **No repository was given to you.** That is the whole answer — report the
    empty state and say so. Reading whatever is at hand would produce evidence
    nothing can check."""
     listing = "\n".join(f"   - `{e['repo_id']}` — {e.get('path')}" for e in entries)
-    return f"""3. **Not covered there?** Read these repositories:
+    return f"""3. **Only if 2 turned up nothing that bears on this question**, read these
+   repositories:
 {listing}
    Look wherever you need to; cite only these. Follow what the question
    plainly touches — report what bears on it, not everything near it."""
@@ -422,7 +423,8 @@ def _payload_stub(
         reuse = f"""2. **Read what this lane already found here.** `ouroboros_fetch_artifact`
    with `lane_id: {lane_id}` and no `contract_id` lists them, newest first
    (load the tool via tool discovery if deferred); pass back a `contract_id`
-   from that list to read one. Stop there if it already covers this question."""
+   from that list to read one. This lane found it — carry it as it stands
+   rather than establishing it again."""
     else:
         reuse = """2. **Nothing has been found here yet** for this lane, so there is nothing to
    reuse. Go to 3."""

--- a/src/ouroboros/mcp/tools/pm_batch.py
+++ b/src/ouroboros/mcp/tools/pm_batch.py
@@ -26,6 +26,12 @@ from typing import Any
 
 import structlog
 
+from ouroboros.bigbang.pm_interview import (
+    DECIDE_LATER_PLACEHOLDER,
+    DEFERRED_PLACEHOLDER,
+)
+from ouroboros.core.errors import ValidationError
+from ouroboros.core.security import InputValidator
 from ouroboros.core.types import Result
 
 log = structlog.get_logger()
@@ -123,7 +129,7 @@ def turn_answers(
     return [], None
 
 
-async def record_turn_answers(engine: Any, state: Any, pairs: list[tuple[str, str]]) -> Any:
+async def record_turn_answers(engine: Any | None, state: Any, pairs: list[tuple[str, str]]) -> Any:
     """Record a turn's answers, each as a whole question-and-answer round.
 
     A skip sentinel is honoured wherever it arrives. The server no longer
@@ -133,21 +139,54 @@ async def record_turn_answers(engine: Any, state: Any, pairs: list[tuple[str, st
     question that may not have been offered as deferrable; refusing it would
     write a control token into the transcript as though the PM had typed it.
     The first loses no words of the user's, the second invents some.
+
+    ``engine`` is None on the runtime that dispatches to a child session.
+    That runtime has no engine to reach — building one there would put an LLM
+    adapter behind an answer being written down, on the very path that exists
+    so the server need not hold one. What it must not have is a second reading
+    of the same answer: whether a token is a skip, and what a skipped round
+    then says, is decided here, above the fork. Below it lies only what an
+    engine uniquely owns — the reframe map, and the open items it accumulates
+    for the summary — and a runtime that plans no questions has neither.
     """
     for question, answer in pairs:
         stripped = answer.strip()
-        skipped = stripped in ("[decide_later]", "[deferred]")
-        if stripped == "[decide_later]":
-            result = await engine.skip_as_decide_later(state, question)
-        elif stripped == "[deferred]":
-            result = await engine.skip_as_deferred(state, question)
+        placeholder = _SKIP_PLACEHOLDERS.get(stripped)
+        if engine is not None:
+            if stripped == "[decide_later]":
+                result = await engine.skip_as_decide_later(state, question)
+            elif stripped == "[deferred]":
+                result = await engine.skip_as_deferred(state, question)
+            else:
+                result = await engine.record_response(state, answer, question)
         else:
-            result = await engine.record_response(state, answer, question)
+            result = _record_without_engine(state, question, placeholder or answer)
         if result.is_err:
             return result
         state = result.value
-        if skipped:
+        if placeholder is not None:
             state.clear_stored_ambiguity()
+    return Result.ok(state)
+
+
+#: The control tokens a turn's answer may be, and the round each one leaves.
+_SKIP_PLACEHOLDERS = {
+    "[decide_later]": DECIDE_LATER_PLACEHOLDER,
+    "[deferred]": DEFERRED_PLACEHOLDER,
+}
+
+
+def _record_without_engine(state: Any, question: str, user_response: str) -> Any:
+    """Write one round the way ``InterviewEngine.record_response`` writes it.
+
+    The same validation guards the same field: a runtime does not get to
+    accept a response the other refuses, any more than it gets to read a
+    skip differently.
+    """
+    is_valid, error_msg = InputValidator.validate_user_response(user_response)
+    if not is_valid:
+        return Result.err(ValidationError(error_msg, field="user_response"))
+    state.record_answer(question, user_response)
     return Result.ok(state)
 
 

--- a/src/ouroboros/mcp/tools/pm_batch.py
+++ b/src/ouroboros/mcp/tools/pm_batch.py
@@ -1,0 +1,386 @@
+"""Batched PM turns (RFC #2222): pending state, member routing, responses.
+
+A batched turn puts one to three questions on the table at once. What this
+module owns is everything that is *about the batch* rather than about one
+question: where pending members live, how an incoming answer is matched to its
+member, and how a batched turn renders to the host.
+
+Batch pending state lives in PM meta, never as core question-only rounds. The
+engine's ``record_answer`` fills the *trailing* unanswered round and overwrites
+its question text, so two pending rounds in core state would let an
+out-of-order answer destroy a question silently. One entry per pending
+question, each carrying the classification its skip sentinel is guarded by;
+every member is recorded question-and-answer together at answer time.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+
+log = structlog.get_logger()
+
+#: Store kind for externalized lane briefs. Not ``question_advisory``, so the
+#: recent-findings reuse query never offers a brief as a finding.
+ADVISORY_PROMPT_BUNDLE_KIND = "advisory_prompt_bundle"
+
+#: What a lane child replies when it cannot fetch its externalized brief. The
+#: host submits that lane as ``undispatched`` — a lane without its brief has
+#: no contract to answer under, and guessing one is worse than absence.
+UNDISPATCHED_SENTINEL = "UNDISPATCHED"
+
+
+def pending_batch_entries(meta: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Return the still-unanswered members of a batched turn."""
+    entries = (meta or {}).get("pending_batch")
+    if not isinstance(entries, list):
+        return []
+    return [
+        entry for entry in entries if isinstance(entry, dict) and str(entry.get("question") or "")
+    ]
+
+
+def batch_entries_for_turns(turns: list[Any]) -> list[dict[str, Any]]:
+    """Project planned turns into persistable pending-batch entries."""
+    return [
+        {
+            "question": turn.question,
+            "classification": turn.classification.output_type.value,
+            "skip_eligible": turn.classification.output_type.value in ("decide_later", "deferred"),
+        }
+        for turn in turns
+    ]
+
+
+def resolve_batch_member(
+    pending_batch: list[dict[str, Any]],
+    last_question: str | None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Match an incoming answer to its pending member.
+
+    Returns ``(member, None)`` on a match and ``(None, error_message)`` when
+    the answer cannot be filed — several members pending and none named, or a
+    named question that is not one of them. Refusing is what keeps an answer
+    from being recorded under a question the user was not looking at.
+    """
+    pending_list = "\n".join(f"- {e.get('question')}" for e in pending_batch)
+    if last_question:
+        target = next(
+            (e for e in pending_batch if e.get("question") == last_question),
+            None,
+        )
+        if target is None:
+            return None, (
+                "last_question does not match any pending question of this "
+                f"turn. Pending:\n{pending_list}"
+            )
+        return target, None
+    if len(pending_batch) == 1:
+        return pending_batch[0], None
+    return None, (
+        "Several questions from this turn are pending. Pass the question this "
+        f"answer belongs to as 'last_question'. Pending:\n{pending_list}"
+    )
+
+
+def skip_hint_suffix(classification: str | None, session_id: str) -> str:
+    """Return the single-question skip hint for a response text, or ``""``.
+
+    Shared by every turn shape that shows one question at a time — start,
+    reconnect, and the single-question response — which carried three verbatim
+    copies of these sentences before batching made a fourth unaffordable.
+    """
+    if classification == "decide_later":
+        return (
+            "\n\n💡 This question can be deferred. "
+            'The user may answer now, or choose "decide later" to skip it. '
+            "If they choose to decide later, pass "
+            f'answer="[decide_later]" with session_id="{session_id}".'
+        )
+    if classification == "deferred":
+        return (
+            "\n\n💡 This is a technical question that can be deferred to the dev phase. "
+            "The user may answer now, or choose to defer it. "
+            "If they choose to defer, pass "
+            f'answer="[deferred]" with session_id="{session_id}".'
+        )
+    return ""
+
+
+async def record_member_answer(
+    engine: Any,
+    state: Any,
+    member: dict[str, Any],
+    answer: str,
+) -> Any:
+    """Record one batch member's answer, honouring its own skip sentinel.
+
+    The sentinel is guarded by the *member's* classification — a
+    ``[decide_later]`` sent for a passthrough member records as a plain answer
+    rather than silently discarding data, exactly as the single-question guard
+    does with the last classification.
+    """
+    question = str(member.get("question"))
+    classification = member.get("classification")
+    stripped = answer.strip()
+    skipped = False
+    if stripped == "[decide_later]" and classification == "decide_later":
+        result = await engine.skip_as_decide_later(state, question)
+        skipped = True
+    elif stripped == "[deferred]" and classification == "deferred":
+        result = await engine.skip_as_deferred(state, question)
+        skipped = True
+    else:
+        result = await engine.record_response(state, answer, question)
+    if skipped and result.is_ok:
+        result.value.clear_stored_ambiguity()
+    return result
+
+
+def _batch_skip_hint(entry: dict[str, Any], session_id: str) -> str:
+    """Return the skip hint for one batch member, or an empty string."""
+    classification = entry.get("classification")
+    question = str(entry.get("question") or "")
+    if classification == "decide_later":
+        return (
+            '  💡 May be skipped: pass answer="[decide_later]" with '
+            f'last_question="{question}" and session_id="{session_id}".'
+        )
+    if classification == "deferred":
+        return (
+            '  💡 May be deferred to the dev phase: pass answer="[deferred]" '
+            f'with last_question="{question}" and session_id="{session_id}".'
+        )
+    return ""
+
+
+def _numbered_questions(session_id: str, entries: list[dict[str, Any]]) -> list[str]:
+    lines: list[str] = []
+    for index, entry in enumerate(entries, 1):
+        lines.append(f"{index}. {entry.get('question')}")
+        hint = _batch_skip_hint(entry, session_id)
+        if hint:
+            lines.append(hint)
+    return lines
+
+
+def batch_pending_meta(
+    session_id: str,
+    remaining: list[dict[str, Any]],
+    *,
+    decide_later_count: int,
+) -> dict[str, Any]:
+    """Build the response meta for a turn whose batch is partially answered."""
+    first = remaining[0]
+    return {
+        "session_id": session_id,
+        "input_type": "freeText",
+        "response_param": "answer",
+        "question": first.get("question"),
+        "question_batch": [dict(entry) for entry in remaining],
+        "is_complete": False,
+        "interview_complete": False,
+        "classification": first.get("classification"),
+        "skip_eligible": bool(first.get("skip_eligible")),
+        "deferred_this_round": [],
+        "decide_later_this_round": [],
+        "new_deferred": [],
+        "new_decide_later": [],
+        "deferred_count": 0,
+        "decide_later_count": decide_later_count,
+    }
+
+
+def batch_pending_result(
+    session_id: str,
+    remaining: list[dict[str, Any]],
+    *,
+    decide_later_count: int,
+    diff: dict[str, Any] | None = None,
+) -> MCPToolResult:
+    """Render the still-pending members of a batch for the host.
+
+    Advisory lanes were dispatched when the batch was issued, so a re-display
+    carries none — dispatching again would multiply fan-outs for questions
+    whose lanes already ran.
+    """
+    meta = batch_pending_meta(session_id, remaining, decide_later_count=decide_later_count)
+    if diff:
+        meta["deferred_this_round"] = diff["new_deferred"]
+        meta["decide_later_this_round"] = diff["new_decide_later"]
+        meta.update(diff)
+    lines = [
+        f"Session {session_id}",
+        "",
+        f"{len(remaining)} question(s) from this turn still await an answer. "
+        "Answer each with its own call, passing the question text as "
+        "'last_question'. Evidence lanes for these questions were already "
+        "dispatched with the turn — do not dispatch them again.",
+        "",
+        *_numbered_questions(session_id, remaining),
+    ]
+    return MCPToolResult(
+        content=(MCPContentItem(type=ContentType.TEXT, text="\n".join(lines)),),
+        is_error=False,
+        meta=meta,
+    )
+
+
+def batch_turn_meta_and_text(
+    session_id: str,
+    batch_entries: list[dict[str, Any]],
+    advisories: list[dict[str, Any]],
+    *,
+    pending_reframe: dict[str, str] | None,
+    diff: dict[str, Any],
+) -> tuple[dict[str, Any], str]:
+    """Build the response meta and pre-dispatch text for a freshly issued batch.
+
+    One advisory envelope per question, nested rather than merged: the fan-out
+    stamps a fixed key namespace, so envelopes on one flat dict would overwrite
+    each other's fanout ids and payloads. The caller appends each envelope's
+    dispatch block to the returned text.
+    """
+    response_meta = {
+        "session_id": session_id,
+        "input_type": "freeText",
+        "response_param": "answer",
+        "question": batch_entries[0]["question"],
+        "question_batch": [dict(e) for e in batch_entries],
+        "question_advisories": advisories,
+        "is_complete": False,
+        "interview_complete": False,
+        "classification": batch_entries[0]["classification"],
+        "skip_eligible": batch_entries[0]["skip_eligible"],
+        "pending_reframe": pending_reframe,
+        "deferred_this_round": diff["new_deferred"],
+        "decide_later_this_round": diff["new_decide_later"],
+        **diff,
+    }
+    lines = [
+        f"Session {session_id}",
+        "",
+        f"This turn asks {len(batch_entries)} independent questions. Answer "
+        "each with its own call, passing the question text as "
+        "'last_question'. Answer in any order; unanswered ones stay pending.",
+        "",
+        *_numbered_questions(session_id, batch_entries),
+    ]
+    return response_meta, "\n".join(lines)
+
+
+def _payload_stub(payload: dict[str, Any], bundle_id: str) -> str:
+    """Render the compact prompt a child receives when its brief is stored."""
+    context = payload.get("context") or {}
+    lane_id = context.get("lane_id")
+    return f"""## Task
+You are an Ouroboros PM interview advisory subagent — lane {lane_id}.
+
+## PM Question
+{context.get("question")}
+
+## Session
+- session_id: {context.get("session_id")}
+- question_identity: {context.get("question_identity")}
+
+## Your Brief
+The full brief (rules, repository roster, answer contract) is stored, not
+inlined. Fetch it with the MCP tool `ouroboros_fetch_artifact` (load it via
+your runtime's tool discovery if deferred):
+- contract_id: `{bundle_id}`
+- lane_id: `{lane_id}`
+Follow the fetched brief exactly — it defines your answer contract, and your
+final message is only what its Output section specifies.
+If the fetch fails, reply with exactly `{UNDISPATCHED_SENTINEL}` and nothing else."""
+
+
+async def externalize_advisory_payloads(meta: dict[str, Any], findings_store: Any) -> None:
+    """Store the lane briefs and leave references on the wire (RFC #2222).
+
+    The same rule findings follow — bodies do not travel; ids do — applied to
+    the plumbing itself. A turn's response used to carry each lane's full
+    brief twice (meta and dispatch text) plus a copy of the tool's capability
+    metadata per envelope, so one question cost ~120k characters and a batch
+    outgrew what a host accepts inline, forcing hosts to improvise file
+    surgery. After this, the response carries the questions and fetchable
+    references; the briefs sit in the same store the children already fetch
+    findings from.
+
+    Fail-open on every edge: no store, no fanout id, or a publish that fails
+    leaves the full prompts inline — today's behavior, oversized but whole.
+    """
+    fanout_id = meta.get("question_advisory_fanout_id")
+    payloads = meta.get("question_advisory_subagents")
+    if findings_store is None or not fanout_id or not isinstance(payloads, list) or not payloads:
+        return
+    bundle_id = f"advisory-prompts:{fanout_id}"
+    body = {
+        "kind": ADVISORY_PROMPT_BUNDLE_KIND,
+        "result": {
+            "aggregated_outputs": [
+                {
+                    "lane_id": (payload.get("context") or {}).get("lane_id"),
+                    "output": payload.get("prompt"),
+                }
+                for payload in payloads
+                if isinstance(payload, dict)
+            ]
+        },
+    }
+    try:
+        from ouroboros.orchestrator.disposable_memory import DisposableMemory
+
+        memory = DisposableMemory(artifact_store=findings_store)
+
+        async def _work(_handle: Any) -> Any:
+            return body
+
+        await memory.run(
+            intent="publish advisory prompt bundle",
+            runtime_id="mcp:pm-advisory-prompts",
+            work_fn=_work,
+            contract_id=bundle_id,
+        )
+    except Exception as exc:
+        log.warning(
+            "pm_batch.prompt_bundle_publish_failed",
+            fanout_id=fanout_id,
+            error=str(exc),
+        )
+        return
+    for payload in payloads:
+        if isinstance(payload, dict) and payload.get("prompt"):
+            payload["prompt"] = _payload_stub(payload, bundle_id)
+    request = meta.get("question_advisory_request")
+    if isinstance(request, dict):
+        capability = request.get("mcp_tool_capability")
+        if isinstance(capability, dict) and capability.get("tool_name"):
+            # The only field any wire consumer reads; the rest is fetchable
+            # from the capability registry by name.
+            request["mcp_tool_capability"] = {"tool_name": capability["tool_name"]}
+        # The payloads were already built from it, and they are the wire's
+        # authority on what each lane is asked; a second copy of every lane's
+        # answer contract is weight without a reader.
+        request.pop("lanes", None)
+    log.info(
+        "pm_batch.advisory_payloads_externalized",
+        fanout_id=fanout_id,
+        bundle_id=bundle_id,
+        payload_count=len(payloads),
+    )
+
+
+__all__ = [
+    "ADVISORY_PROMPT_BUNDLE_KIND",
+    "UNDISPATCHED_SENTINEL",
+    "batch_entries_for_turns",
+    "batch_pending_meta",
+    "batch_pending_result",
+    "batch_turn_meta_and_text",
+    "externalize_advisory_payloads",
+    "pending_batch_entries",
+    "resolve_batch_member",
+]

--- a/src/ouroboros/mcp/tools/pm_batch.py
+++ b/src/ouroboros/mcp/tools/pm_batch.py
@@ -299,7 +299,7 @@ _ANSWER_SPECS: dict[str, str] = {
 - `examined`: one entry per repository you opened — its `repo_id` from 3 and
   `policy_claims` of `{path, policy_claim, plain_statement}`. Read and found
   nothing: an entry with no claims. Never opened: no entry.
-- Opened nothing at all: `examined: []` with `nothing_examined_reason`.
+- Opened nothing at all: `examined: []` with {no_op}.
 - `path` is relative to the repository.
 - `plain_statement`: that claim once, in the question's language, no paths or
   identifiers.""",
@@ -308,7 +308,7 @@ _ANSWER_SPECS: dict[str, str] = {
   `operation: "read"`, `tool_name`, `metric`, `aggregation`,
   `informs_decision`, and `values` — the numbers you read back. Optional:
   `filters` of `{field, comparator, value}`, `time_window`, `group_by`.
-- Nothing to measure: `data_needed: false` with `no_evidence_reason`.
+- Nothing to measure: `data_needed: false` with {no_op}.
 - `aggregation`: count, distinct_count, sum, average, median, p90, p95, p99,
   min, max, rate. `comparator`: eq, neq, gt, gte, lt, lte.
 - `values` is one entry, or one per group when you grouped.
@@ -363,7 +363,7 @@ Your final message is this JSON and nothing else — no prose around it:
     return f"""## Answer
 Your final message is one JSON object and nothing else — no prose around it.
 
-{spec}
+{spec.replace("{no_op}", _no_op_literals(schema_json) if schema_json else "its reason")}
 
 """
 
@@ -380,7 +380,7 @@ def _investigation_step(roster: Any, schema_json: str | None) -> str:
     cites_repos = bool(schema_json) and '"repo_id"' in (schema_json or "")
     entries = [e for e in roster if isinstance(e, dict) and e.get("repo_id")] if roster else []
     if not cites_repos:
-        return """3. **Still not enough?** Find and call the data tools this host exposes. An
+        return """3. **Not covered there?** Find and call the data tools this host exposes. An
    empty tool search is where you start, not where you stop; a store counts as
    unreachable only after a call to it failed."""
     if not entries:
@@ -388,9 +388,10 @@ def _investigation_step(roster: Any, schema_json: str | None) -> str:
    empty state and say so. Reading whatever is at hand would produce evidence
    nothing can check."""
     listing = "\n".join(f"   - `{e['repo_id']}` — {e.get('path')}" for e in entries)
-    return f"""3. **Still not enough?** Read these repositories:
+    return f"""3. **Not covered there?** Read these repositories:
 {listing}
-   Look wherever you need to; cite only these."""
+   Look wherever you need to; cite only these. Follow what the question
+   plainly touches — report what bears on it, not everything near it."""
 
 
 def _payload_stub(
@@ -421,12 +422,10 @@ def _payload_stub(
         reuse = f"""2. **Read what this lane already found here.** `ouroboros_fetch_artifact`
    with `lane_id: {lane_id}` and no `contract_id` lists them, newest first
    (load the tool via tool discovery if deferred); pass back a `contract_id`
-   from that list to read one. Stop there if it answers the question."""
+   from that list to read one. Stop there if it already covers this question."""
     else:
         reuse = """2. **Nothing has been found here yet** for this lane, so there is nothing to
    reuse. Go to 3."""
-    no_op = _no_op_literals(schema_json) if schema_json else ""
-    no_op_hint = f" ({no_op})" if no_op else ""
     answer_section = _answer_section(contract, schema_json)
     return f"""## Task
 You are an Ouroboros PM interview advisory subagent — lane {lane_id}. You
@@ -440,8 +439,8 @@ gather evidence the PM reads before deciding; you never decide for them.
 - question_identity: {context.get("question_identity")}
 
 ## Order of work
-1. **Does this question need this lane?** If not, answer the empty
-   state{no_op_hint} and stop — do not investigate to prove it.
+1. **Does this question need this lane?** If not, answer the empty state
+   below and stop — do not investigate to prove it.
 {reuse}
 {_investigation_step(roster, schema_json)}
 

--- a/src/ouroboros/mcp/tools/pm_batch.py
+++ b/src/ouroboros/mcp/tools/pm_batch.py
@@ -220,7 +220,10 @@ def batch_turn_meta_and_text(
     response_meta = {
         "session_id": session_id,
         "input_type": "freeText",
-        "response_param": "answer",
+        # The batch relay parameter, named as itself: a generic host reading
+        # this to build its reply would otherwise be told to send one answer to
+        # a turn that asked several.
+        "response_param": "answers",
         "question": batch_entries[0]["question"],
         "question_batch": [dict(e) for e in batch_entries],
         "question_advisories": advisories,
@@ -239,8 +242,9 @@ def batch_turn_meta_and_text(
         f"This turn asks {len(batch_entries)} independent questions. Put every "
         "answer to the user, then send them back together in one call: "
         f"'answers': [{{question, answer}}, ...] with session_id=\"{session_id}\". "
-        "The turn is recorded as a whole; a call that arrives without them "
-        "plans a new turn instead.",
+        "One call records the turn. The server does not hold the questions "
+        "between calls, so whatever you leave out is abandoned — the next call "
+        "plans a new turn, and a question that still matters is asked again.",
         "",
         *_numbered_questions(batch_entries),
     ]

--- a/src/ouroboros/mcp/tools/pm_batch.py
+++ b/src/ouroboros/mcp/tools/pm_batch.py
@@ -358,23 +358,24 @@ def _payload_stub(
     schema_json = _lean_schema(contract)
     offered = [e for e in findings if isinstance(e, dict)] if findings else []
     if offered:
+        # To the minute. Sub-second precision and a UTC offset decide nothing
+        # here and are twenty lines of it.
         listing = "\n".join(
-            f"   - `{e.get('contract_id')}` — published {e.get('published_at')}" for e in offered
+            f"   - `{e.get('contract_id')}` — {str(e.get('published_at') or '')[:16]}"
+            for e in offered
         )
-        # Newest first, and named as a shelf to choose from. Told to fetch each
-        # in turn, a child would spend its whole budget before it started —
-        # these are a head start, not a checklist.
-        reuse = (
-            f"""2. **Read what this lane already found here.** `ouroboros_fetch_artifact`
+        # Recency is the only thing separating these entries, so it is the only
+        # thing the instruction may lean on. Telling a child to pick the ones
+        # whose subject fits would name a signal the offer does not carry, and
+        # telling it to fetch each in turn would spend the budget before the
+        # work started. These are a head start, not a checklist.
+        reuse = f"""2. **Read what this lane already found here.** `ouroboros_fetch_artifact`
    takes a `contract_id` below plus `lane_id: {lane_id}` (load the tool via
-   your runtime's tool discovery if deferred). Newest first — open the ones
-   whose subject looks like this question, not all of them. Use what helps and
-   investigate the rest yourself; if what you read answers the question, stop
-   there.
+   your runtime's tool discovery if deferred). They are newest first and that
+   is all you can tell them apart by, so start at the top and open a few
+   rather than all of them. Use what helps, investigate the rest yourself, and
+   if what you read answers the question, stop there.
 {listing}"""
-            if offered
-            else ""
-        )
     else:
         reuse = """2. **Nothing has been found here yet** for this lane, so there is nothing to
    reuse. Go to 3."""

--- a/src/ouroboros/mcp/tools/pm_handler.py
+++ b/src/ouroboros/mcp/tools/pm_handler.py
@@ -175,8 +175,11 @@ def _save_pm_meta(
             "decide_later_items": combined_decide_later,
             "codebase_context": engine.codebase_context,
             "pending_reframe": pending_reframe,
-            # A batched turn holds several reframes; the single entry above
-            # stays for older readers (RFC #2222).
+            # The reframe routing of the turn on the wire, whole — a batch
+            # holds several, and the single entry above stays for older
+            # readers. Planning replaces this map rather than adding to it, so
+            # an abandoned turn's routing cannot reach a later question that
+            # merely reads the same (RFC #2222 revision 4).
             "pending_reframes": dict(getattr(engine, "_reframe_map", {})),
             "cwd": cwd,
             "brownfield_repos": list(getattr(engine, "_selected_brownfield_repos", [])),

--- a/src/ouroboros/mcp/tools/pm_handler.py
+++ b/src/ouroboros/mcp/tools/pm_handler.py
@@ -60,6 +60,7 @@ from ouroboros.mcp.tools.pm_batch import (
     batch_pending_result,
     batch_turn_meta_and_text,
     externalize_advisory_payloads,
+    interview_answer_lock,
     pending_batch_entries,
     record_member_answer,
     resolve_batch_member,
@@ -192,8 +193,8 @@ def _save_pm_meta(
             "decide_later_items": combined_decide_later,
             "codebase_context": engine.codebase_context,
             "pending_reframe": pending_reframe,
-            # A batched turn can hold several pending reframes (RFC #2222);
-            # the single entry above stays for older readers.
+            # A batched turn holds several reframes; the single entry above
+            # stays for older readers (RFC #2222).
             "pending_reframes": dict(getattr(engine, "_reframe_map", {})),
             "cwd": cwd,
             "brownfield_repos": list(getattr(engine, "_selected_brownfield_repos", [])),
@@ -390,6 +391,7 @@ class PMInterviewHandler:
     opencode_mode: str | None = field(default=None, repr=False)
     fanout_registry: FanoutRegistry | None = field(default=None, repr=False)
     findings_store: Any | None = field(default=None, repr=False)
+    _answer_locks: dict[str, asyncio.Lock] = field(default_factory=dict, repr=False)
 
     async def _attach_advisory(self, meta: dict[str, Any], session_id: str, question: str) -> None:
         """Attach the evidence lanes to one PM turn that shows ``question``.
@@ -817,10 +819,9 @@ class PMInterviewHandler:
                                 tool_name="ouroboros_pm_interview",
                             )
                         )
-                    # One call for every answer, whatever its provenance —
+                    # One call for every answer, whatever its provenance:
                     # ``record_answer`` classifies any leading marker itself,
-                    # so this branch needs no case of its own, which is what
-                    # makes the two runtimes agree by default instead of by a
+                    # so the two runtimes agree by default rather than by a
                     # second rule someone has to keep in step.
                     state.record_answer(question_text, answer)
                     state.mark_updated()
@@ -901,9 +902,10 @@ class PMInterviewHandler:
 
             # ── Resume with answer ─────────────────────────────────
             if action == "resume" and session_id:
-                return await self._handle_answer(
-                    engine, session_id, answer, cwd, last_question=last_question
-                )
+                async with interview_answer_lock(self._answer_locks, session_id):
+                    return await self._handle_answer(
+                        engine, session_id, answer, cwd, last_question=last_question
+                    )
 
             return Result.err(
                 MCPToolError(
@@ -1462,8 +1464,8 @@ class PMInterviewHandler:
                         diff=diff,
                     )
                 )
-            # Batch resolved — persist without the key and continue to the
-            # completion check and next-turn generation below.
+            # Batch resolved — persist without the key, then fall through to
+            # completion checking and next-turn generation.
             _save_pm_meta(session_id, engine, cwd=cwd, data_dir=self.data_dir)
             batch_answer_recorded = True
 
@@ -1778,8 +1780,7 @@ class PMInterviewHandler:
             )
 
             # One fan-out per question in its own envelope, so fanout ids and
-            # payloads never overwrite each other (dispatch: one wave, submit
-            # per envelope).
+            # payloads never overwrite each other (one wave, submit per envelope).
             advisories: list[dict[str, Any]] = []
             for t in batch_turns:
                 envelope: dict[str, Any] = {"question": t.question}

--- a/src/ouroboros/mcp/tools/pm_handler.py
+++ b/src/ouroboros/mcp/tools/pm_handler.py
@@ -32,7 +32,6 @@ from ouroboros.bigbang.ambiguity import qualifies_for_seed_completion
 from ouroboros.bigbang.answer_provenance import extraction_rounds
 from ouroboros.bigbang.interview import (
     MIN_ROUNDS_BEFORE_EARLY_EXIT,
-    InterviewRound,
     InterviewState,
 )
 from ouroboros.bigbang.pm_completion import (
@@ -57,14 +56,12 @@ from ouroboros.mcp.tools.advisory_dispatch import append_question_advisory_dispa
 from ouroboros.mcp.tools.fanout import FanoutRegistry
 from ouroboros.mcp.tools.pm_batch import (
     batch_entries_for_turns,
-    batch_pending_result,
     batch_turn_meta_and_text,
     externalize_advisory_payloads,
     interview_answer_lock,
-    pending_batch_entries,
-    record_member_answer,
-    resolve_batch_member,
+    record_turn_answers,
     skip_hint_suffix,
+    turn_answers,
 )
 from ouroboros.mcp.tools.question_advisory import attach_question_advisory
 from ouroboros.mcp.tools.subagent import (
@@ -135,21 +132,6 @@ def _plugin_repo_paths(repos: list[Any], *, durable: bool = False) -> list[Any]:
 def _refresh_plugin_repo_paths(paths: list[Any]) -> list[Any]:
     """Backward-compatible scan-path projection for plugin repo refresh."""
     return _plugin_repo_paths(_refresh_plugin_repo_records(paths))
-
-
-def _pending_round(state: InterviewState) -> InterviewRound | None:
-    """Return the round still waiting for an answer, or ``None``.
-
-    Pending means *unanswered*, not *last*. Those two agreed until a round could
-    be answered without being a question, and every consumer that assumed the
-    trailing round was the pending one then filed the next decision against
-    whatever sat behind it.
-
-    ``None`` is now load-bearing rather than a fallback: it means there is no
-    question for an incoming answer to belong to, and the caller is asked to
-    name one instead of the trailing round being borrowed.
-    """
-    return next((r for r in reversed(state.rounds) if r.user_response is None), None)
 
 
 def _meta_path(session_id: str, data_dir: Path | None = None) -> Path:
@@ -461,8 +443,31 @@ class PMInterviewHandler:
                 MCPToolParameter(
                     name="answer",
                     type=ToolInputType.STRING,
-                    description="PM's response to the current interview question",
+                    description=(
+                        "PM's response to a single-question turn. Pass the question it "
+                        "answers as 'last_question'. For a turn that asked more than one "
+                        "question, use 'answers' instead."
+                    ),
                     required=False,
+                ),
+                MCPToolParameter(
+                    name="answers",
+                    type=ToolInputType.ARRAY,
+                    description=(
+                        "A turn's answers, sent together: [{question, answer}, ...], one "
+                        "entry per question the turn asked. A turn is recorded whole, so "
+                        "collect every answer before calling. Each entry names its own "
+                        "question; nothing is matched against server-side state."
+                    ),
+                    required=False,
+                    items={
+                        "type": "object",
+                        "properties": {
+                            "question": {"type": "string"},
+                            "answer": {"type": "string"},
+                        },
+                        "required": ["question", "answer"],
+                    },
                 ),
                 MCPToolParameter(
                     name="action",
@@ -501,14 +506,11 @@ class PMInterviewHandler:
                     name="last_question",
                     type=ToolInputType.STRING,
                     description=(
-                        "The question this answer is answering, when the server is "
-                        "not already holding it unanswered. In plugin mode each "
-                        "dispatch creates a new child session whose questions are "
-                        "not persisted server-side, so pass the child's last "
-                        "question here. On any runtime, an answer sent when no "
-                        "question is pending is refused without it — there is no "
-                        "question to file it under, and the round behind it is one "
-                        "somebody already answered."
+                        "The question this answer is answering. A turn persists "
+                        "nothing when it asks, on any runtime, so an answer without "
+                        "its question is refused — there is no remembered question "
+                        "to file it under, and the round behind it is one somebody "
+                        "already answered."
                     ),
                     required=False,
                 ),
@@ -796,13 +798,12 @@ class PMInterviewHandler:
                 # question) and passes it back here so we can persist the real
                 # question text instead of a placeholder.
                 if answer:
-                    # ``record_answer`` fills a round persisted question-only or
-                    # appends a new one, and settles provenance where the answer
-                    # arrives rather than at construction.
-                    plugin_pending = _pending_round(state)
-                    if plugin_pending is not None:
-                        question_text = last_question or plugin_pending.question
-                    elif last_question:
+                    # Every answer names its question, on every runtime: a turn
+                    # persists nothing when it asks (RFC #2222 revision 4), so
+                    # there is no stored question to prefer over the echo.
+                    # ``record_answer`` appends the pair and settles provenance
+                    # where the answer arrives rather than at construction.
+                    if last_question:
                         question_text = last_question
                     else:
                         # The same refusal the in-process path gives, because a
@@ -904,7 +905,12 @@ class PMInterviewHandler:
             if action == "resume" and session_id:
                 async with interview_answer_lock(self._answer_locks, session_id):
                     return await self._handle_answer(
-                        engine, session_id, answer, cwd, last_question=last_question
+                        engine,
+                        session_id,
+                        answer,
+                        cwd,
+                        last_question=last_question,
+                        answers=arguments.get("answers"),
                     )
 
             return Result.err(
@@ -1010,14 +1016,8 @@ class PMInterviewHandler:
         # Compute diff
         diff = _compute_deferred_diff(engine, deferred_before, decide_later_before)
 
-        # Record unanswered round
-        state.rounds.append(
-            InterviewRound(
-                round_number=state.current_round_number,
-                question=question,
-                user_response=None,
-            )
-        )
+        # RFC #2222 revision 4: a turn persists nothing when it asks. The
+        # question travels in the response and comes back with its answer.
         state.mark_updated()
 
         # Persist — check save result to avoid handing back a session that wasn't written
@@ -1245,9 +1245,15 @@ class PMInterviewHandler:
         """Return the first question when select_repos is called on an already-started session.
 
         This handles the case where the caller sends ``select_repos`` more
-        than once for the same session.  Instead of re-starting the
-        interview (which would create duplicate state), we load the existing
-        ``InterviewState`` and replay the first question from its rounds.
+        than once for the same session. Instead of re-starting the interview
+        (which would create duplicate state), the existing ``InterviewState``
+        is loaded and a question is planned from it.
+
+        It plans rather than replays because a turn persists nothing when it
+        asks (RFC #2222 revision 4): the question the first call returned was
+        never written down, so there is none to hand back. This is the same
+        trade a reconnect makes — one regenerated question, and no half-written
+        state to keep consistent.
         """
         log.info(
             "pm_handler.select_repos.idempotent",
@@ -1265,19 +1271,18 @@ class PMInterviewHandler:
             )
 
         state = load_result.value
-        # Return the last unanswered round's question (the pending PM-facing prompt),
-        # not rounds[0] which may be a hidden auto-deferred/auto-decided question.
-        pending = next(
-            (r for r in reversed(state.rounds) if r.user_response is None),
-            None,
-        )
-        first_question = (
-            pending.question
-            if pending
-            else (state.rounds[-1].question if state.rounds else "No question available.")
-        )
-
         engine.restore_meta(meta)
+        question_result = await engine.ask_next_question(state)
+        if question_result.is_err:
+            return Result.err(
+                MCPToolError(
+                    f"Session {session_id} is already started but a question could "
+                    f"not be planned: {question_result.error}",
+                    tool_name="ouroboros_pm_interview",
+                )
+            )
+        first_question = question_result.value
+
         classification = _last_classification(engine)
         skip_eligible = classification in ("decide_later", "deferred")
 
@@ -1323,8 +1328,15 @@ class PMInterviewHandler:
         answer: str | None,
         cwd: str,
         last_question: str | None = None,
+        answers: Any = None,
     ) -> Result[MCPToolResult, MCPServerError]:
-        """Resume session, record an answer, check completion, then ask next question.
+        """Record a turn's answers, check completion, then ask the next turn.
+
+        A turn is atomic (RFC #2222 revision 4): its answers arrive together,
+        each holding the question it belongs to, and the rounds they become are
+        the only durable state. A call with no answers is a host that lost its
+        turn — the next turn is planned from the transcript rather than
+        restored, so there is no pending question to reconcile against.
 
         Completion is determined by the engine's ambiguity score dropping
         below the threshold (requirements are clear).  User controls when
@@ -1343,62 +1355,10 @@ class PMInterviewHandler:
         if meta:
             engine.restore_meta(meta)
 
-        # ── Batched turn (RFC #2222): pending members live in PM meta ──
-        pending_batch = pending_batch_entries(meta)
-
-        if not answer and pending_batch:
-            return Result.ok(
-                batch_pending_result(
-                    session_id,
-                    pending_batch,
-                    decide_later_count=len(engine.deferred_items) + len(engine.decide_later_items),
-                )
-            )
-
-        # If no answer provided, re-display the pending question (retry/reconnect)
-        reconnect_pending = _pending_round(state)
-        if not answer and reconnect_pending is not None:
-            pending_question = reconnect_pending.question
-            classification = _last_classification(engine)
-            skip_eligible = classification in ("decide_later", "deferred")
-
-            pending_reframe = engine.get_pending_reframe()
-
-            # Include skip hint in re-displayed question
-            pending_text = f"Session {session_id}\n\n{pending_question}"
-            pending_text += skip_hint_suffix(classification, session_id)
-
-            pending_meta: dict[str, Any] = {
-                "session_id": session_id,
-                "input_type": "freeText",
-                "response_param": "answer",
-                "question": pending_question,
-                "is_complete": False,
-                "classification": classification,
-                "skip_eligible": skip_eligible,
-                "deferred_this_round": [],
-                "decide_later_this_round": [],
-                "interview_complete": False,
-                "pending_reframe": pending_reframe,
-                "new_deferred": [],
-                "new_decide_later": [],
-                "deferred_count": 0,
-                "decide_later_count": len(engine.deferred_items) + len(engine.decide_later_items),
-            }
-            await self._attach_advisory(pending_meta, session_id, pending_question)
-
-            return Result.ok(
-                MCPToolResult(
-                    content=(
-                        MCPContentItem(
-                            type=ContentType.TEXT,
-                            text=append_question_advisory_dispatch(pending_text, pending_meta),
-                        ),
-                    ),
-                    is_error=False,
-                    meta=pending_meta,
-                )
-            )
+        # ── This turn's answers, each holding its question (RFC #2222 r4) ──
+        pairs, pair_error = turn_answers(answers, answer, last_question)
+        if pair_error:
+            return Result.err(MCPToolError(pair_error, tool_name="ouroboros_pm_interview"))
 
         # ── Per-round diff snapshot — must be BEFORE any skip/record call ──
         # Snapshot list lengths here so that items appended inside
@@ -1407,155 +1367,13 @@ class PMInterviewHandler:
         deferred_before = len(engine.deferred_items)
         decide_later_before = len(engine.decide_later_items)
 
-        # Record answer if provided
-        if answer and not state.rounds:
-            return Result.err(
-                MCPToolError(
-                    "Cannot record answer: no questions have been asked yet.",
-                    tool_name="ouroboros_pm_interview",
-                )
-            )
-
-        # ── Batch member answer (RFC #2222) — see pm_batch for the rules ──
-        batch_answer_recorded = False
-        if answer and pending_batch:
-            target, member_error = resolve_batch_member(pending_batch, last_question)
-            if target is None:
+        if pairs:
+            record_result = await record_turn_answers(engine, state, pairs)
+            if record_result.is_err:
                 return Result.err(
-                    MCPToolError(
-                        member_error or "No pending batch member matched.",
-                        tool_name="ouroboros_pm_interview",
-                    )
+                    MCPToolError(str(record_result.error), tool_name="ouroboros_pm_interview")
                 )
-
-            member_result = await record_member_answer(engine, state, target, answer)
-            if member_result.is_err:
-                return Result.err(
-                    MCPToolError(
-                        str(member_result.error),
-                        tool_name="ouroboros_pm_interview",
-                    )
-                )
-            state = member_result.value
-
-            remaining = [e for e in pending_batch if e is not target]
-            save_result = await engine.save_state(state)
-            if isinstance(save_result, Result) and save_result.is_err:
-                return Result.err(
-                    MCPToolError(
-                        f"Failed to persist PM answer: {save_result.error}",
-                        tool_name="ouroboros_pm_interview",
-                    )
-                )
-            if remaining:
-                _save_pm_meta(
-                    session_id,
-                    engine,
-                    cwd=cwd,
-                    data_dir=self.data_dir,
-                    extra={"pending_batch": remaining},
-                )
-                diff = _compute_deferred_diff(engine, deferred_before, decide_later_before)
-                return Result.ok(
-                    batch_pending_result(
-                        session_id,
-                        remaining,
-                        decide_later_count=diff["decide_later_count"],
-                        diff=diff,
-                    )
-                )
-            # Batch resolved — persist without the key, then fall through to
-            # completion checking and next-turn generation.
-            _save_pm_meta(session_id, engine, cwd=cwd, data_dir=self.data_dir)
-            batch_answer_recorded = True
-
-        if answer and state.rounds and not batch_answer_recorded:
-            # Pending means unanswered, not last. Those two agree now that
-            # nothing but a question occupies a round, and the search is written
-            # this way rather than as ``rounds[-1]`` so that it keeps agreeing:
-            # the assumption cost three stored sessions their real questions
-            # when it last stopped holding.
-            #
-            # What follows is ``ouroboros_interview``'s guard, copied rather
-            # than adapted (``authoring_handlers._handle_interview_answer``).
-            # An answer needs a question to be filed under, and when none is
-            # pending the trailing round is one somebody already answered —
-            # binding a second answer to it overwrites a decision that was
-            # made. The caller has the question on screen, so it is asked for.
-            #
-            # Deliberately provenance-blind. The previous shape branched here
-            # on ``classify_answer_provenance`` and routed observations to a
-            # side path that reported success while persisting nothing when no
-            # round was pending. A second door for one class of answer is what
-            # produced that; the rule is the same for every answer now, and an
-            # adopted fact is protected downstream by its provenance rather
-            # than by a branch here.
-            pending = _pending_round(state)
-            if pending is not None:
-                # The stored question of an unanswered round is what we asked,
-                # and it is preferred over the echo: what the host has on screen
-                # carries the advisory dispatch directive appended to it, so an
-                # echo would write our own instructions into the transcript.
-                question_for_answer = pending.question
-                state.rounds.remove(pending)
-            elif last_question:
-                question_for_answer = last_question
-            else:
-                return Result.err(
-                    MCPToolError(
-                        "Cannot record answer - the previous round is already "
-                        "answered and no follow-up question was provided. Pass "
-                        "the question this answer belongs to as 'last_question' "
-                        "alongside 'answer'.",
-                        tool_name="ouroboros_pm_interview",
-                    )
-                )
-
-            # ── User chose to skip (decide later / defer to dev) ───
-            # The main session detects classification via response_meta
-            # and offers skip options.  The user's choice arrives as:
-            #   answer="[decide_later]" → skip_as_decide_later()
-            #   answer="[deferred]"     → skip_as_deferred()
-            # Guard: only honour the sentinel when the last question was
-            # actually classified as that type.  If a client sends
-            # "[decide_later]" for a passthrough/reframed question, treat
-            # it as a normal answer so no data is silently discarded.
-            stripped = answer.strip()
-            last_classification = _last_classification(engine)
-            if stripped == "[decide_later]" and last_classification == "decide_later":
-                skip_result = await engine.skip_as_decide_later(state, question_for_answer)
-                if skip_result.is_err:
-                    return Result.err(
-                        MCPToolError(
-                            str(skip_result.error),
-                            tool_name="ouroboros_pm_interview",
-                        )
-                    )
-                state = skip_result.value
-                state.clear_stored_ambiguity()
-            elif stripped == "[deferred]" and last_classification == "deferred":
-                skip_result = await engine.skip_as_deferred(state, question_for_answer)
-                if skip_result.is_err:
-                    return Result.err(
-                        MCPToolError(
-                            str(skip_result.error),
-                            tool_name="ouroboros_pm_interview",
-                        )
-                    )
-                state = skip_result.value
-                state.clear_stored_ambiguity()
-            else:
-                record_result = await engine.record_response(state, answer, question_for_answer)
-                if record_result.is_err:
-                    return Result.err(
-                        MCPToolError(
-                            str(record_result.error),
-                            tool_name="ouroboros_pm_interview",
-                        )
-                    )
-                state = record_result.value
-
-        if answer and not batch_answer_recorded:
+            state = record_result.value
             save_result = await engine.save_state(state)
             if isinstance(save_result, Result) and save_result.is_err:
                 return Result.err(
@@ -1759,7 +1577,7 @@ class PMInterviewHandler:
         # slice from the pre-snapshot length to current length
         diff = _compute_deferred_diff(engine, deferred_before, decide_later_before)
 
-        # ── Batched turn (RFC #2222) — see pm_batch for the invariant ──
+        # ── Batched turn (RFC #2222) — asked whole, answered whole ──
         if len(batch_turns) > 1:
             state.mark_updated()
             save_result = await engine.save_state(state)
@@ -1770,14 +1588,12 @@ class PMInterviewHandler:
                         tool_name="ouroboros_pm_interview",
                     )
                 )
+            # The questions go out in the response and nowhere else. Persisting
+            # them would recreate the pending list revision 4 removed — the
+            # second place a turn was remembered, and the seam every replay and
+            # ordering defect lived in.
             batch_entries = batch_entries_for_turns(batch_turns)
-            _save_pm_meta(
-                session_id,
-                engine,
-                cwd=cwd,
-                data_dir=self.data_dir,
-                extra={"pending_batch": batch_entries},
-            )
+            _save_pm_meta(session_id, engine, cwd=cwd, data_dir=self.data_dir)
 
             # One fan-out per question in its own envelope, so fanout ids and
             # payloads never overwrite each other (one wave, submit per envelope).
@@ -1811,14 +1627,7 @@ class PMInterviewHandler:
                 )
             )
 
-        # Save unanswered round
-        state.rounds.append(
-            InterviewRound(
-                round_number=state.current_round_number,
-                question=question,
-                user_response=None,
-            )
-        )
+        # RFC #2222 revision 4: nothing is persisted until it is whole.
         state.mark_updated()
 
         save_result = await engine.save_state(state)

--- a/src/ouroboros/mcp/tools/pm_handler.py
+++ b/src/ouroboros/mcp/tools/pm_handler.py
@@ -562,6 +562,7 @@ class PMInterviewHandler:
         initial_context = arguments.get("initial_context")
         session_id = arguments.get("session_id")
         answer = arguments.get("answer")
+        answers = arguments.get("answers")
         cwd_arg = arguments.get("cwd")
         selected_repos: list[str] | None = arguments.get("selected_repos")
         last_question = arguments.get("last_question")
@@ -800,34 +801,26 @@ class PMInterviewHandler:
                 # the parent LLM sees the child's response (which contains the
                 # question) and passes it back here so we can persist the real
                 # question text instead of a placeholder.
-                if answer:
+                pairs, pair_error = turn_answers(answers, answer, last_question)
+                if pair_error:
+                    return Result.err(MCPToolError(pair_error, tool_name="ouroboros_pm_interview"))
+                if pairs:
+                    # The same normalization the in-process branch uses, so the
+                    # public answer shape means one thing on every runtime. It
+                    # was not shared once, and `answers` sent here was accepted
+                    # and dropped: the call reported success and the decisions
+                    # were never written.
+                    #
                     # Every answer names its question, on every runtime: a turn
                     # persists nothing when it asks (RFC #2222 revision 4), so
                     # there is no stored question to prefer over the echo.
                     # ``record_answer`` appends the pair and settles provenance
-                    # where the answer arrives rather than at construction.
-                    if last_question:
-                        question_text = last_question
-                    else:
-                        # The same refusal the in-process path gives, because a
-                        # question this server never asked is worse here: the
-                        # placeholder that stood here was written into the
-                        # durable transcript, and later questions and extraction
-                        # read it back as something the user was asked.
-                        return Result.err(
-                            MCPToolError(
-                                "Cannot record answer - the previous round is already "
-                                "answered and no follow-up question was provided. Pass "
-                                "the question this answer belongs to as 'last_question' "
-                                "alongside 'answer'.",
-                                tool_name="ouroboros_pm_interview",
-                            )
-                        )
-                    # One call for every answer, whatever its provenance:
-                    # ``record_answer`` classifies any leading marker itself,
-                    # so the two runtimes agree by default rather than by a
-                    # second rule someone has to keep in step.
-                    state.record_answer(question_text, answer)
+                    # where the answer arrives rather than at construction — one
+                    # call for every answer, whatever its provenance, so the two
+                    # runtimes agree by default rather than by a second rule
+                    # someone has to keep in step.
+                    for question_text, answer_text in pairs:
+                        state.record_answer(question_text, answer_text)
                     state.mark_updated()
                     save_result = await _plugin_save_state(state_dir, state)
                     if save_result.is_err:
@@ -913,7 +906,7 @@ class PMInterviewHandler:
                         answer,
                         cwd,
                         last_question=last_question,
-                        answers=arguments.get("answers"),
+                        answers=answers,
                     )
 
             return Result.err(

--- a/src/ouroboros/mcp/tools/pm_handler.py
+++ b/src/ouroboros/mcp/tools/pm_handler.py
@@ -55,6 +55,16 @@ from ouroboros.mcp.errors import MCPServerError, MCPToolError
 from ouroboros.mcp.host_context import resolve_request_subagent_dispatch
 from ouroboros.mcp.tools.advisory_dispatch import append_question_advisory_dispatch
 from ouroboros.mcp.tools.fanout import FanoutRegistry
+from ouroboros.mcp.tools.pm_batch import (
+    batch_entries_for_turns,
+    batch_pending_result,
+    batch_turn_meta_and_text,
+    externalize_advisory_payloads,
+    pending_batch_entries,
+    record_member_answer,
+    resolve_batch_member,
+    skip_hint_suffix,
+)
 from ouroboros.mcp.tools.question_advisory import attach_question_advisory
 from ouroboros.mcp.tools.subagent import (
     DELEGATED_TO_SUBAGENT,
@@ -182,6 +192,9 @@ def _save_pm_meta(
             "decide_later_items": combined_decide_later,
             "codebase_context": engine.codebase_context,
             "pending_reframe": pending_reframe,
+            # A batched turn can hold several pending reframes (RFC #2222);
+            # the single entry above stays for older readers.
+            "pending_reframes": dict(getattr(engine, "_reframe_map", {})),
             "cwd": cwd,
             "brownfield_repos": list(getattr(engine, "_selected_brownfield_repos", [])),
             "classifications": [
@@ -378,7 +391,7 @@ class PMInterviewHandler:
     fanout_registry: FanoutRegistry | None = field(default=None, repr=False)
     findings_store: Any | None = field(default=None, repr=False)
 
-    def _attach_advisory(self, meta: dict[str, Any], session_id: str, question: str) -> None:
+    async def _attach_advisory(self, meta: dict[str, Any], session_id: str, question: str) -> None:
         """Attach the evidence lanes to one PM turn that shows ``question``.
 
         The lanes, their contracts and their requiredness all come from this
@@ -414,6 +427,8 @@ class PMInterviewHandler:
             fanout_registry=self.fanout_registry,
             findings_store=self.findings_store,
         )
+        # RFC #2222: briefs travel as references, not bodies (see pm_batch).
+        await externalize_advisory_payloads(meta, self.findings_store)
 
     @property
     def definition(self) -> MCPToolDefinition:
@@ -802,12 +817,11 @@ class PMInterviewHandler:
                                 tool_name="ouroboros_pm_interview",
                             )
                         )
-                    # One call for every answer, whatever its provenance. A
-                    # confirmed lane finding arrives here as an ordinary
-                    # ``[from-code]`` answer and ``record_answer`` settles it as
-                    # an observation, so this branch needs no case of its own —
-                    # which is what makes the two runtimes agree by default
-                    # instead of by a second rule someone has to keep in step.
+                    # One call for every answer, whatever its provenance —
+                    # ``record_answer`` classifies any leading marker itself,
+                    # so this branch needs no case of its own, which is what
+                    # makes the two runtimes agree by default instead of by a
+                    # second rule someone has to keep in step.
                     state.record_answer(question_text, answer)
                     state.mark_updated()
                     save_result = await _plugin_save_state(state_dir, state)
@@ -1026,9 +1040,7 @@ class PMInterviewHandler:
 
         # Check classification to signal skip eligibility
         classification = _last_classification(engine)
-        is_decide_later = classification == "decide_later"
-        is_deferred = classification == "deferred"
-        skip_eligible = is_decide_later or is_deferred
+        skip_eligible = classification in ("decide_later", "deferred")
 
         meta = {
             "session_id": state.interview_id,
@@ -1042,7 +1054,7 @@ class PMInterviewHandler:
             "pending_reframe": pending_reframe,
             **diff,
         }
-        self._attach_advisory(meta, state.interview_id, question)
+        await self._attach_advisory(meta, state.interview_id, question)
 
         log.info(
             "pm_handler.started",
@@ -1059,20 +1071,7 @@ class PMInterviewHandler:
             f"PM interview started. Session ID: {state.interview_id}\n\n"
             f"{PM_UNCERTAINTY_GUIDANCE}\n\n{question}"
         )
-        if is_decide_later:
-            start_text += (
-                "\n\n💡 This question can be deferred. "
-                'The user may answer now, or choose "decide later" to skip it. '
-                "If they choose to decide later, pass "
-                f'answer="[decide_later]" with session_id="{state.interview_id}".'
-            )
-        elif is_deferred:
-            start_text += (
-                "\n\n💡 This is a technical question that can be deferred to the dev phase. "
-                "The user may answer now, or choose to defer it. "
-                "If they choose to defer, pass "
-                f'answer="[deferred]" with session_id="{state.interview_id}".'
-            )
+        start_text += skip_hint_suffix(classification, state.interview_id)
 
         return Result.ok(
             MCPToolResult(
@@ -1278,9 +1277,7 @@ class PMInterviewHandler:
 
         engine.restore_meta(meta)
         classification = _last_classification(engine)
-        is_decide_later = classification == "decide_later"
-        is_deferred = classification == "deferred"
-        skip_eligible = is_decide_later or is_deferred
+        skip_eligible = classification in ("decide_later", "deferred")
 
         resume_meta: dict[str, Any] = {
             "session_id": session_id,
@@ -1295,7 +1292,7 @@ class PMInterviewHandler:
         # the lanes like any other. This is the turn where the "every question"
         # rule would otherwise fail quietly: the answer that follows looks
         # identical whether or not evidence was ever fetched for it.
-        self._attach_advisory(resume_meta, session_id, first_question)
+        await self._attach_advisory(resume_meta, session_id, first_question)
 
         return Result.ok(
             MCPToolResult(
@@ -1344,33 +1341,30 @@ class PMInterviewHandler:
         if meta:
             engine.restore_meta(meta)
 
+        # ── Batched turn (RFC #2222): pending members live in PM meta ──
+        pending_batch = pending_batch_entries(meta)
+
+        if not answer and pending_batch:
+            return Result.ok(
+                batch_pending_result(
+                    session_id,
+                    pending_batch,
+                    decide_later_count=len(engine.deferred_items) + len(engine.decide_later_items),
+                )
+            )
+
         # If no answer provided, re-display the pending question (retry/reconnect)
         reconnect_pending = _pending_round(state)
         if not answer and reconnect_pending is not None:
             pending_question = reconnect_pending.question
             classification = _last_classification(engine)
-            is_decide_later = classification == "decide_later"
-            is_deferred = classification == "deferred"
-            skip_eligible = is_decide_later or is_deferred
+            skip_eligible = classification in ("decide_later", "deferred")
 
             pending_reframe = engine.get_pending_reframe()
 
             # Include skip hint in re-displayed question
             pending_text = f"Session {session_id}\n\n{pending_question}"
-            if is_decide_later:
-                pending_text += (
-                    "\n\n💡 This question can be deferred. "
-                    'The user may answer now, or choose "decide later" to skip it. '
-                    "If they choose to decide later, pass "
-                    f'answer="[decide_later]" with session_id="{session_id}".'
-                )
-            elif is_deferred:
-                pending_text += (
-                    "\n\n💡 This is a technical question that can be deferred to the dev phase. "
-                    "The user may answer now, or choose to defer it. "
-                    "If they choose to defer, pass "
-                    f'answer="[deferred]" with session_id="{session_id}".'
-                )
+            pending_text += skip_hint_suffix(classification, session_id)
 
             pending_meta: dict[str, Any] = {
                 "session_id": session_id,
@@ -1389,7 +1383,7 @@ class PMInterviewHandler:
                 "deferred_count": 0,
                 "decide_later_count": len(engine.deferred_items) + len(engine.decide_later_items),
             }
-            self._attach_advisory(pending_meta, session_id, pending_question)
+            await self._attach_advisory(pending_meta, session_id, pending_question)
 
             return Result.ok(
                 MCPToolResult(
@@ -1419,7 +1413,61 @@ class PMInterviewHandler:
                     tool_name="ouroboros_pm_interview",
                 )
             )
-        if answer and state.rounds:
+
+        # ── Batch member answer (RFC #2222) — see pm_batch for the rules ──
+        batch_answer_recorded = False
+        if answer and pending_batch:
+            target, member_error = resolve_batch_member(pending_batch, last_question)
+            if target is None:
+                return Result.err(
+                    MCPToolError(
+                        member_error or "No pending batch member matched.",
+                        tool_name="ouroboros_pm_interview",
+                    )
+                )
+
+            member_result = await record_member_answer(engine, state, target, answer)
+            if member_result.is_err:
+                return Result.err(
+                    MCPToolError(
+                        str(member_result.error),
+                        tool_name="ouroboros_pm_interview",
+                    )
+                )
+            state = member_result.value
+
+            remaining = [e for e in pending_batch if e is not target]
+            save_result = await engine.save_state(state)
+            if isinstance(save_result, Result) and save_result.is_err:
+                return Result.err(
+                    MCPToolError(
+                        f"Failed to persist PM answer: {save_result.error}",
+                        tool_name="ouroboros_pm_interview",
+                    )
+                )
+            if remaining:
+                _save_pm_meta(
+                    session_id,
+                    engine,
+                    cwd=cwd,
+                    data_dir=self.data_dir,
+                    extra={"pending_batch": remaining},
+                )
+                diff = _compute_deferred_diff(engine, deferred_before, decide_later_before)
+                return Result.ok(
+                    batch_pending_result(
+                        session_id,
+                        remaining,
+                        decide_later_count=diff["decide_later_count"],
+                        diff=diff,
+                    )
+                )
+            # Batch resolved — persist without the key and continue to the
+            # completion check and next-turn generation below.
+            _save_pm_meta(session_id, engine, cwd=cwd, data_dir=self.data_dir)
+            batch_answer_recorded = True
+
+        if answer and state.rounds and not batch_answer_recorded:
             # Pending means unanswered, not last. Those two agree now that
             # nothing but a question occupies a round, and the search is written
             # this way rather than as ``rounds[-1]`` so that it keeps agreeing:
@@ -1505,7 +1553,7 @@ class PMInterviewHandler:
                     )
                 state = record_result.value
 
-        if answer:
+        if answer and not batch_answer_recorded:
             save_result = await engine.save_state(state)
             if isinstance(save_result, Result) and save_result.is_err:
                 return Result.err(
@@ -1522,10 +1570,11 @@ class PMInterviewHandler:
             and isinstance(engine, PMInterviewEngine)
             and engine.supports_atomic_turn is True
         )
+        batch_turns: list[PMInterviewTurnPlan] = []
         if supports_atomic_turn:
-            turn_result = await engine.plan_next_turn(state)
-            if turn_result.is_err:
-                error_msg = str(turn_result.error)
+            turns_result = await engine.plan_next_turns(state)
+            if turns_result.is_err:
+                error_msg = str(turns_result.error)
                 return Result.ok(
                     MCPToolResult(
                         content=(
@@ -1542,7 +1591,8 @@ class PMInterviewHandler:
                         meta={"session_id": session_id, "recoverable": True},
                     )
                 )
-            turn: PMInterviewTurnPlan = turn_result.value
+            batch_turns = turns_result.value
+            turn: PMInterviewTurnPlan = batch_turns[0]
             question = turn.question
             if turn.ambiguity is not None:
                 state.store_ambiguity(
@@ -1707,6 +1757,59 @@ class PMInterviewHandler:
         # slice from the pre-snapshot length to current length
         diff = _compute_deferred_diff(engine, deferred_before, decide_later_before)
 
+        # ── Batched turn (RFC #2222) — see pm_batch for the invariant ──
+        if len(batch_turns) > 1:
+            state.mark_updated()
+            save_result = await engine.save_state(state)
+            if isinstance(save_result, Result) and save_result.is_err:
+                return Result.err(
+                    MCPToolError(
+                        f"Failed to persist resume state: {save_result.error}",
+                        tool_name="ouroboros_pm_interview",
+                    )
+                )
+            batch_entries = batch_entries_for_turns(batch_turns)
+            _save_pm_meta(
+                session_id,
+                engine,
+                cwd=cwd,
+                data_dir=self.data_dir,
+                extra={"pending_batch": batch_entries},
+            )
+
+            # One fan-out per question in its own envelope, so fanout ids and
+            # payloads never overwrite each other (dispatch: one wave, submit
+            # per envelope).
+            advisories: list[dict[str, Any]] = []
+            for t in batch_turns:
+                envelope: dict[str, Any] = {"question": t.question}
+                await self._attach_advisory(envelope, session_id, t.question)
+                advisories.append(envelope)
+
+            response_meta, response_text = batch_turn_meta_and_text(
+                session_id,
+                batch_entries,
+                advisories,
+                pending_reframe=engine.get_pending_reframe(),
+                diff=diff,
+            )
+            for envelope in advisories:
+                response_text = append_question_advisory_dispatch(response_text, envelope)
+
+            log.info(
+                "pm_handler.question_batch_asked",
+                session_id=session_id,
+                batch_size=len(batch_entries),
+                **diff,
+            )
+            return Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text=response_text),),
+                    is_error=False,
+                    meta=response_meta,
+                )
+            )
+
         # Save unanswered round
         state.rounds.append(
             InterviewRound(
@@ -1734,9 +1837,7 @@ class PMInterviewHandler:
         classification = _last_classification(engine)
 
         # Signal to the caller that the user can skip this question
-        is_decide_later = classification == "decide_later"
-        is_deferred = classification == "deferred"
-        skip_eligible = is_decide_later or is_deferred
+        skip_eligible = classification in ("decide_later", "deferred")
 
         response_meta = {
             "session_id": session_id,
@@ -1753,7 +1854,7 @@ class PMInterviewHandler:
             "pending_reframe": pending_reframe,
             **diff,
         }
-        self._attach_advisory(response_meta, session_id, question)
+        await self._attach_advisory(response_meta, session_id, question)
 
         log.info(
             "pm_handler.question_asked",
@@ -1766,20 +1867,7 @@ class PMInterviewHandler:
 
         # Build response text — include skip hint when applicable
         response_text = f"Session {session_id}\n\n{question}"
-        if is_decide_later:
-            response_text += (
-                "\n\n💡 This question can be deferred. "
-                'The user may answer now, or choose "decide later" to skip it. '
-                "If they choose to decide later, pass "
-                f'answer="[decide_later]" with session_id="{session_id}".'
-            )
-        elif is_deferred:
-            response_text += (
-                "\n\n💡 This is a technical question that can be deferred to the dev phase. "
-                "The user may answer now, or choose to defer it. "
-                "If they choose to defer, pass "
-                f'answer="[deferred]" with session_id="{session_id}".'
-            )
+        response_text += skip_hint_suffix(classification, session_id)
 
         return Result.ok(
             MCPToolResult(

--- a/src/ouroboros/mcp/tools/pm_handler.py
+++ b/src/ouroboros/mcp/tools/pm_handler.py
@@ -805,22 +805,29 @@ class PMInterviewHandler:
                 if pair_error:
                     return Result.err(MCPToolError(pair_error, tool_name="ouroboros_pm_interview"))
                 if pairs:
-                    # The same normalization the in-process branch uses, so the
-                    # public answer shape means one thing on every runtime. It
-                    # was not shared once, and `answers` sent here was accepted
-                    # and dropped: the call reported success and the decisions
-                    # were never written.
+                    # The same recorder the in-process branch uses, not a
+                    # second one that agrees with it today. A pair became a
+                    # round here once by a loop of its own, and that loop
+                    # spelled `[decide_later]` as a sentence the user typed:
+                    # a control token committed as a decision, and an open
+                    # question the generated seed never heard was open.
+                    #
+                    # No engine is passed, and none is built: this runtime
+                    # dispatches generation to a child precisely so the server
+                    # need not hold an LLM adapter, and an answer being written
+                    # down must not be what finally requires one.
                     #
                     # Every answer names its question, on every runtime: a turn
                     # persists nothing when it asks (RFC #2222 revision 4), so
                     # there is no stored question to prefer over the echo.
-                    # ``record_answer`` appends the pair and settles provenance
-                    # where the answer arrives rather than at construction — one
-                    # call for every answer, whatever its provenance, so the two
-                    # runtimes agree by default rather than by a second rule
-                    # someone has to keep in step.
-                    for question_text, answer_text in pairs:
-                        state.record_answer(question_text, answer_text)
+                    record_result = await record_turn_answers(None, state, pairs)
+                    if record_result.is_err:
+                        return Result.err(
+                            MCPToolError(
+                                str(record_result.error), tool_name="ouroboros_pm_interview"
+                            )
+                        )
+                    state = record_result.value
                     state.mark_updated()
                     save_result = await _plugin_save_state(state_dir, state)
                     if save_result.is_err:
@@ -852,9 +859,12 @@ class PMInterviewHandler:
                     "status": DELEGATED_TO_SUBAGENT,
                     "dispatch_mode": "plugin",
                     "next_turn_hint": (
-                        "When the user answers, pass the child session's "
-                        "question text as 'last_question' alongside 'answer' "
-                        "to preserve PM interview transcript fidelity."
+                        "When the user answers, send the turn's answers as "
+                        "'answers': [{question, answer}] — each answer names "
+                        "its own question. A single answer may instead pass "
+                        "the child session's question text as 'last_question' "
+                        "alongside 'answer'. Either way the question travels "
+                        "with the answer, which is what the transcript keeps."
                     ),
                 },
             )

--- a/src/ouroboros/mcp/tools/question_advisory.py
+++ b/src/ouroboros/mcp/tools/question_advisory.py
@@ -321,9 +321,7 @@ def _declared_lanes(catalog: Mapping[str, Any]) -> set[str]:
     }
 
 
-def _recent_findings_section(
-    request: Mapping[str, Any], lane_id: str, *, contracted: bool
-) -> str:
+def _recent_findings_section(request: Mapping[str, Any], lane_id: str, *, contracted: bool) -> str:
     """Return the block carrying what has already been found in this project.
 
     Rendered by presence, like the scores above it: a project with nothing

--- a/src/ouroboros/mcp/tools/question_advisory.py
+++ b/src/ouroboros/mcp/tools/question_advisory.py
@@ -287,25 +287,25 @@ def _lane_agent(raw_lane: Mapping[str, Any], persona: str, capability: str) -> s
     return "researcher" if capability in {"inspect_code", "web_research"} else "general"
 
 
-def _open_contract_lanes(catalog: Mapping[str, Any]) -> set[str]:
-    """Return the lanes of one tool whose answer is prose rather than a fixed shape.
+def _declared_lanes(catalog: Mapping[str, Any]) -> set[str]:
+    """Return every lane id one tool's catalog declares.
 
-    A lane answering under a closed contract is not one of them, and the reason
-    is the same on both sides of the exchange. It has nowhere to *use* a
-    finding: what it may return is policy claims read from this question's
-    roster, or aggregates measured here, and a previous turn's finding is
-    neither. And it has nowhere to say it could not fetch one -- its answer
-    shape rejects any field it does not name, so writing that discards the whole
-    answer, and those lanes are required, so the fan-out then cannot complete.
-    Staying silent instead reports having found nothing, which is the confusion
-    this mechanism exists to prevent (RFC Q00/ouroboros#2167).
+    This is the offer set handed to ``recent_findings_by_lane``, which narrows
+    it to the lanes RFC Q00/ouroboros#2167 admits (``code_context``,
+    ``data_context``). Whether a lane answers under a closed contract is not
+    part of the test: eligibility follows what a lane *produces*, and the shape
+    of its answer is a validation concern, not a reuse one (#2223).
 
-    This is half of what decides who is offered a finding; the other half is
-    which lanes produce one worth reusing, which belongs to ``recent_findings``
-    and is applied there. Each list stays with its own reason -- this one is
-    about answer shapes, that one about what a lane's work repeats -- and the
-    two meet where they are passed to each other rather than being restated in
-    one place that would then own neither.
+    It was gated on answer shape once -- a contracted lane was offered nothing,
+    on the reasoning that its closed answer had no field in which to confess a
+    failed fetch. That withheld the head start from exactly the lanes doing the
+    most repeated work (both PM lanes are contracted) to protect a report
+    nobody consumes: a contracted answer carries no reuse statement a reader
+    could be misled by, a fetch that fails degrades to the investigation the
+    lane would have run anyway, and whether reuse happens at all is visible
+    server-side from the ``ouroboros_fetch_artifact`` calls. What the shape
+    still decides is the offer *text* -- a contracted lane is not told to
+    confess in-band; see ``_recent_findings_section``.
 
     Decided here rather than at render time so the request carries only what
     some lane will read. A key nothing renders is a promise the schema makes and
@@ -317,13 +317,13 @@ def _open_contract_lanes(catalog: Mapping[str, Any]) -> set[str]:
     return {
         str(lane.get("lane_id"))
         for lane in lanes
-        if isinstance(lane, Mapping)
-        and lane.get("lane_id")
-        and not isinstance(lane.get("answer_contract"), Mapping)
+        if isinstance(lane, Mapping) and lane.get("lane_id")
     }
 
 
-def _recent_findings_section(request: Mapping[str, Any], lane_id: str) -> str:
+def _recent_findings_section(
+    request: Mapping[str, Any], lane_id: str, *, contracted: bool
+) -> str:
     """Return the block carrying what has already been found in this project.
 
     Rendered by presence, like the scores above it: a project with nothing
@@ -332,7 +332,17 @@ def _recent_findings_section(request: Mapping[str, Any], lane_id: str) -> str:
     (RFC Q00/ouroboros#2167).
 
     Which lanes have a key at all is decided once, where the catalog is read
-    (see ``_open_contract_lanes``); this only renders what it was handed.
+    (see ``_declared_lanes``); this only renders what it was handed.
+
+    ``contracted`` selects what the block asks of a lane that cannot reach the
+    fetch tool. A prose lane says so in its finding -- silence there would read
+    as "nothing to reuse", the confusion RFC Q00/ouroboros#2167 exists to
+    prevent. A contracted lane has no field for that sentence and no reader who
+    would be misled by its absence: its answer carries claims about the
+    system, validated against the roster identically whether the fetch worked,
+    so it is told to keep its shape and investigate -- the offer's failure mode
+    is the exact behaviour the lane had without the offer. Whether it fetched
+    is the server's to observe, from the fetch calls themselves (#2223).
 
     **A place to find them, and nothing to work out about it.** This block used
     to hand over paths and then explain how to arrange what was inside them --
@@ -384,6 +394,13 @@ def _recent_findings_section(request: Mapping[str, Any], lane_id: str) -> str:
     )
     count = len(entries)
     plural = "" if count == 1 else "s"
+    if contracted:
+        unreachable = """**If you cannot reach that tool, investigate as usual.** Either way your answer
+keeps its contracted shape — do not add fields about reuse."""
+    else:
+        unreachable = f"""**If you cannot reach that tool, say so in your finding** — you were offered
+{count}, so reporting nothing to reuse would be false — then investigate as you
+would have without them."""
     return f"""## Recently Found Here
 You are offered {count} recent finding{plural} your lane published in this project
 within the last day. The bodies are not here. Fetch each with the MCP tool
@@ -395,9 +412,7 @@ narrows the artifact to your lane's own output:
 Read what you fetch, use what helps, and investigate the rest yourself. These
 are a head start, not a substitute.
 
-**If you cannot reach that tool, say so in your finding** — you were offered
-{count}, so reporting nothing to reuse would be false — then investigate as you
-would have without them.
+{unreachable}
 
 These may come from other sessions, which chose their own repositories. Report
 only what is true of the repositories *this* question gave you; a claim about
@@ -483,7 +498,11 @@ def build_question_advisory_subagents(request: Mapping[str, Any]) -> list[Subage
         # Built per lane: a lane is offered only what its own lane published
         # (RFC Q00/ouroboros#2167), so this differs between lanes and is absent
         # for the four that read nothing.
-        recent_findings = _recent_findings_section(request, lane_id)
+        recent_findings = _recent_findings_section(
+            request,
+            lane_id,
+            contracted=isinstance(raw_lane.get("answer_contract"), Mapping),
+        )
         recent_findings_section = f"\n{recent_findings}\n" if recent_findings else ""
         prompt = f"""## Task
 {task_preamble}
@@ -649,7 +668,7 @@ def attach_question_advisory(
         last_question=last_question,
         recent_findings=recent_findings_by_lane(
             findings_store,
-            lanes=_open_contract_lanes(_tool_advisory_catalog(tool_name)),
+            lanes=_declared_lanes(_tool_advisory_catalog(tool_name)),
         ),
     )
     try:

--- a/src/ouroboros/mcp/tools/question_advisory.py
+++ b/src/ouroboros/mcp/tools/question_advisory.py
@@ -170,12 +170,6 @@ contradiction is the most useful thing you can hand a PRD author.
 this list, that is not evidence and it will be rejected: report it in your
 finding as a repository worth adding, and give it no entry.
 
-**Fill what a carried finding requires.** If any entry carries a claim, set
-`answer_prefix` to `[from-code]`, `requires_user_confirmation` to true, and write
-`user_confirmation_prompt` as the question the user should be asked before your
-finding is recorded on their behalf. There is no prefix that skips that step.
-If no entry carries one, those three fields do not exist in your answer.
-
 **Stop while the answer is still useful.** Read the roster in order and stop
 once you can answer, giving entries only to what you actually opened. A partial
 scope named honestly is a complete answer; an exhaustive search that has not

--- a/src/ouroboros/mcp/tools/recent_findings.py
+++ b/src/ouroboros/mcp/tools/recent_findings.py
@@ -152,10 +152,11 @@ def recent_findings_by_lane(
     that keeps consumes none either, and handing one a code fact is a new
     capability rather than a cache hit.
 
-    ``lanes`` narrows it further to the lanes of a particular tool that can
-    read at all -- a caller passing none of them gets an empty mapping, which
-    is the honest answer for a tool whose every lane answers under a closed
-    contract. Absent, every eligible lane is returned.
+    ``lanes`` narrows it further to the lanes a particular tool declares.
+    Eligibility follows what a lane produces, never the shape of its answer:
+    a contracted lane is offered its own findings exactly as a prose lane is
+    (#2223) -- what differs is only the offer text it is handed, decided where
+    the prompt is rendered. Absent, every eligible lane is returned.
 
     A store that cannot be read returns nothing, and so does a single record
     that cannot be read: the rest of the store still answers. This is advisory

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -1706,6 +1706,10 @@ def build_pm_interview_subagent(
     if transcript:
         transcript_section = f"\n## Conversation History\n{transcript}\n"
 
+    # A turn's answers arrive under ``answers``, leaving the singular
+    # ``answer`` empty for exactly the turns carrying the most history. The
+    # history is the transcript; ``answer`` only adds one round beneath it.
+    answer_section = f"\n## User's Latest Answer\n{answer}\n" if answer else ""
     if action == "start" and initial_context:
         prompt = f"""{system_prompt}
 
@@ -1725,7 +1729,7 @@ constraints.
 
 Begin the PM interview. Ask your first question about product requirements."""
 
-    elif (action == "answer" or action == "resume") and answer:
+    elif (action == "answer" or action == "resume") and (answer or transcript):
         prompt = f"""{system_prompt}
 
 ---
@@ -1737,10 +1741,7 @@ Analyze their answer, classify requirements, and ask the next question.
 
 ## Session ID
 {session_id}
-{transcript_section}
-## User's Latest Answer
-{answer}
-{repos_section}
+{transcript_section}{answer_section}{repos_section}
 Continue the PM interview."""
 
     elif action == "generate":

--- a/src/ouroboros/orchestrator/capabilities/pm_schemas.py
+++ b/src/ouroboros/orchestrator/capabilities/pm_schemas.py
@@ -1,33 +1,36 @@
 """Schemas for the PM interview's advisory lanes (RFC Q00/ouroboros#1937).
 
 The PM interview fans out the same way the regular interview does, with two
-deliberate differences that both fall out of one sentence: *a confirmed fact may
-occupy a round of its own; an unconfirmed one may not become anything.*
+deliberate differences that both fall out of one sentence: *a finding is
+evidence the PM reads before answering; it is never an answer.*
 
 **Two lanes, not six.** Only the lanes that fetch evidence carry over — what the
 code does today, and what the data says. A lane that critiques the question or
 narrows it into options produces a draft judgment, not evidence, and a draft
 wears the face of material while standing in for the decision.
 
-**One answer path, and no exception to its confirmation.** The regular
-interview's code-fact contract carries an ``answer_prefix``, and a chain follows
-it: a confirmation flag, an exception to that flag
-(``[from-code][auto-confirmed]``), and a confidence grade deciding which answers
-earn the exception. That exception is justified there — the person being asked
-usually wrote the code — and PM has no such premise, so PM does not inherit it.
+**Findings are shown, not recorded** (RFC #2222 decision 4). An earlier design
+let a confirmed finding occupy a round of its own, carried into the transcript
+by an ``answer_prefix`` the lane declared and gated by a confirmation the PM had
+to give. Both are retired: the round duplicated the published fan-out, which is
+already addressable and re-offered, and the gate spent a turn to record what the
+store already held. The v2 code-lane contract has no ``answer_prefix``, no
+``requires_user_confirmation`` and no ``user_confirmation_prompt`` — with
+nothing recorded there is nothing to gate, and the closed shape rejects an
+answer that still carries them. Interview rounds carry the PM's own words.
 
-What PM inherits is the rest: the same ``answer_prefix`` field, under an enum
-holding exactly one element. ``[from-code][auto-confirmed]`` is therefore not
-forbidden here; it is unspellable. The prohibition is retired by removing the
-place rather than by growing the list of things forbidden — the same move the
-data lane made when a typed read request replaced its free-text query field
-(#1754/#1825).
+What each claim gains instead is a lane-authored ``plain_statement``: the
+product-language sentence the screen renders, in the question's own language,
+with no paths or identifiers. Citations stay in the published fan-out, which is
+where the record belongs. The prohibition is enforced by removing the place
+rather than by growing a list of forbidden values — the same move the data lane
+made when a typed read request replaced its free-text query field (#1754/#1825).
 
 Two doors were the alternative, and the cost was measured. PM originally kept
 no answer path at all and grew a second entrance for findings — an ``evidence``
 parameter no sibling tool has. Two entrances meant two sets of rules for the
 same payload, and seven review rounds found the same class of silent loss at a
-new address each time. One door with a one-element enum is what closed it.
+new address each time. Removing the entrance is what closed it.
 
 **What holds when a host skips the confirmation anyway.** The prompt is shown by
 the host, so the contract can ask for it but not perform it. The guarantee that

--- a/src/ouroboros/orchestrator/capabilities/pm_schemas.py
+++ b/src/ouroboros/orchestrator/capabilities/pm_schemas.py
@@ -186,7 +186,7 @@ def _pm_policy_claim_schema() -> dict[str, Any]:
     return {
         "type": "object",
         "additionalProperties": False,
-        "required": ["path", "policy_claim"],
+        "required": ["path", "policy_claim", "plain_statement"],
         "properties": {
             "path": {
                 "type": "string",
@@ -209,6 +209,18 @@ def _pm_policy_claim_schema() -> dict[str, Any]:
                 "description": (
                     "What this source shows the system does today. Descriptive "
                     "only: what exists, never what the PRD should decide."
+                ),
+            },
+            "plain_statement": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 300,
+                "description": (
+                    "The same claim as one plain sentence for the PM, written "
+                    "in the question's language: what the system does, in "
+                    "product terms — no file paths, no code identifiers. The "
+                    "citation stays in policy_claim; this is what the user is "
+                    "shown (RFC #2222)."
                 ),
             },
         },
@@ -287,22 +299,17 @@ def _pm_code_context_answer_contract() -> dict[str, Any]:
       implements policy bearing on the question. Every entry carries no claim,
       which is what keeps "found nothing across two of five" different from
       "found nothing across all five".
-    - ``PolicyCarried`` -- at least one entry carries a claim, and the three
-      forwarding fields are required. ``contains`` is what makes this state
-      unreachable without a claim, so "confirm my finding" with nothing to
-      confirm has no spelling, and neither has a claim that arrives with no
-      confirmation asked for.
+    - ``PolicyCarried`` -- at least one entry carries a claim. ``contains`` is
+      what makes this state unreachable without one.
 
-    ``answer_prefix`` exists only in the carried state, under an enum of one
-    element, and there is no confidence grade beside it. The enum is the
-    enforcement: a child cannot mark this output as skipping confirmation
-    because ``[from-code][auto-confirmed]`` is not a value this field can hold,
-    and the shape is closed, so it cannot add a field that says so another way.
-    A rule forbidding the prefix would read as authoritative while being
-    enforced by nothing -- three of #1825's findings were guarantees stated
-    where nothing made them true. The other two states have no ``answer_prefix``
-    property at all, for the same reason they carry no claim: there is nothing
-    to forward.
+    No forwarding fields (RFC #2222). A finding is evidence shown beside the
+    question, never an answer recorded on the user's behalf: the published
+    fan-out is already the durable record of what was found, and the interview
+    rounds carry only what the user themselves wrote. The v1 contract carried
+    ``answer_prefix`` / ``requires_user_confirmation`` /
+    ``user_confirmation_prompt`` to gate a recorded adopted fact; with nothing
+    recorded there is nothing to gate, and the closed shape means an answer
+    carrying those fields is rejected rather than quietly honoured.
 
     ``examined`` is required in all three states, empty list included. It is
     what keeps the lane's reporting about itself: "no policy found" means
@@ -393,53 +400,15 @@ def _pm_code_context_answer_contract() -> dict[str, Any]:
         "title": "PolicyCarried",
         "type": "object",
         "additionalProperties": False,
-        "required": [
-            "question_identity",
-            "lane_id",
-            "examined",
-            "answer_prefix",
-            "requires_user_confirmation",
-            "user_confirmation_prompt",
-        ],
+        "required": ["question_identity", "lane_id", "examined"],
         "properties": {
             "question_identity": identity_property,
             "lane_id": {"const": "code_context"},
             "examined": examined_property(max_claims=_PM_CLAIMS_MAX_PER_REPOSITORY),
-            "answer_prefix": {
-                "type": "string",
-                "enum": ["[from-code]"],
-                "description": (
-                    "The prefix the host puts on this finding when the user "
-                    "confirms it. One value, and that is the whole of the "
-                    "confirmation policy: the interview's "
-                    "'[from-code][auto-confirmed]' cannot be spelled here, so "
-                    "no output of this lane can declare itself exempt from "
-                    "being confirmed."
-                ),
-            },
-            "requires_user_confirmation": {
-                "const": True,
-                "description": (
-                    "Always true. Named as the interview names it so one host "
-                    "code path serves both tools, and constant because the "
-                    "premise that earns an exception there -- the person being "
-                    "asked usually wrote the code -- is not a premise a PRD has."
-                ),
-            },
-            "user_confirmation_prompt": {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 600,
-                "description": (
-                    "What to ask the user before forwarding this finding. "
-                    "Required, because a confirmation step with no text to show "
-                    "is one the host is free to skip silently."
-                ),
-            },
         },
     }
     return {
-        "contract_id": "pm_code_context_answer.v1",
+        "contract_id": "pm_code_context_answer.v2",
         "scope": "single_pm_question_code_context",
         # Two things, and deliberately no third -- the schema re-entry enforces,
         # and the instruction the child must follow. A claim *about* the system
@@ -457,12 +426,11 @@ def _pm_code_context_answer_contract() -> dict[str, Any]:
             "If two repositories implement different policies, carry both; the "
             "disagreement is what the PM most needs to see. Evidence from outside "
             "the roster is not evidence: say so in your finding so the PM can add "
-            "the repository, and do not give it an entry. When you carry a "
-            "policy, set answer_prefix to [from-code] and write "
-            "user_confirmation_prompt as the question the user should be asked "
-            "before your finding is recorded on their behalf -- the finding is "
-            "recorded as an adopted fact, never as their decision, and the "
-            "decision is what they write on the question that follows."
+            "the repository, and do not give it an entry. Beside each claim, "
+            "write plain_statement in the question's language: the same fact as "
+            "one product-language sentence, no paths or identifiers — it is what "
+            "the user sees. Your finding is evidence beside the question, "
+            "recorded nowhere else; the decision is what the user writes."
         ),
     }
 
@@ -519,27 +487,22 @@ def _pm_question_advisory_fanout_metadata() -> dict[str, Any]:
         "allowed_capabilities": ["inspect_code", "read_data"],
         "question_heading": "## PM Question",
         # The counterpart of the interview's, and the sentence that differs: no
-        # quality of evidence lets a finding here skip the user.
+        # quality of evidence lets a finding here stand in for the user.
         "task_preamble": (
             "You are an Ouroboros PM interview advisory subagent.\n"
             "\n"
             "The parent session has already shown the PM question to the user. "
-            "Your job is to\nreport what the system does today. Never decide on "
-            "behalf of the user, however\nclear your finding is: a PRD asks what "
-            "the system should do and you can only\nreport what it does. Your "
-            "finding is shown to the user for confirmation, and it\nis recorded "
-            "as an adopted fact -- never as their decision."
+            "Report what the system does today. Never decide on behalf of the "
+            "user: your finding is shown beside the question as evidence, and "
+            "the decision is what they write in their own words."
         ),
-        # Unconditional, unlike the interview's. There is no configuration of
-        # evidence quality that lets a finding here reach the record without the
-        # user seeing it, so the rule the child reads must not be phrased as a
-        # condition it evaluates.
+        # Unconditional, unlike the interview's: no quality of evidence turns
+        # a finding into an answer here (RFC #2222 — findings are display-only).
         "child_answer_rule": (
             "Never decide on behalf of the user, however clear your finding is. "
-            "A PRD asks what the system should do and you can only report what "
-            "it does. Your finding is confirmed by the user and then recorded as "
-            "an adopted fact; the decision is what they write in their own words "
-            "on the question that follows."
+            "A PRD asks what the system should do; you report what it does. "
+            "Your finding is evidence beside the question, recorded nowhere "
+            "else; the decision is what the user writes."
         ),
         "dispatch_timing": "after_question_is_visible_to_user",
         "parallel_preference": "parallel_when_runtime_supports_subagents",
@@ -565,14 +528,10 @@ def _pm_question_advisory_fanout_metadata() -> dict[str, Any]:
         },
         "runtime_instruction": (
             "Show the PM question to the user first, then fan out the code-policy "
-            "and data lanes. A code lane that carries a policy returns "
-            "answer_prefix [from-code] and a confirmation prompt: show that "
-            "prompt, and only if the user confirms, send the finding as the "
-            "answer with its [from-code] prefix. It is recorded as an adopted "
-            "fact -- withheld from requirement extraction, not counted toward "
-            "completion -- and the server returns the next question, which is "
-            "the one the user answers in their own words. There is no prefix "
-            "that skips the confirmation."
+            "and data lanes. Render each claim's plain_statement beside the "
+            "question as evidence — findings are never sent as answers and "
+            "never recorded on the user's behalf. The user answers every "
+            "question in their own words."
         ),
     }
 

--- a/tests/unit/bigbang/test_pm_interview.py
+++ b/tests/unit/bigbang/test_pm_interview.py
@@ -2383,3 +2383,52 @@ async def test_a_dropped_companion_does_not_take_the_primary_reframe_with_it(
     # The primary's reframe survived the companion's undo.
     assert engine._reframe_map[reframed] == "Which index strategy should the store use?"
     assert len(engine.classifications) == 1
+
+
+@pytest.mark.asyncio
+async def test_an_abandoned_turns_reframe_does_not_attach_to_the_next_one(
+    tmp_path: Path,
+) -> None:
+    """Planning a turn replaces the reframe routing, never adds to it.
+
+    A reframe maps a shown question back to the technical one behind it, and
+    that mapping is meaningful only while its turn is on the wire. A host
+    abandons a turn by not answering it, and the next call plans a fresh one —
+    so a mapping that outlived its turn would attach to a later question that
+    merely reads the same, and record that decision under a technical question
+    nobody was asked.
+    """
+    shown = "How fast must saved reports open?"
+    reframed_payload = _batch_payload(
+        next_question="Which index strategy should the store use?",
+        category="development",
+        reframed_question=shown,
+        reasoning="Technical question needing a PM reframe.",
+    )
+    plain_payload = _batch_payload(next_question=shown, reframed_question=shown)
+    adapter = MagicMock()
+    adapter.complete = AsyncMock(
+        side_effect=[
+            Result.ok(_mock_completion(json.dumps(reframed_payload))),
+            Result.ok(_mock_completion(json.dumps(plain_payload))),
+        ]
+    )
+    engine = _make_engine(adapter=adapter, tmp_path=tmp_path)
+    state = _batch_state("pm_abandoned_reframe")
+
+    first = await engine.plan_next_turns(state)
+    assert first.is_ok
+    assert engine._reframe_map[shown] == "Which index strategy should the store use?"
+
+    # The turn is abandoned: no answer is recorded, and a fresh turn is planned.
+    second = await engine.plan_next_turns(state)
+    assert second.is_ok
+    assert [plan.question for plan in second.value] == [shown]
+    assert engine._reframe_map == {}
+
+    # The answer to the freshly planned question carries only itself.
+    recorded = await engine.record_response(state, "Three seconds.", shown)
+    assert recorded.is_ok
+    round_written = recorded.value.rounds[-1]
+    assert round_written.question == shown
+    assert "Original technical question" not in round_written.question

--- a/tests/unit/bigbang/test_pm_interview.py
+++ b/tests/unit/bigbang/test_pm_interview.py
@@ -2341,3 +2341,45 @@ async def test_plan_next_turns_rejects_wrong_typed_companion_routing(
     assert result.value[1].classification.output_type == ClassifierOutputType.DECIDE_LATER
     # The rejected companion left no routing state behind.
     assert len(engine.classifications) == len(questions)
+
+
+@pytest.mark.asyncio
+async def test_a_dropped_companion_does_not_take_the_primary_reframe_with_it(
+    tmp_path: Path,
+) -> None:
+    """Undoing a companion restores the reframe map, never pops its key.
+
+    A companion whose own text differs passes the identity gate, then reframes
+    onto the primary's shown question and is dropped for it. Its
+    ``_apply_classification`` has already overwritten the primary's map entry
+    by then, so popping the key would delete the primary's original question —
+    and the PM's answer to a reframed question would have nothing to bundle.
+    """
+    reframed = "How fast must saved reports open?"
+    payload = _batch_payload(
+        next_question="Which index strategy should the store use?",
+        category="development",
+        reframed_question=reframed,
+        reasoning="Technical question needing a PM reframe.",
+        companion_questions=[
+            {
+                "question": "Which storage engine should back the report cache?",
+                "category": "development",
+                "reframed_question": reframed,
+                "reasoning": "Reframes onto the primary's shown question.",
+                "defer_to_dev": False,
+                "decide_later": False,
+            },
+        ],
+    )
+    adapter = MagicMock()
+    adapter.complete = AsyncMock(return_value=Result.ok(_mock_completion(json.dumps(payload))))
+    engine = _make_engine(adapter=adapter, tmp_path=tmp_path)
+
+    result = await engine.plan_next_turns(_batch_state("pm_batch_reframe_undo"))
+
+    assert result.is_ok
+    assert [plan.question for plan in result.value] == [reframed]
+    # The primary's reframe survived the companion's undo.
+    assert engine._reframe_map[reframed] == "Which index strategy should the store use?"
+    assert len(engine.classifications) == 1

--- a/tests/unit/bigbang/test_pm_interview.py
+++ b/tests/unit/bigbang/test_pm_interview.py
@@ -2294,3 +2294,50 @@ async def test_plan_next_turns_drops_duplicates_and_malformed_companions(
     ]
     # One classification per shipped question — dropped companions leave no trace.
     assert len(engine.classifications) == len(questions)
+
+
+@pytest.mark.asyncio
+async def test_plan_next_turns_rejects_wrong_typed_companion_routing(
+    tmp_path: Path,
+) -> None:
+    """A companion's routing fields are validated, never coerced (RFC #2222).
+
+    ``bool("false")`` is True: a string where a boolean belongs would make a
+    question the PM must answer skip-eligible, and ``[decide_later]`` would
+    then discard it. The companion goes through the primary's own parser, so
+    the wrong-typed one is dropped while a properly typed decide-later
+    companion keeps its skip route.
+    """
+    payload = _batch_payload(
+        companion_questions=[
+            {
+                "question": "What data retention constraint applies?",
+                "category": "planning",
+                "decide_later": "false",  # a string, not a boolean
+            },
+            {
+                "question": "Which decisions can wait until launch scope is known?",
+                "category": "decide_later",
+                "reframed_question": "Which decisions can wait until launch scope is known?",
+                "reasoning": "Deferrable dimension.",
+                "defer_to_dev": False,
+                "decide_later": True,
+                "placeholder_response": "To be decided at launch.",
+            },
+        ]
+    )
+    adapter = MagicMock()
+    adapter.complete = AsyncMock(return_value=Result.ok(_mock_completion(json.dumps(payload))))
+    engine = _make_engine(adapter=adapter, tmp_path=tmp_path)
+
+    result = await engine.plan_next_turns(_batch_state("pm_batch_typed_flags"))
+
+    assert result.is_ok
+    questions = [plan.question for plan in result.value]
+    assert questions == [
+        "Which user workflow matters most?",
+        "Which decisions can wait until launch scope is known?",
+    ]
+    assert result.value[1].classification.output_type == ClassifierOutputType.DECIDE_LATER
+    # The rejected companion left no routing state behind.
+    assert len(engine.classifications) == len(questions)

--- a/tests/unit/bigbang/test_pm_interview.py
+++ b/tests/unit/bigbang/test_pm_interview.py
@@ -2163,3 +2163,134 @@ class TestRestoreMeta:
 
         assert engine.codebase_context == ""
         assert engine.classifier.codebase_context == ""
+
+
+# ── RFC #2222: batched turn planning ─────────────────────────────
+
+
+def _batch_payload(**overrides: object) -> dict[str, object]:
+    """One atomic-turn payload with moderate ambiguity and PM routing fields."""
+    payload: dict[str, object] = {
+        "next_question": "Which user workflow matters most?",
+        "goal_clarity_score": 0.8,
+        "goal_clarity_justification": "The product goal is specific.",
+        "constraint_clarity_score": 0.7,
+        "constraint_clarity_justification": "Core boundaries are present.",
+        "success_criteria_clarity_score": 0.6,
+        "success_criteria_clarity_justification": "One workflow decision remains.",
+        "category": "planning",
+        "reframed_question": "Which user workflow matters most?",
+        "reasoning": "Planning question.",
+        "defer_to_dev": False,
+        "decide_later": False,
+        "placeholder_response": "",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _batch_state(interview_id: str) -> InterviewState:
+    return InterviewState(
+        interview_id=interview_id,
+        initial_context="Build an analytics workflow",
+        rounds=[
+            InterviewRound(round_number=1, question="Who uses it?", user_response="PMs"),
+            InterviewRound(round_number=2, question="What output?", user_response="Reports"),
+            InterviewRound(round_number=3, question="What scope?", user_response="MVP only"),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_plan_next_turns_carries_independent_companions(tmp_path: Path) -> None:
+    """One planner call, up to three questions out, each classified (RFC #2222)."""
+    payload = _batch_payload(
+        companion_questions=[
+            {
+                "question": "What data retention constraint applies?",
+                "category": "planning",
+                "reframed_question": "What data retention constraint applies?",
+                "reasoning": "Independent constraint dimension.",
+                "defer_to_dev": False,
+                "decide_later": False,
+            },
+            {
+                "question": "Which index strategy should the store use?",
+                "category": "development",
+                "reframed_question": "How fast must saved reports open?",
+                "reasoning": "Technical question needing a PM reframe.",
+                "defer_to_dev": False,
+                "decide_later": False,
+            },
+        ]
+    )
+    adapter = MagicMock()
+    adapter.complete = AsyncMock(return_value=Result.ok(_mock_completion(json.dumps(payload))))
+    engine = _make_engine(adapter=adapter, tmp_path=tmp_path)
+
+    result = await engine.plan_next_turns(_batch_state("pm_batch_companions"))
+
+    assert result.is_ok
+    plans = result.value
+    assert [plan.question for plan in plans] == [
+        "Which user workflow matters most?",
+        "What data retention constraint applies?",
+        "How fast must saved reports open?",
+    ]
+    assert plans[2].classification.output_type == ClassifierOutputType.REFRAMED
+    # The reframed companion is tracked exactly as a single-question reframe is.
+    assert engine._reframe_map["How fast must saved reports open?"] == (
+        "Which index strategy should the store use?"
+    )
+    adapter.complete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_plan_next_turns_closure_mode_is_single_question(tmp_path: Path) -> None:
+    """At or below the closure threshold, companions are dropped (RFC #2222)."""
+    payload = _batch_payload(
+        goal_clarity_score=0.98,
+        constraint_clarity_score=0.97,
+        success_criteria_clarity_score=0.96,
+        companion_questions=[{"question": "A second topic the closure probe must not open?"}],
+    )
+    adapter = MagicMock()
+    adapter.complete = AsyncMock(return_value=Result.ok(_mock_completion(json.dumps(payload))))
+    engine = _make_engine(adapter=adapter, tmp_path=tmp_path)
+
+    result = await engine.plan_next_turns(_batch_state("pm_batch_closure"))
+
+    assert result.is_ok
+    assert len(result.value) == 1
+
+
+@pytest.mark.asyncio
+async def test_plan_next_turns_drops_duplicates_and_malformed_companions(
+    tmp_path: Path,
+) -> None:
+    """A companion that repeats a question, or carries none, never dispatches."""
+    payload = _batch_payload(
+        companion_questions=[
+            {"question": "Which user workflow matters most?"},  # duplicate of primary
+            {"category": "planning"},  # no question text
+            "not even an object",
+            {"question": "What launch constraint is fixed?"},
+            {"question": "What launch constraint is fixed?"},  # duplicate companion
+            {"question": "A third extra question over the ceiling?"},
+        ]
+    )
+    adapter = MagicMock()
+    adapter.complete = AsyncMock(return_value=Result.ok(_mock_completion(json.dumps(payload))))
+    engine = _make_engine(adapter=adapter, tmp_path=tmp_path)
+
+    result = await engine.plan_next_turns(_batch_state("pm_batch_dedupe"))
+
+    assert result.is_ok
+    questions = [plan.question for plan in result.value]
+    assert questions == [
+        "Which user workflow matters most?",
+        "What launch constraint is fixed?",
+        "A third extra question over the ceiling?",
+    ]
+    # One classification per shipped question — dropped companions leave no trace.
+    assert len(engine.classifications) == len(questions)

--- a/tests/unit/mcp/tools/test_handler_subagent_wiring.py
+++ b/tests/unit/mcp/tools/test_handler_subagent_wiring.py
@@ -683,10 +683,14 @@ class TestPMInterviewHandlerSubagentDispatch:
         assert payload["tool_name"] == "ouroboros_pm_interview"
 
     async def test_resume_with_answer_returns_subagent(self, handler) -> None:
+        # Every answer names its question, on every runtime: a turn persists
+        # nothing when it asks (RFC #2222 revision 4), so there is no stored
+        # question for the server to file an unnamed answer under.
         result = await handler.handle(
             {
                 "session_id": "sess-123",
                 "answer": "React + Node.js",
+                "last_question": "What stack?",
             }
         )
         assert result.is_ok

--- a/tests/unit/mcp/tools/test_pm_handler.py
+++ b/tests/unit/mcp/tools/test_pm_handler.py
@@ -389,6 +389,7 @@ class TestPrdMetaFileLocation:
             "decide_later_items",
             "codebase_context",
             "pending_reframe",
+            "pending_reframes",
             "cwd",
             "brownfield_repos",
             "classifications",

--- a/tests/unit/mcp/tools/test_pm_handler.py
+++ b/tests/unit/mcp/tools/test_pm_handler.py
@@ -944,7 +944,6 @@ async def test_atomic_pm_failure_returns_recoverable_session_envelope(tmp_path: 
             InterviewRound(round_number=1, question="Q1", user_response="A1"),
             InterviewRound(round_number=2, question="Q2", user_response="A2"),
             InterviewRound(round_number=3, question="Q3", user_response="A3"),
-            InterviewRound(round_number=4, question="Q4", user_response=None),
         ],
     )
     assert (await engine.save_state(state)).is_ok
@@ -952,7 +951,12 @@ async def test_atomic_pm_failure_returns_recoverable_session_envelope(tmp_path: 
     handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
 
     result = await handler.handle(
-        {"session_id": state.interview_id, "answer": "A4", "cwd": str(tmp_path)}
+        {
+            "session_id": state.interview_id,
+            "answer": "A4",
+            "last_question": "Q4",
+            "cwd": str(tmp_path),
+        }
     )
 
     assert result.is_ok
@@ -1036,7 +1040,6 @@ async def test_skip_metadata_survives_atomic_planner_failure(
             InterviewRound(round_number=1, question="Q1", user_response="A1"),
             InterviewRound(round_number=2, question="Q2", user_response="A2"),
             InterviewRound(round_number=3, question="Q3", user_response="A3"),
-            InterviewRound(round_number=4, question="Q4", user_response=None),
         ],
     )
     assert (await engine.save_state(state)).is_ok
@@ -1045,7 +1048,12 @@ async def test_skip_metadata_survives_atomic_planner_failure(
     handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
 
     result = await handler.handle(
-        {"session_id": state.interview_id, "answer": answer, "cwd": str(tmp_path)}
+        {
+            "session_id": state.interview_id,
+            "answer": answer,
+            "last_question": "Q4",
+            "cwd": str(tmp_path),
+        }
     )
 
     assert result.is_ok

--- a/tests/unit/mcp/tools/test_pm_handler_batch.py
+++ b/tests/unit/mcp/tools/test_pm_handler_batch.py
@@ -555,7 +555,7 @@ async def test_a_stub_carries_what_the_lane_cannot_work_without(tmp_path: Path) 
     # 2 — the findings this lane may reuse, ids only, offered as a shelf to
     # choose from rather than a list to work through.
     assert "fanout_earlier" in code
-    assert "not all of them" in code
+    assert "rather than all of them" in code
     assert "nothing to" in data and "reuse" in data
     # 3 — where each may look.
     assert roster[0]["repo_id"] in code and str(tmp_path / "podo-backend") in code

--- a/tests/unit/mcp/tools/test_pm_handler_batch.py
+++ b/tests/unit/mcp/tools/test_pm_handler_batch.py
@@ -552,9 +552,11 @@ async def test_a_stub_carries_what_the_lane_cannot_work_without(tmp_path: Path) 
     # 1 — the empty state, named from each lane's own contract.
     assert "not_a_policy_question" in code
     assert "not_a_measurement" in data
-    # 2 — the findings this lane may reuse, ids only.
+    # 2 — the findings this lane may reuse, ids only, offered as a shelf to
+    # choose from rather than a list to work through.
     assert "fanout_earlier" in code
-    assert "none published yet" in data
+    assert "not all of them" in code
+    assert "nothing to" in data and "reuse" in data
     # 3 — where each may look.
     assert roster[0]["repo_id"] in code and str(tmp_path / "podo-backend") in code
     assert "data tools" in data and roster[0]["repo_id"] not in data

--- a/tests/unit/mcp/tools/test_pm_handler_batch.py
+++ b/tests/unit/mcp/tools/test_pm_handler_batch.py
@@ -564,7 +564,8 @@ async def test_a_stub_carries_what_the_lane_cannot_work_without(tmp_path: Path) 
     # evidence to adopt, and nothing in the block a copy could be made from.
     assert "`examined`: one entry per repository" in code
     assert "`data_needed: true`" in data
-    assert "rejected with the answer" in code and "rejected with the answer" in data
+    assert "`path` is relative to the repository" in code
+    assert "never a row, a name, or an identifier" in data
     assert "```json" not in code.split("## Answer")[1]
     assert "plain_statement" in code and "plain_statement" not in data
     # Compact: the full brief is several times this, and stays fetchable.

--- a/tests/unit/mcp/tools/test_pm_handler_batch.py
+++ b/tests/unit/mcp/tools/test_pm_handler_batch.py
@@ -1,0 +1,394 @@
+"""Batched PM turns (RFC #2222): issue, partial answering, per-member routing.
+
+The decisions these hold:
+
+* A batched turn leaves **no** question-only rounds in core interview state —
+  the engine fills the trailing unanswered round on record, so a second
+  pending round is a question waiting to be silently overwritten. Batch
+  pending state lives in PM meta, and every member is recorded question and
+  answer together.
+* Every question shown keeps its evidence: one advisory envelope per batch
+  member, none shared, none skipped.
+* An unanswered member stays pending. Answering one member returns the rest;
+  only the answer that resolves the batch reaches completion checking and
+  next-turn generation.
+* Skip sentinels are guarded by the member's own classification, not by
+  whichever question was classified last.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ouroboros.bigbang.interview import InterviewRound, InterviewState
+from ouroboros.bigbang.pm_interview import PMInterviewEngine, PMInterviewTurnPlan
+from ouroboros.bigbang.question_classifier import (
+    ClassificationResult,
+    QuestionCategory,
+)
+from ouroboros.core.types import Result
+from ouroboros.mcp.tools.pm_handler import (
+    PMInterviewHandler,
+    _meta_path,
+    _save_pm_meta,
+)
+
+Q_PRIMARY = "Which user workflow matters most?"
+Q_SECOND = "What data retention constraint applies?"
+Q_THIRD = "Which decisions can wait until launch scope is known?"
+
+
+def _plan(
+    question: str,
+    *,
+    category: QuestionCategory = QuestionCategory.PLANNING,
+    decide_later: bool = False,
+) -> PMInterviewTurnPlan:
+    return PMInterviewTurnPlan(
+        question=question,
+        ambiguity=None,
+        classification=ClassificationResult(
+            original_question=question,
+            category=category,
+            reframed_question=question,
+            reasoning="test",
+            decide_later=decide_later,
+        ),
+        raw_payload={"next_question": question},
+    )
+
+
+def _engine(tmp_path: Path) -> PMInterviewEngine:
+    return PMInterviewEngine.create(
+        llm_adapter=MagicMock(),
+        model="test-model",
+        state_dir=tmp_path,
+    )
+
+
+def _answered_state(interview_id: str, *, pending: str | None = None) -> InterviewState:
+    rounds = [
+        InterviewRound(round_number=1, question="Q1", user_response="A1"),
+        InterviewRound(round_number=2, question="Q2", user_response="A2"),
+        InterviewRound(round_number=3, question="Q3", user_response="A3"),
+    ]
+    if pending is not None:
+        rounds.append(InterviewRound(round_number=4, question=pending, user_response=None))
+    return InterviewState(
+        interview_id=interview_id,
+        initial_context="Build an analytics workflow",
+        rounds=rounds,
+    )
+
+
+def _load_meta(session_id: str, data_dir: Path) -> dict:
+    return json.loads(_meta_path(session_id, data_dir).read_text(encoding="utf-8"))
+
+
+@pytest.mark.asyncio
+async def test_a_batched_turn_issues_every_question_with_its_own_evidence(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(tmp_path)
+    state = _answered_state("pm_batch_issue", pending="Q4")
+    assert (await engine.save_state(state)).is_ok
+    _save_pm_meta(state.interview_id, engine, cwd=str(tmp_path), data_dir=tmp_path)
+    engine.plan_next_turns = AsyncMock(
+        return_value=Result.ok([_plan(Q_PRIMARY), _plan(Q_SECOND), _plan(Q_THIRD)])
+    )
+    handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
+
+    result = await handler.handle(
+        {"session_id": state.interview_id, "answer": "A4", "cwd": str(tmp_path)}
+    )
+
+    assert result.is_ok
+    meta = result.value.meta
+    assert [entry["question"] for entry in meta["question_batch"]] == [
+        Q_PRIMARY,
+        Q_SECOND,
+        Q_THIRD,
+    ]
+    # One advisory envelope per question, each with its own payloads.
+    advisories = meta["question_advisories"]
+    assert [envelope["question"] for envelope in advisories] == [Q_PRIMARY, Q_SECOND, Q_THIRD]
+    for envelope in advisories:
+        lane_ids = [
+            payload["context"]["lane_id"] for payload in envelope["question_advisory_subagents"]
+        ]
+        assert sorted(lane_ids) == ["code_context", "data_context"]
+    # The dispatch text carries every question and every envelope's block.
+    text = result.value.text_content
+    for question in (Q_PRIMARY, Q_SECOND, Q_THIRD):
+        assert question in text
+
+    # Core state holds no question-only rounds for the batch: the answer
+    # filled Q4, and nothing pending was appended behind it.
+    reloaded = (await engine.load_state(state.interview_id)).value
+    assert all(r.user_response is not None for r in reloaded.rounds)
+
+    # Batch pending state is persisted in PM meta, with per-member routing.
+    saved = _load_meta(state.interview_id, tmp_path)
+    assert [entry["question"] for entry in saved["pending_batch"]] == [
+        Q_PRIMARY,
+        Q_SECOND,
+        Q_THIRD,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_answering_one_member_returns_the_rest_without_generating(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(tmp_path)
+    state = _answered_state("pm_batch_partial")
+    assert (await engine.save_state(state)).is_ok
+    _save_pm_meta(
+        state.interview_id,
+        engine,
+        cwd=str(tmp_path),
+        data_dir=tmp_path,
+        extra={
+            "pending_batch": [
+                {"question": Q_PRIMARY, "classification": "passthrough", "skip_eligible": False},
+                {"question": Q_SECOND, "classification": "passthrough", "skip_eligible": False},
+            ]
+        },
+    )
+    engine.plan_next_turns = AsyncMock()
+    handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
+
+    result = await handler.handle(
+        {
+            "session_id": state.interview_id,
+            "answer": "Retention is 90 days.",
+            "last_question": Q_SECOND,
+            "cwd": str(tmp_path),
+        }
+    )
+
+    assert result.is_ok
+    meta = result.value.meta
+    assert [entry["question"] for entry in meta["question_batch"]] == [Q_PRIMARY]
+    assert meta["is_complete"] is False
+    engine.plan_next_turns.assert_not_called()
+
+    # The answered member is a full question-and-answer round; the pending
+    # member is nowhere in core state.
+    reloaded = (await engine.load_state(state.interview_id)).value
+    assert reloaded.rounds[-1].question == Q_SECOND
+    assert reloaded.rounds[-1].user_response == "Retention is 90 days."
+    assert all(r.user_response is not None for r in reloaded.rounds)
+    saved = _load_meta(state.interview_id, tmp_path)
+    assert [entry["question"] for entry in saved["pending_batch"]] == [Q_PRIMARY]
+
+
+@pytest.mark.asyncio
+async def test_resolving_the_batch_reaches_generation_and_clears_pending(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(tmp_path)
+    state = _answered_state("pm_batch_resolve")
+    assert (await engine.save_state(state)).is_ok
+    _save_pm_meta(
+        state.interview_id,
+        engine,
+        cwd=str(tmp_path),
+        data_dir=tmp_path,
+        extra={
+            "pending_batch": [
+                {"question": Q_PRIMARY, "classification": "passthrough", "skip_eligible": False},
+            ]
+        },
+    )
+    engine.plan_next_turns = AsyncMock(return_value=Result.ok([_plan("Next single question?")]))
+    handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
+
+    result = await handler.handle(
+        {
+            "session_id": state.interview_id,
+            "answer": "The review workflow.",
+            "last_question": Q_PRIMARY,
+            "cwd": str(tmp_path),
+        }
+    )
+
+    assert result.is_ok
+    engine.plan_next_turns.assert_awaited_once()
+    assert result.value.meta["question"] == "Next single question?"
+    assert "question_batch" not in result.value.meta
+    saved = _load_meta(state.interview_id, tmp_path)
+    assert "pending_batch" not in saved
+
+
+@pytest.mark.asyncio
+async def test_batch_answer_without_last_question_is_refused_while_ambiguous(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(tmp_path)
+    state = _answered_state("pm_batch_ambiguous")
+    assert (await engine.save_state(state)).is_ok
+    _save_pm_meta(
+        state.interview_id,
+        engine,
+        cwd=str(tmp_path),
+        data_dir=tmp_path,
+        extra={
+            "pending_batch": [
+                {"question": Q_PRIMARY, "classification": "passthrough", "skip_eligible": False},
+                {"question": Q_SECOND, "classification": "passthrough", "skip_eligible": False},
+            ]
+        },
+    )
+    handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
+
+    result = await handler.handle(
+        {"session_id": state.interview_id, "answer": "ambiguous", "cwd": str(tmp_path)}
+    )
+
+    assert result.is_err
+    assert "last_question" in str(result.error)
+    # Nothing was recorded against either pending member.
+    reloaded = (await engine.load_state(state.interview_id)).value
+    assert len(reloaded.rounds) == 3
+
+
+@pytest.mark.asyncio
+async def test_skip_sentinel_is_guarded_by_the_members_own_classification(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(tmp_path)
+    state = _answered_state("pm_batch_sentinel")
+    assert (await engine.save_state(state)).is_ok
+    _save_pm_meta(
+        state.interview_id,
+        engine,
+        cwd=str(tmp_path),
+        data_dir=tmp_path,
+        extra={
+            "pending_batch": [
+                {"question": Q_PRIMARY, "classification": "passthrough", "skip_eligible": False},
+                {"question": Q_THIRD, "classification": "decide_later", "skip_eligible": True},
+            ]
+        },
+    )
+    engine.plan_next_turns = AsyncMock()
+    handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
+
+    # The decide-later member honours the sentinel...
+    result = await handler.handle(
+        {
+            "session_id": state.interview_id,
+            "answer": "[decide_later]",
+            "last_question": Q_THIRD,
+            "cwd": str(tmp_path),
+        }
+    )
+    assert result.is_ok
+    assert Q_THIRD in engine.decide_later_items
+
+    # ...while the passthrough member records the same sentinel as a plain
+    # answer rather than silently discarding it.
+    result = await handler.handle(
+        {
+            "session_id": state.interview_id,
+            "answer": "[decide_later]",
+            "last_question": Q_PRIMARY,
+            "cwd": str(tmp_path),
+        }
+    )
+    assert result.is_ok
+    reloaded = (await engine.load_state(state.interview_id)).value
+    primary_round = next(r for r in reloaded.rounds if r.question == Q_PRIMARY)
+    assert primary_round.user_response == "[decide_later]"
+    assert Q_PRIMARY not in engine.decide_later_items
+
+
+@pytest.mark.asyncio
+async def test_briefs_travel_as_references_when_a_store_is_wired(tmp_path: Path) -> None:
+    """RFC #2222: the wire carries questions and references; briefs are fetched.
+
+    A turn's response used to carry every lane's full brief twice plus a copy
+    of the capability metadata per envelope, and a batch outgrew what a host
+    accepts inline. With a store wired, each payload prompt becomes a compact
+    stub naming the bundle to fetch; the bundle returns the full brief, lane-
+    scoped, through the same fetch path findings use.
+    """
+    from ouroboros.mcp.tools.fanout import FanoutRegistry
+    from ouroboros.persistence.artifact_store import ArtifactStore
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = ArtifactStore.for_project(workspace)
+    store.initialize()
+    registry = FanoutRegistry(tmp_path / "fanout")
+
+    engine = _engine(tmp_path)
+    state = _answered_state("pm_batch_reference", pending="Q4")
+    assert (await engine.save_state(state)).is_ok
+    _save_pm_meta(state.interview_id, engine, cwd=str(tmp_path), data_dir=tmp_path)
+    engine.plan_next_turns = AsyncMock(
+        return_value=Result.ok([_plan(Q_PRIMARY), _plan(Q_SECOND)])
+    )
+    handler = PMInterviewHandler(
+        pm_engine=engine,
+        data_dir=tmp_path,
+        fanout_registry=registry,
+        findings_store=store,
+    )
+
+    result = await handler.handle(
+        {"session_id": state.interview_id, "answer": "A4", "cwd": str(tmp_path)}
+    )
+
+    assert result.is_ok
+    for envelope in result.value.meta["question_advisories"]:
+        bundle_id = f"advisory-prompts:{envelope['question_advisory_fanout_id']}"
+        for payload in envelope["question_advisory_subagents"]:
+            stub = payload["prompt"]
+            # The stub names the fetch, and carries no brief body.
+            assert "ouroboros_fetch_artifact" in stub
+            assert bundle_id in stub
+            assert "Answer Contract" not in stub
+            assert "UNDISPATCHED" in stub
+            # The full brief is one scoped fetch away.
+            fetched = store.fetch_lane(bundle_id, payload["context"]["lane_id"]).body
+            assert "Answer Contract" in fetched
+            assert envelope["question"] in fetched
+        # The request no longer ships the capability metadata or lane catalog.
+        request = envelope["question_advisory_request"]
+        assert request["mcp_tool_capability"] == {"tool_name": "ouroboros_pm_interview"}
+        assert "lanes" not in request
+    # The dispatch text carries the stubs, not the briefs.
+    assert "Answer Contract" not in result.value.text_content
+
+
+@pytest.mark.asyncio
+async def test_without_a_store_the_full_briefs_stay_inline(tmp_path: Path) -> None:
+    """Fail-open: no store means the oversized-but-whole wire of today."""
+    from ouroboros.mcp.tools.fanout import FanoutRegistry
+
+    registry = FanoutRegistry(tmp_path / "fanout")
+    engine = _engine(tmp_path)
+    state = _answered_state("pm_batch_inline", pending="Q4")
+    assert (await engine.save_state(state)).is_ok
+    _save_pm_meta(state.interview_id, engine, cwd=str(tmp_path), data_dir=tmp_path)
+    engine.plan_next_turns = AsyncMock(return_value=Result.ok([_plan(Q_PRIMARY), _plan(Q_SECOND)]))
+    handler = PMInterviewHandler(
+        pm_engine=engine,
+        data_dir=tmp_path,
+        fanout_registry=registry,
+    )
+
+    result = await handler.handle(
+        {"session_id": state.interview_id, "answer": "A4", "cwd": str(tmp_path)}
+    )
+
+    assert result.is_ok
+    for envelope in result.value.meta["question_advisories"]:
+        for payload in envelope["question_advisory_subagents"]:
+            assert "Answer Contract" in payload["prompt"]

--- a/tests/unit/mcp/tools/test_pm_handler_batch.py
+++ b/tests/unit/mcp/tools/test_pm_handler_batch.py
@@ -143,13 +143,13 @@ async def test_a_batched_turn_issues_every_question_with_its_own_evidence(
 
 @pytest.mark.asyncio
 async def test_briefs_travel_as_references_when_a_store_is_wired(tmp_path: Path) -> None:
-    """RFC #2222: the wire carries questions and references; briefs are fetched.
+    """RFC #2222: the explanation is fetched; what the child works from is not.
 
     A turn's response used to carry every lane's full brief twice plus a copy
     of the capability metadata per envelope, and a batch outgrew what a host
-    accepts inline. With a store wired, each payload prompt becomes a compact
-    stub naming the bundle to fetch; the bundle returns the full brief, lane-
-    scoped, through the same fetch path findings use.
+    accepts inline. The stub keeps what a child cannot work without — its
+    answer schema, where it may look, what it has already found — and leaves
+    behind only the prose that explains them, one lane-scoped fetch away.
     """
     from ouroboros.mcp.tools.fanout import FanoutRegistry
     from ouroboros.persistence.artifact_store import ArtifactStore
@@ -186,13 +186,21 @@ async def test_briefs_travel_as_references_when_a_store_is_wired(tmp_path: Path)
         bundle_id = f"advisory-prompts:{envelope['question_advisory_fanout_id']}"
         for payload in envelope["question_advisory_subagents"]:
             stub = payload["prompt"]
-            # The stub names the fetch, and carries no brief body.
+            lane_id = payload["context"]["lane_id"]
+            # The stub names the fetch, and carries no brief prose.
             assert "ouroboros_fetch_artifact" in stub
             assert bundle_id in stub
             assert "Answer Contract" not in stub
-            assert "UNDISPATCHED" in stub
+            # A failed fetch no longer ends the lane, so nothing tells it to say so.
+            assert "UNDISPATCHED" not in stub
+            # What it cannot work without rides the stub: the answer shape, the
+            # lane's own empty state, and where it may look.
+            assert f'"lane_id":{{"const":"{lane_id}"}}' in stub
+            assert "answer the empty" in stub
+            # Step 3 follows the lane's own answer shape, not its name.
+            assert ("data tools" in stub) == (lane_id == "data_context")
             # The full brief is one scoped fetch away.
-            fetched = store.fetch_lane(bundle_id, payload["context"]["lane_id"]).body
+            fetched = store.fetch_lane(bundle_id, lane_id).body
             assert "Answer Contract" in fetched
             assert envelope["question"] in fetched
         # The request no longer ships the capability metadata or lane catalog.
@@ -441,3 +449,119 @@ async def test_plugin_mode_never_enters_the_batch_contract(tmp_path: Path) -> No
     engine.plan_next_turns.assert_not_called()
     assert "pending_batch" not in _load_meta(state.interview_id, tmp_path)
     assert "question_batch" not in (result.value.meta or {})
+
+
+@pytest.mark.asyncio
+async def test_the_batch_transport_means_the_same_thing_in_plugin_mode(
+    tmp_path: Path,
+) -> None:
+    """One public answer shape, one meaning, on every runtime.
+
+    The plugin branch records answers on its own path. When `answers` was added
+    to the in-process branch alone, a host that sent it here was answered with
+    success while its decisions were never written — the shape changed meaning
+    with the runtime, which is worse than not accepting it at all.
+
+    Plugin mode still never *plans* a batch (RFC #2222 keeps the producer
+    in-process); this is about what it does with the answers it is handed.
+    """
+    from ouroboros.mcp.tools.authoring_handlers import _plugin_load_state, _plugin_save_state
+
+    state = _answered_state("pm_plugin_answers")
+    assert (await _plugin_save_state(tmp_path, state)).is_ok
+    handler = PMInterviewHandler(
+        data_dir=tmp_path,
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    result = await handler.handle(
+        {
+            "session_id": state.interview_id,
+            "answers": [
+                {"question": Q_PRIMARY, "answer": "The review workflow."},
+                {"question": Q_SECOND, "answer": "Retention is 90 days."},
+            ],
+            "cwd": str(tmp_path),
+        }
+    )
+
+    assert result.is_ok
+    reloaded = (await _plugin_load_state(tmp_path, state.interview_id)).value
+    recorded = [(r.question, r.user_response) for r in reloaded.rounds[3:]]
+    assert recorded == [
+        (Q_PRIMARY, "The review workflow."),
+        (Q_SECOND, "Retention is 90 days."),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_stub_carries_what_the_lane_cannot_work_without(tmp_path: Path) -> None:
+    """The stub is compact, not partial (RFC #2222 decision 6).
+
+    Three things decide whether a lane can do its job at all: what shape its
+    answer must take, what it has already found here, and where it may look.
+    All three ride the stub, so a child that cannot reach the store still
+    works. Only the prose explaining them stays behind the fetch.
+
+    The two lanes are told different things about step 3, and the difference is
+    read from each lane's own answer shape: the lane that cites ``repo_id`` is
+    bounded by the roster, the one that does not measures what the host
+    exposes.
+    """
+    from ouroboros.mcp.tools.pm_batch import externalize_advisory_payloads
+    from ouroboros.orchestrator.capabilities.pm_schemas import (
+        _interview_data_evidence_answer_contract,
+        pm_code_context_answer_contract,
+        pm_repository_roster,
+    )
+    from ouroboros.persistence.artifact_store import ArtifactStore
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = ArtifactStore.for_project(workspace)
+    store.initialize()
+    roster = pm_repository_roster([str(tmp_path / "podo-backend")])
+    meta = {
+        "question_advisory_fanout_id": "fanout_stub",
+        "question_advisory_subagents": [
+            {
+                "prompt": "FULL BRIEF",
+                "context": {"lane_id": lane, "question": Q_PRIMARY, "session_id": "s"},
+            }
+            for lane in ("code_context", "data_context")
+        ],
+        "question_advisory_request": {
+            "lanes": [
+                {"lane_id": "code_context", "answer_contract": pm_code_context_answer_contract()},
+                {
+                    "lane_id": "data_context",
+                    "answer_contract": _interview_data_evidence_answer_contract(),
+                },
+            ],
+            "repository_roster": roster,
+            "recent_findings": {
+                "code_context": [{"contract_id": "fanout_earlier", "lane_id": "code_context"}]
+            },
+        },
+    }
+
+    await externalize_advisory_payloads(meta, store)
+
+    code, data = (p["prompt"] for p in meta["question_advisory_subagents"])
+    # 1 — the empty state, named from each lane's own contract.
+    assert "not_a_policy_question" in code
+    assert "not_a_measurement" in data
+    # 2 — the findings this lane may reuse, ids only.
+    assert "fanout_earlier" in code
+    assert "none published yet" in data
+    # 3 — where each may look.
+    assert roster[0]["repo_id"] in code and str(tmp_path / "podo-backend") in code
+    assert "data tools" in data and roster[0]["repo_id"] not in data
+    # The answer shape, and the plain statement only where the shape has one.
+    assert '"additionalProperties":false' in code and '"additionalProperties":false' in data
+    assert "plain_statement" in code and "plain_statement" not in data
+    # Compact: the full brief is several times this, and stays fetchable.
+    assert len(code) < 6000
+    stored = store.fetch_lane("advisory-prompts:fanout_stub", "code_context").body
+    assert stored == "FULL BRIEF"

--- a/tests/unit/mcp/tools/test_pm_handler_batch.py
+++ b/tests/unit/mcp/tools/test_pm_handler_batch.py
@@ -331,9 +331,7 @@ async def test_briefs_travel_as_references_when_a_store_is_wired(tmp_path: Path)
     state = _answered_state("pm_batch_reference", pending="Q4")
     assert (await engine.save_state(state)).is_ok
     _save_pm_meta(state.interview_id, engine, cwd=str(tmp_path), data_dir=tmp_path)
-    engine.plan_next_turns = AsyncMock(
-        return_value=Result.ok([_plan(Q_PRIMARY), _plan(Q_SECOND)])
-    )
+    engine.plan_next_turns = AsyncMock(return_value=Result.ok([_plan(Q_PRIMARY), _plan(Q_SECOND)]))
     handler = PMInterviewHandler(
         pm_engine=engine,
         data_dir=tmp_path,

--- a/tests/unit/mcp/tools/test_pm_handler_batch.py
+++ b/tests/unit/mcp/tools/test_pm_handler_batch.py
@@ -31,6 +31,7 @@ from ouroboros.bigbang.question_classifier import (
     QuestionCategory,
 )
 from ouroboros.core.types import Result
+from ouroboros.mcp.tools.pm_batch import record_turn_answers
 from ouroboros.mcp.tools.pm_handler import (
     PMInterviewHandler,
     _meta_path,
@@ -493,6 +494,70 @@ async def test_the_batch_transport_means_the_same_thing_in_plugin_mode(
         (Q_PRIMARY, "The review workflow."),
         (Q_SECOND, "Retention is 90 days."),
     ]
+
+    # Writing them down is half the turn; the child has to be handed them.
+    # A turn's answers arrive under `answers`, which leaves the singular
+    # `answer` empty — and the prompt used to decide whether there was
+    # anything to resume with by reading exactly that field. The turns
+    # carrying the most history took the branch that names none of it.
+    prompt = result.value.meta["_subagent"]["prompt"]
+    assert "## Conversation History" in prompt
+    assert "The review workflow." in prompt
+    assert "Retention is 90 days." in prompt
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sentinel", ["[decide_later]", "[deferred]"])
+async def test_a_skip_control_is_a_skip_on_every_runtime(tmp_path: Path, sentinel: str) -> None:
+    """A control token is not something the user said.
+
+    ``[decide_later]`` and ``[deferred]`` ask the server to leave a decision
+    open. Recorded literally they become the opposite: a transcript in which
+    the PM answered the question with the token's own text, and an open item
+    the generated seed never hears about. Whether that happens turned on which
+    runtime took the call.
+
+    The postcondition is equality, not a spelling: the same call recorded on
+    either runtime leaves the same round. Pinning the placeholder text instead
+    would pass a plugin path that had merely copied today's wording.
+    """
+    from ouroboros.mcp.tools.authoring_handlers import _plugin_load_state, _plugin_save_state
+
+    in_process_engine = _engine(tmp_path)
+    in_process_state = _answered_state("pm_skip_in_process")
+    assert (await in_process_engine.save_state(in_process_state)).is_ok
+    settled = await record_turn_answers(
+        in_process_engine, in_process_state, [(Q_PRIMARY, sentinel)]
+    )
+    assert settled.is_ok
+    expected = settled.value.rounds[-1].user_response
+
+    plugin_state = _answered_state("pm_skip_plugin")
+    assert (await _plugin_save_state(tmp_path, plugin_state)).is_ok
+    handler = PMInterviewHandler(
+        data_dir=tmp_path,
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    result = await handler.handle(
+        {
+            "session_id": plugin_state.interview_id,
+            "answers": [{"question": Q_PRIMARY, "answer": sentinel}],
+            "cwd": str(tmp_path),
+        }
+    )
+
+    assert result.is_ok
+    reloaded = (await _plugin_load_state(tmp_path, plugin_state.interview_id)).value
+    recorded = reloaded.rounds[-1]
+    assert recorded.question == Q_PRIMARY
+    assert recorded.user_response == expected
+    assert recorded.user_response != sentinel
+    # And the child reads the decision as open, not as an answer it may build on.
+    prompt = result.value.meta["_subagent"]["prompt"]
+    assert expected in prompt
+    assert sentinel not in prompt
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/tools/test_pm_handler_batch.py
+++ b/tests/unit/mcp/tools/test_pm_handler_batch.py
@@ -195,8 +195,7 @@ async def test_briefs_travel_as_references_when_a_store_is_wired(tmp_path: Path)
             assert "UNDISPATCHED" not in stub
             # What it cannot work without rides the stub: the answer shape, the
             # lane's own empty state, and where it may look.
-            assert f'"lane_id": "{lane_id}"' in stub
-            assert "Nothing to report is its own answer" in stub
+            assert "`question_identity` and `lane_id`" in stub
             assert "answer the empty" in stub
             # Step 3 follows the lane's own answer shape, not its name.
             assert ("data tools" in stub) == (lane_id == "data_context")
@@ -561,13 +560,12 @@ async def test_a_stub_carries_what_the_lane_cannot_work_without(tmp_path: Path) 
     # 3 — where each may look.
     assert roster[0]["repo_id"] in code and str(tmp_path / "podo-backend") in code
     assert "data tools" in data and roster[0]["repo_id"] not in data
-    # The answer shape, shown as a worked answer rather than as its schema.
-    assert '"lane_id": "code_context"' in code and '"lane_id": "data_context"' in data
-    assert "Anything the shape does not name is rejected" in code
-    # The example is not copyable into a valid answer: its identifiers are none
-    # of the ones this lane was actually given, and it says so.
-    assert "Every value above is invented" in code and "Every value above is invented" in data
-    assert roster[0]["repo_id"] not in code.split("## Answer")[1]
+    # The answer shape, named in words — no filled-in claim for a child short on
+    # evidence to adopt, and nothing in the block a copy could be made from.
+    assert "`examined`: one entry per repository" in code
+    assert "`data_needed: true`" in data
+    assert "rejected with the answer" in code and "rejected with the answer" in data
+    assert "```json" not in code.split("## Answer")[1]
     assert "plain_statement" in code and "plain_statement" not in data
     # Compact: the full brief is several times this, and stays fetchable.
     assert len(code) < 6000
@@ -575,21 +573,18 @@ async def test_a_stub_carries_what_the_lane_cannot_work_without(tmp_path: Path) 
     assert stored == "FULL BRIEF"
 
 
-def test_every_worked_example_satisfies_the_contract_it_stands_for() -> None:
-    """An example shown to a child must be an answer that would be accepted.
+def test_every_answer_spec_names_what_its_contract_requires() -> None:
+    """The prompt describes the contract in words, so the words must be complete.
 
-    The stub shows a filled-in answer instead of the contract's schema, which
-    is a quarter of the characters and says the part a regex says worst: what
-    a value looks like. The trade is that an example can be wrong in a way a
-    schema cannot, and a child copying a wrong one is rejected at submission
-    for doing exactly as it was told. So each example is validated against the
-    contract it is keyed to — and the key is the ``contract_id``, so a version
-    bump falls back to the schema rather than to an example written for the
-    shape before it.
+    No worked example: an example is a claim already written in the answer's
+    shape, and a child short on evidence would have one in front of it needing
+    only its identifiers changed. What replaces it is the field list, which can
+    go stale in the one way that matters — a contract gaining a required field
+    nothing tells the child to send. Every required name is checked against the
+    text, and the text is keyed by ``contract_id`` so a version bump falls back
+    to the schema rather than to a description of the shape before it.
     """
-    from jsonschema import Draft202012Validator
-
-    from ouroboros.mcp.tools.pm_batch import _ANSWER_EXAMPLES
+    from ouroboros.mcp.tools.pm_batch import _ANSWER_SPECS
     from ouroboros.orchestrator.capabilities.pm_schemas import (
         _interview_data_evidence_answer_contract,
         pm_code_context_answer_contract,
@@ -599,22 +594,21 @@ def test_every_worked_example_satisfies_the_contract_it_stands_for() -> None:
         c["contract_id"]: c
         for c in (pm_code_context_answer_contract(), _interview_data_evidence_answer_contract())
     }
-    # Every example stands for a contract this build declares — an example for
-    # a contract_id nothing produces is one nobody would notice going stale.
-    assert set(_ANSWER_EXAMPLES) == set(contracts)
-    for contract_id, (answer, empty, notes) in _ANSWER_EXAMPLES.items():
-        validator = Draft202012Validator(contracts[contract_id]["response_model_schema"])
-        for name, candidate in (("answer", answer), ("empty", empty)):
-            errors = sorted(validator.iter_errors(candidate), key=str)
-            assert not errors, f"{contract_id} {name}: {[e.message for e in errors]}"
-        assert notes.strip()
-        # Fictional by construction. A child that copies the example instead of
-        # reading anything must be refused, not believed: an invented claim
-        # wearing a real repo_id validates, and validating is what puts it in
-        # front of the PM. `example-repo-*` is in no roster, so the copy is
-        # rejected at submission — wrong-and-refused rather than
-        # invented-and-accepted.
-        for entry in answer.get("examined", []):
-            assert entry["repo_id"].startswith("example-")
-        assert answer["question_identity"] == "pm-question:0000000000000000"
-        assert empty["question_identity"] == "pm-question:0000000000000000"
+    assert set(_ANSWER_SPECS) == set(contracts)
+
+    def required_names(node: object) -> set[str]:
+        found: set[str] = set()
+        if isinstance(node, dict):
+            if isinstance(node.get("required"), list):
+                found |= {str(name) for name in node["required"]}
+            for value in node.values():
+                found |= required_names(value)
+        elif isinstance(node, list):
+            for item in node:
+                found |= required_names(item)
+        return found
+
+    for contract_id, spec in _ANSWER_SPECS.items():
+        schema = contracts[contract_id]["response_model_schema"]
+        missing = sorted(name for name in required_names(schema) if name not in spec)
+        assert not missing, f"{contract_id} does not tell the child about: {missing}"

--- a/tests/unit/mcp/tools/test_pm_handler_batch.py
+++ b/tests/unit/mcp/tools/test_pm_handler_batch.py
@@ -555,7 +555,6 @@ async def test_a_stub_carries_what_the_lane_cannot_work_without(tmp_path: Path) 
     # 2 — the findings this lane may reuse, ids only, offered as a shelf to
     # choose from rather than a list to work through.
     assert "fanout_earlier" in code
-    assert "rather than all of them" in code
     assert "nothing to" in data and "reuse" in data
     # 3 — where each may look.
     assert roster[0]["repo_id"] in code and str(tmp_path / "podo-backend") in code
@@ -612,3 +611,47 @@ def test_every_answer_spec_names_what_its_contract_requires() -> None:
         schema = contracts[contract_id]["response_model_schema"]
         missing = sorted(name for name in required_names(schema) if name not in spec)
         assert not missing, f"{contract_id} does not tell the child about: {missing}"
+
+
+@pytest.mark.asyncio
+async def test_a_stub_lists_a_few_findings_and_says_what_it_withheld(tmp_path: Path) -> None:
+    """The prompt is bounded separately from the offer, and says so.
+
+    An offered entry carries an id and a time. Past the first few, a child is
+    choosing between identifiers it has no way to tell apart, so listing all
+    twenty spends a fifth of the prompt on a choice it cannot make. The rest
+    are named as withheld rather than dropped — a truncation nobody mentions
+    reads as "this is all there was", which is the confusion the reuse
+    mechanism exists to prevent.
+    """
+    from ouroboros.mcp.tools.pm_batch import _STUB_FINDINGS_SHOWN, externalize_advisory_payloads
+    from ouroboros.orchestrator.capabilities.pm_schemas import pm_code_context_answer_contract
+    from ouroboros.persistence.artifact_store import ArtifactStore
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = ArtifactStore.for_project(workspace)
+    store.initialize()
+
+    offered = [
+        {"contract_id": f"fanout:{index:04d}", "lane_id": "code_context"} for index in range(20)
+    ]
+    meta = {
+        "question_advisory_fanout_id": "fanout_many",
+        "question_advisory_subagents": [
+            {"prompt": "FULL", "context": {"lane_id": "code_context", "question": Q_PRIMARY}}
+        ],
+        "question_advisory_request": {
+            "lanes": [
+                {"lane_id": "code_context", "answer_contract": pm_code_context_answer_contract()}
+            ],
+            "recent_findings": {"code_context": offered},
+        },
+    }
+
+    await externalize_advisory_payloads(meta, store)
+
+    stub = meta["question_advisory_subagents"][0]["prompt"]
+    listed = [entry["contract_id"] for entry in offered if entry["contract_id"] in stub]
+    assert listed == [entry["contract_id"] for entry in offered[:_STUB_FINDINGS_SHOWN]]
+    assert f"{20 - _STUB_FINDINGS_SHOWN} older ones from today are not listed" in stub

--- a/tests/unit/mcp/tools/test_pm_handler_batch.py
+++ b/tests/unit/mcp/tools/test_pm_handler_batch.py
@@ -585,7 +585,7 @@ def test_every_answer_spec_names_what_its_contract_requires() -> None:
     text, and the text is keyed by ``contract_id`` so a version bump falls back
     to the schema rather than to a description of the shape before it.
     """
-    from ouroboros.mcp.tools.pm_batch import _ANSWER_SPECS
+    from ouroboros.mcp.tools.pm_batch import _ANSWER_SPECS, _answer_section, _lean_schema
     from ouroboros.orchestrator.capabilities.pm_schemas import (
         _interview_data_evidence_answer_contract,
         pm_code_context_answer_contract,
@@ -609,7 +609,14 @@ def test_every_answer_spec_names_what_its_contract_requires() -> None:
                 found |= required_names(item)
         return found
 
-    for contract_id, spec in _ANSWER_SPECS.items():
-        schema = contracts[contract_id]["response_model_schema"]
-        missing = sorted(name for name in required_names(schema) if name not in spec)
+    for contract_id in _ANSWER_SPECS:
+        contract = contracts[contract_id]
+        # What the child is shown, not the template it is built from: the
+        # empty state's reasons are filled in from the schema at render time.
+        rendered = _answer_section(contract, _lean_schema(contract))
+        missing = sorted(
+            name
+            for name in required_names(contract["response_model_schema"])
+            if name not in rendered
+        )
         assert not missing, f"{contract_id} does not tell the child about: {missing}"

--- a/tests/unit/mcp/tools/test_pm_handler_batch.py
+++ b/tests/unit/mcp/tools/test_pm_handler_batch.py
@@ -554,7 +554,8 @@ async def test_a_stub_carries_what_the_lane_cannot_work_without(tmp_path: Path) 
     assert "not_a_measurement" in data
     # 2 — the findings this lane may reuse, ids only, offered as a shelf to
     # choose from rather than a list to work through.
-    assert "fanout_earlier" in code
+    assert "`lane_id: code_context` and no `contract_id`" in code
+    assert "fanout_earlier" not in code, "ids do not travel; the tool answers on request"
     assert "nothing to" in data and "reuse" in data
     # 3 — where each may look.
     assert roster[0]["repo_id"] in code and str(tmp_path / "podo-backend") in code
@@ -611,47 +612,3 @@ def test_every_answer_spec_names_what_its_contract_requires() -> None:
         schema = contracts[contract_id]["response_model_schema"]
         missing = sorted(name for name in required_names(schema) if name not in spec)
         assert not missing, f"{contract_id} does not tell the child about: {missing}"
-
-
-@pytest.mark.asyncio
-async def test_a_stub_lists_a_few_findings_and_says_what_it_withheld(tmp_path: Path) -> None:
-    """The prompt is bounded separately from the offer, and says so.
-
-    An offered entry carries an id and a time. Past the first few, a child is
-    choosing between identifiers it has no way to tell apart, so listing all
-    twenty spends a fifth of the prompt on a choice it cannot make. The rest
-    are named as withheld rather than dropped — a truncation nobody mentions
-    reads as "this is all there was", which is the confusion the reuse
-    mechanism exists to prevent.
-    """
-    from ouroboros.mcp.tools.pm_batch import _STUB_FINDINGS_SHOWN, externalize_advisory_payloads
-    from ouroboros.orchestrator.capabilities.pm_schemas import pm_code_context_answer_contract
-    from ouroboros.persistence.artifact_store import ArtifactStore
-
-    workspace = tmp_path / "workspace"
-    workspace.mkdir()
-    store = ArtifactStore.for_project(workspace)
-    store.initialize()
-
-    offered = [
-        {"contract_id": f"fanout:{index:04d}", "lane_id": "code_context"} for index in range(20)
-    ]
-    meta = {
-        "question_advisory_fanout_id": "fanout_many",
-        "question_advisory_subagents": [
-            {"prompt": "FULL", "context": {"lane_id": "code_context", "question": Q_PRIMARY}}
-        ],
-        "question_advisory_request": {
-            "lanes": [
-                {"lane_id": "code_context", "answer_contract": pm_code_context_answer_contract()}
-            ],
-            "recent_findings": {"code_context": offered},
-        },
-    }
-
-    await externalize_advisory_payloads(meta, store)
-
-    stub = meta["question_advisory_subagents"][0]["prompt"]
-    listed = [entry["contract_id"] for entry in offered if entry["contract_id"] in stub]
-    assert listed == [entry["contract_id"] for entry in offered[:_STUB_FINDINGS_SHOWN]]
-    assert f"{20 - _STUB_FINDINGS_SHOWN} older ones from today are not listed" in stub

--- a/tests/unit/mcp/tools/test_pm_handler_batch.py
+++ b/tests/unit/mcp/tools/test_pm_handler_batch.py
@@ -18,6 +18,7 @@ The decisions these hold:
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -390,3 +391,73 @@ async def test_without_a_store_the_full_briefs_stay_inline(tmp_path: Path) -> No
     for envelope in result.value.meta["question_advisories"]:
         for payload in envelope["question_advisory_subagents"]:
             assert "Answer Contract" in payload["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_two_members_answered_concurrently_both_survive(tmp_path: Path) -> None:
+    """Answers to one turn's members do not overwrite each other.
+
+    Recording an answer reads interview state and PM meta, then writes both.
+    A batched turn is the first shape where a host holds two answerable
+    questions at once, so two answers can be in flight together; unserialized,
+    the later write carries a state that never saw the earlier answer and the
+    user's words are gone while their question comes back as still pending.
+
+    ``save_state`` is made to yield here so the interleave is scheduled rather
+    than hoped for — without the per-interview lock this test loses a round.
+    """
+    engine = _engine(tmp_path)
+    state = _answered_state("pm_batch_concurrent")
+    assert (await engine.save_state(state)).is_ok
+    _save_pm_meta(
+        state.interview_id,
+        engine,
+        cwd=str(tmp_path),
+        data_dir=tmp_path,
+        extra={
+            "pending_batch": [
+                {"question": Q_PRIMARY, "classification": "passthrough", "skip_eligible": False},
+                {"question": Q_SECOND, "classification": "passthrough", "skip_eligible": False},
+                {"question": Q_THIRD, "classification": "passthrough", "skip_eligible": False},
+            ]
+        },
+    )
+    engine.plan_next_turns = AsyncMock()
+
+    inner_save = engine.save_state
+
+    async def _yielding_save(saved_state: InterviewState) -> object:
+        await asyncio.sleep(0)
+        return await inner_save(saved_state)
+
+    engine.save_state = _yielding_save  # type: ignore[method-assign]
+    handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
+
+    first, second = await asyncio.gather(
+        handler.handle(
+            {
+                "session_id": state.interview_id,
+                "answer": "The review workflow.",
+                "last_question": Q_PRIMARY,
+                "cwd": str(tmp_path),
+            }
+        ),
+        handler.handle(
+            {
+                "session_id": state.interview_id,
+                "answer": "Retention is 90 days.",
+                "last_question": Q_SECOND,
+                "cwd": str(tmp_path),
+            }
+        ),
+    )
+
+    assert first.is_ok and second.is_ok
+    reloaded = (await engine.load_state(state.interview_id)).value
+    answered = {r.question: r.user_response for r in reloaded.rounds}
+    assert answered[Q_PRIMARY] == "The review workflow."
+    assert answered[Q_SECOND] == "Retention is 90 days."
+    # Only the untouched member is still pending.
+    saved = _load_meta(state.interview_id, tmp_path)
+    assert [entry["question"] for entry in saved["pending_batch"]] == [Q_THIRD]
+    engine.plan_next_turns.assert_not_called()

--- a/tests/unit/mcp/tools/test_pm_handler_batch.py
+++ b/tests/unit/mcp/tools/test_pm_handler_batch.py
@@ -564,6 +564,10 @@ async def test_a_stub_carries_what_the_lane_cannot_work_without(tmp_path: Path) 
     # The answer shape, shown as a worked answer rather than as its schema.
     assert '"lane_id": "code_context"' in code and '"lane_id": "data_context"' in data
     assert "Anything the shape does not name is rejected" in code
+    # The example is not copyable into a valid answer: its identifiers are none
+    # of the ones this lane was actually given, and it says so.
+    assert "Every value above is invented" in code and "Every value above is invented" in data
+    assert roster[0]["repo_id"] not in code.split("## Answer")[1]
     assert "plain_statement" in code and "plain_statement" not in data
     # Compact: the full brief is several times this, and stays fetchable.
     assert len(code) < 6000
@@ -604,3 +608,13 @@ def test_every_worked_example_satisfies_the_contract_it_stands_for() -> None:
             errors = sorted(validator.iter_errors(candidate), key=str)
             assert not errors, f"{contract_id} {name}: {[e.message for e in errors]}"
         assert notes.strip()
+        # Fictional by construction. A child that copies the example instead of
+        # reading anything must be refused, not believed: an invented claim
+        # wearing a real repo_id validates, and validating is what puts it in
+        # front of the PM. `example-repo-*` is in no roster, so the copy is
+        # rejected at submission — wrong-and-refused rather than
+        # invented-and-accepted.
+        for entry in answer.get("examined", []):
+            assert entry["repo_id"].startswith("example-")
+        assert answer["question_identity"] == "pm-question:0000000000000000"
+        assert empty["question_identity"] == "pm-question:0000000000000000"

--- a/tests/unit/mcp/tools/test_pm_handler_batch.py
+++ b/tests/unit/mcp/tools/test_pm_handler_batch.py
@@ -195,7 +195,8 @@ async def test_briefs_travel_as_references_when_a_store_is_wired(tmp_path: Path)
             assert "UNDISPATCHED" not in stub
             # What it cannot work without rides the stub: the answer shape, the
             # lane's own empty state, and where it may look.
-            assert f'"lane_id":{{"const":"{lane_id}"}}' in stub
+            assert f'"lane_id": "{lane_id}"' in stub
+            assert "Nothing to report is its own answer" in stub
             assert "answer the empty" in stub
             # Step 3 follows the lane's own answer shape, not its name.
             assert ("data tools" in stub) == (lane_id == "data_context")
@@ -560,10 +561,46 @@ async def test_a_stub_carries_what_the_lane_cannot_work_without(tmp_path: Path) 
     # 3 — where each may look.
     assert roster[0]["repo_id"] in code and str(tmp_path / "podo-backend") in code
     assert "data tools" in data and roster[0]["repo_id"] not in data
-    # The answer shape, and the plain statement only where the shape has one.
-    assert '"additionalProperties":false' in code and '"additionalProperties":false' in data
+    # The answer shape, shown as a worked answer rather than as its schema.
+    assert '"lane_id": "code_context"' in code and '"lane_id": "data_context"' in data
+    assert "Anything the shape does not name is rejected" in code
     assert "plain_statement" in code and "plain_statement" not in data
     # Compact: the full brief is several times this, and stays fetchable.
     assert len(code) < 6000
     stored = store.fetch_lane("advisory-prompts:fanout_stub", "code_context").body
     assert stored == "FULL BRIEF"
+
+
+def test_every_worked_example_satisfies_the_contract_it_stands_for() -> None:
+    """An example shown to a child must be an answer that would be accepted.
+
+    The stub shows a filled-in answer instead of the contract's schema, which
+    is a quarter of the characters and says the part a regex says worst: what
+    a value looks like. The trade is that an example can be wrong in a way a
+    schema cannot, and a child copying a wrong one is rejected at submission
+    for doing exactly as it was told. So each example is validated against the
+    contract it is keyed to — and the key is the ``contract_id``, so a version
+    bump falls back to the schema rather than to an example written for the
+    shape before it.
+    """
+    from jsonschema import Draft202012Validator
+
+    from ouroboros.mcp.tools.pm_batch import _ANSWER_EXAMPLES
+    from ouroboros.orchestrator.capabilities.pm_schemas import (
+        _interview_data_evidence_answer_contract,
+        pm_code_context_answer_contract,
+    )
+
+    contracts = {
+        c["contract_id"]: c
+        for c in (pm_code_context_answer_contract(), _interview_data_evidence_answer_contract())
+    }
+    # Every example stands for a contract this build declares — an example for
+    # a contract_id nothing produces is one nobody would notice going stale.
+    assert set(_ANSWER_EXAMPLES) == set(contracts)
+    for contract_id, (answer, empty, notes) in _ANSWER_EXAMPLES.items():
+        validator = Draft202012Validator(contracts[contract_id]["response_model_schema"])
+        for name, candidate in (("answer", answer), ("empty", empty)):
+            errors = sorted(validator.iter_errors(candidate), key=str)
+            assert not errors, f"{contract_id} {name}: {[e.message for e in errors]}"
+        assert notes.strip()

--- a/tests/unit/mcp/tools/test_pm_handler_batch.py
+++ b/tests/unit/mcp/tools/test_pm_handler_batch.py
@@ -461,3 +461,191 @@ async def test_two_members_answered_concurrently_both_survive(tmp_path: Path) ->
     saved = _load_meta(state.interview_id, tmp_path)
     assert [entry["question"] for entry in saved["pending_batch"]] == [Q_THIRD]
     engine.plan_next_turns.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_an_answerless_resume_is_serialized_because_it_also_writes(
+    tmp_path: Path,
+) -> None:
+    """A resume without an answer is not a read, so it is not exempt.
+
+    It looks like one — it re-displays what is pending — but with no pending
+    batch and no unanswered round it plans the next turn and persists it. Two
+    of them concurrently are two answers concurrently under another name, so
+    the round one of them appends must survive the other.
+    """
+    engine = _engine(tmp_path)
+    state = _answered_state("pm_batch_answerless")
+    assert (await engine.save_state(state)).is_ok
+    _save_pm_meta(state.interview_id, engine, cwd=str(tmp_path), data_dir=tmp_path)
+
+    planned = ["First planned question?", "Second planned question?"]
+
+    async def _plan_in_turn(_state: InterviewState) -> object:
+        await asyncio.sleep(0)
+        return Result.ok([_plan(planned.pop(0))])
+
+    engine.plan_next_turns = _plan_in_turn  # type: ignore[method-assign]
+    inner_save = engine.save_state
+
+    async def _yielding_save(saved_state: InterviewState) -> object:
+        await asyncio.sleep(0)
+        return await inner_save(saved_state)
+
+    engine.save_state = _yielding_save  # type: ignore[method-assign]
+    handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
+
+    first, second = await asyncio.gather(
+        handler.handle({"session_id": state.interview_id, "cwd": str(tmp_path)}),
+        handler.handle({"session_id": state.interview_id, "cwd": str(tmp_path)}),
+    )
+
+    assert first.is_ok and second.is_ok
+    # Serialized, the second call finds the first one's question already
+    # pending and re-displays it. Concurrent, both would plan and the later
+    # save would drop the earlier round.
+    assert first.value.meta["question"] == "First planned question?"
+    assert second.value.meta["question"] == "First planned question?"
+    assert planned == ["Second planned question?"], "the retry planned a second turn"
+    reloaded = (await engine.load_state(state.interview_id)).value
+    assert [r.question for r in reloaded.rounds][-1] == "First planned question?"
+    assert len(reloaded.rounds) == 4
+
+
+@pytest.mark.asyncio
+async def test_plugin_mode_never_enters_the_batch_contract(tmp_path: Path) -> None:
+    """The plugin runtime has no batch to persist, so it persists none.
+
+    Batching rides the in-process planner (RFC #2222, "Deliberately not decided
+    here"). This pins the property that keeps that true: the runtime that
+    dispatches to a child session neither plans a batch nor writes pending
+    members, so there is no batch state for its answer path to bypass.
+    """
+    engine = _engine(tmp_path)
+    state = _answered_state("pm_batch_plugin", pending=Q_PRIMARY)
+    assert (await engine.save_state(state)).is_ok
+    _save_pm_meta(state.interview_id, engine, cwd=str(tmp_path), data_dir=tmp_path)
+    engine.plan_next_turns = AsyncMock()
+    handler = PMInterviewHandler(
+        pm_engine=engine,
+        data_dir=tmp_path,
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    result = await handler.handle(
+        {
+            "session_id": state.interview_id,
+            "answer": "The review workflow.",
+            "last_question": Q_PRIMARY,
+            "cwd": str(tmp_path),
+        }
+    )
+
+    assert result.is_ok
+    engine.plan_next_turns.assert_not_called()
+    assert "pending_batch" not in _load_meta(state.interview_id, tmp_path)
+    assert "question_batch" not in (result.value.meta or {})
+
+
+@pytest.mark.asyncio
+async def test_a_retry_after_an_interrupted_meta_write_repairs_it(tmp_path: Path) -> None:
+    """The decision is recorded once, and the retry heals the pending list.
+
+    Two files carry one turn and the state is written first, so a meta write
+    that fails leaves a member marked pending whose answer is already durable.
+    The host sees the error and retries the same answer. Recording it again
+    would put two rounds under one question — the transcript would say the PM
+    answered twice, and the seed would read both.
+    """
+    engine = _engine(tmp_path)
+    state = _answered_state("pm_batch_replay")
+    # What the interrupted call left behind: the answer committed to state...
+    state.rounds.append(
+        InterviewRound(
+            round_number=4,
+            question=Q_PRIMARY,
+            user_response="The review workflow.",
+        )
+    )
+    assert (await engine.save_state(state)).is_ok
+    # ...while the metadata still marks that member pending.
+    _save_pm_meta(
+        state.interview_id,
+        engine,
+        cwd=str(tmp_path),
+        data_dir=tmp_path,
+        extra={
+            "pending_batch": [
+                {"question": Q_PRIMARY, "classification": "passthrough", "skip_eligible": False},
+                {"question": Q_SECOND, "classification": "passthrough", "skip_eligible": False},
+            ]
+        },
+    )
+    engine.plan_next_turns = AsyncMock()
+    handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
+
+    result = await handler.handle(
+        {
+            "session_id": state.interview_id,
+            "answer": "The review workflow.",
+            "last_question": Q_PRIMARY,
+            "cwd": str(tmp_path),
+        }
+    )
+
+    assert result.is_ok
+    reloaded = (await engine.load_state(state.interview_id)).value
+    assert [r.question for r in reloaded.rounds].count(Q_PRIMARY) == 1
+    assert len(reloaded.rounds) == 4
+    # The metadata is repaired: only the genuinely unanswered member is left.
+    saved = _load_meta(state.interview_id, tmp_path)
+    assert [entry["question"] for entry in saved["pending_batch"]] == [Q_SECOND]
+    engine.plan_next_turns.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_a_different_answer_to_a_repeated_question_is_still_recorded(
+    tmp_path: Path,
+) -> None:
+    """The replay guard must not swallow a decision the user has not made yet.
+
+    It fires on the same answer or on a sentinel, which carries no words of
+    the user's. A question whose text repeats but whose answer differs is a new
+    decision and is recorded as one.
+    """
+    engine = _engine(tmp_path)
+    state = _answered_state("pm_batch_repeat")
+    state.rounds.append(
+        InterviewRound(round_number=4, question=Q_PRIMARY, user_response="An older decision.")
+    )
+    assert (await engine.save_state(state)).is_ok
+    _save_pm_meta(
+        state.interview_id,
+        engine,
+        cwd=str(tmp_path),
+        data_dir=tmp_path,
+        extra={
+            "pending_batch": [
+                {"question": Q_PRIMARY, "classification": "passthrough", "skip_eligible": False},
+                {"question": Q_SECOND, "classification": "passthrough", "skip_eligible": False},
+            ]
+        },
+    )
+    engine.plan_next_turns = AsyncMock()
+    handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
+
+    result = await handler.handle(
+        {
+            "session_id": state.interview_id,
+            "answer": "The review workflow, actually.",
+            "last_question": Q_PRIMARY,
+            "cwd": str(tmp_path),
+        }
+    )
+
+    assert result.is_ok
+    reloaded = (await engine.load_state(state.interview_id)).value
+    assert reloaded.rounds[-1].question == Q_PRIMARY
+    assert reloaded.rounds[-1].user_response == "The review workflow, actually."
+    assert len(reloaded.rounds) == 5

--- a/tests/unit/mcp/tools/test_pm_handler_batch.py
+++ b/tests/unit/mcp/tools/test_pm_handler_batch.py
@@ -1,19 +1,18 @@
-"""Batched PM turns (RFC #2222): issue, partial answering, per-member routing.
+"""Batched PM turns (RFC #2222 revision 4): asked whole, answered whole.
 
 The decisions these hold:
 
-* A batched turn leaves **no** question-only rounds in core interview state —
-  the engine fills the trailing unanswered round on record, so a second
-  pending round is a question waiting to be silently overwritten. Batch
-  pending state lives in PM meta, and every member is recorded question and
-  answer together.
-* Every question shown keeps its evidence: one advisory envelope per batch
-  member, none shared, none skipped.
-* An unanswered member stays pending. Answering one member returns the rest;
-  only the answer that resolves the batch reaches completion checking and
-  next-turn generation.
-* Skip sentinels are guarded by the member's own classification, not by
-  whichever question was classified last.
+* **A turn persists nothing when it asks.** No question-only round, no pending
+  member list. The transcript holds finished rounds only, so there is no second
+  place a turn is remembered and nothing to reconcile after an interruption.
+* **A turn's answers arrive together**, each holding its own question. Answer
+  and question are never matched against remembered state, so a question whose
+  text recurs later is just another question.
+* **An answer without its question is refused.** Nothing is remembered to file
+  it under, and the round behind it is one somebody already answered.
+* **A call with no answers plans a fresh turn** rather than restoring one.
+* Every question shown keeps its evidence: one advisory envelope per question,
+  none shared, none skipped.
 """
 
 from __future__ import annotations
@@ -95,7 +94,7 @@ async def test_a_batched_turn_issues_every_question_with_its_own_evidence(
     tmp_path: Path,
 ) -> None:
     engine = _engine(tmp_path)
-    state = _answered_state("pm_batch_issue", pending="Q4")
+    state = _answered_state("pm_batch_issue")
     assert (await engine.save_state(state)).is_ok
     _save_pm_meta(state.interview_id, engine, cwd=str(tmp_path), data_dir=tmp_path)
     engine.plan_next_turns = AsyncMock(
@@ -104,7 +103,12 @@ async def test_a_batched_turn_issues_every_question_with_its_own_evidence(
     handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
 
     result = await handler.handle(
-        {"session_id": state.interview_id, "answer": "A4", "cwd": str(tmp_path)}
+        {
+            "session_id": state.interview_id,
+            "answer": "A4",
+            "last_question": "Q4",
+            "cwd": str(tmp_path),
+        }
     )
 
     assert result.is_ok
@@ -127,186 +131,14 @@ async def test_a_batched_turn_issues_every_question_with_its_own_evidence(
     for question in (Q_PRIMARY, Q_SECOND, Q_THIRD):
         assert question in text
 
-    # Core state holds no question-only rounds for the batch: the answer
-    # filled Q4, and nothing pending was appended behind it.
+    # Asking persists nothing. The transcript holds finished rounds only, and
+    # this turn's questions live on the wire — the second place they used to be
+    # remembered is what every replay and ordering defect lived in.
     reloaded = (await engine.load_state(state.interview_id)).value
     assert all(r.user_response is not None for r in reloaded.rounds)
-
-    # Batch pending state is persisted in PM meta, with per-member routing.
-    saved = _load_meta(state.interview_id, tmp_path)
-    assert [entry["question"] for entry in saved["pending_batch"]] == [
-        Q_PRIMARY,
-        Q_SECOND,
-        Q_THIRD,
-    ]
-
-
-@pytest.mark.asyncio
-async def test_answering_one_member_returns_the_rest_without_generating(
-    tmp_path: Path,
-) -> None:
-    engine = _engine(tmp_path)
-    state = _answered_state("pm_batch_partial")
-    assert (await engine.save_state(state)).is_ok
-    _save_pm_meta(
-        state.interview_id,
-        engine,
-        cwd=str(tmp_path),
-        data_dir=tmp_path,
-        extra={
-            "pending_batch": [
-                {"question": Q_PRIMARY, "classification": "passthrough", "skip_eligible": False},
-                {"question": Q_SECOND, "classification": "passthrough", "skip_eligible": False},
-            ]
-        },
-    )
-    engine.plan_next_turns = AsyncMock()
-    handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
-
-    result = await handler.handle(
-        {
-            "session_id": state.interview_id,
-            "answer": "Retention is 90 days.",
-            "last_question": Q_SECOND,
-            "cwd": str(tmp_path),
-        }
-    )
-
-    assert result.is_ok
-    meta = result.value.meta
-    assert [entry["question"] for entry in meta["question_batch"]] == [Q_PRIMARY]
-    assert meta["is_complete"] is False
-    engine.plan_next_turns.assert_not_called()
-
-    # The answered member is a full question-and-answer round; the pending
-    # member is nowhere in core state.
-    reloaded = (await engine.load_state(state.interview_id)).value
-    assert reloaded.rounds[-1].question == Q_SECOND
-    assert reloaded.rounds[-1].user_response == "Retention is 90 days."
-    assert all(r.user_response is not None for r in reloaded.rounds)
-    saved = _load_meta(state.interview_id, tmp_path)
-    assert [entry["question"] for entry in saved["pending_batch"]] == [Q_PRIMARY]
-
-
-@pytest.mark.asyncio
-async def test_resolving_the_batch_reaches_generation_and_clears_pending(
-    tmp_path: Path,
-) -> None:
-    engine = _engine(tmp_path)
-    state = _answered_state("pm_batch_resolve")
-    assert (await engine.save_state(state)).is_ok
-    _save_pm_meta(
-        state.interview_id,
-        engine,
-        cwd=str(tmp_path),
-        data_dir=tmp_path,
-        extra={
-            "pending_batch": [
-                {"question": Q_PRIMARY, "classification": "passthrough", "skip_eligible": False},
-            ]
-        },
-    )
-    engine.plan_next_turns = AsyncMock(return_value=Result.ok([_plan("Next single question?")]))
-    handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
-
-    result = await handler.handle(
-        {
-            "session_id": state.interview_id,
-            "answer": "The review workflow.",
-            "last_question": Q_PRIMARY,
-            "cwd": str(tmp_path),
-        }
-    )
-
-    assert result.is_ok
-    engine.plan_next_turns.assert_awaited_once()
-    assert result.value.meta["question"] == "Next single question?"
-    assert "question_batch" not in result.value.meta
+    assert not any(r.question in (Q_PRIMARY, Q_SECOND, Q_THIRD) for r in reloaded.rounds)
     saved = _load_meta(state.interview_id, tmp_path)
     assert "pending_batch" not in saved
-
-
-@pytest.mark.asyncio
-async def test_batch_answer_without_last_question_is_refused_while_ambiguous(
-    tmp_path: Path,
-) -> None:
-    engine = _engine(tmp_path)
-    state = _answered_state("pm_batch_ambiguous")
-    assert (await engine.save_state(state)).is_ok
-    _save_pm_meta(
-        state.interview_id,
-        engine,
-        cwd=str(tmp_path),
-        data_dir=tmp_path,
-        extra={
-            "pending_batch": [
-                {"question": Q_PRIMARY, "classification": "passthrough", "skip_eligible": False},
-                {"question": Q_SECOND, "classification": "passthrough", "skip_eligible": False},
-            ]
-        },
-    )
-    handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
-
-    result = await handler.handle(
-        {"session_id": state.interview_id, "answer": "ambiguous", "cwd": str(tmp_path)}
-    )
-
-    assert result.is_err
-    assert "last_question" in str(result.error)
-    # Nothing was recorded against either pending member.
-    reloaded = (await engine.load_state(state.interview_id)).value
-    assert len(reloaded.rounds) == 3
-
-
-@pytest.mark.asyncio
-async def test_skip_sentinel_is_guarded_by_the_members_own_classification(
-    tmp_path: Path,
-) -> None:
-    engine = _engine(tmp_path)
-    state = _answered_state("pm_batch_sentinel")
-    assert (await engine.save_state(state)).is_ok
-    _save_pm_meta(
-        state.interview_id,
-        engine,
-        cwd=str(tmp_path),
-        data_dir=tmp_path,
-        extra={
-            "pending_batch": [
-                {"question": Q_PRIMARY, "classification": "passthrough", "skip_eligible": False},
-                {"question": Q_THIRD, "classification": "decide_later", "skip_eligible": True},
-            ]
-        },
-    )
-    engine.plan_next_turns = AsyncMock()
-    handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
-
-    # The decide-later member honours the sentinel...
-    result = await handler.handle(
-        {
-            "session_id": state.interview_id,
-            "answer": "[decide_later]",
-            "last_question": Q_THIRD,
-            "cwd": str(tmp_path),
-        }
-    )
-    assert result.is_ok
-    assert Q_THIRD in engine.decide_later_items
-
-    # ...while the passthrough member records the same sentinel as a plain
-    # answer rather than silently discarding it.
-    result = await handler.handle(
-        {
-            "session_id": state.interview_id,
-            "answer": "[decide_later]",
-            "last_question": Q_PRIMARY,
-            "cwd": str(tmp_path),
-        }
-    )
-    assert result.is_ok
-    reloaded = (await engine.load_state(state.interview_id)).value
-    primary_round = next(r for r in reloaded.rounds if r.question == Q_PRIMARY)
-    assert primary_round.user_response == "[decide_later]"
-    assert Q_PRIMARY not in engine.decide_later_items
 
 
 @pytest.mark.asyncio
@@ -341,7 +173,12 @@ async def test_briefs_travel_as_references_when_a_store_is_wired(tmp_path: Path)
     )
 
     result = await handler.handle(
-        {"session_id": state.interview_id, "answer": "A4", "cwd": str(tmp_path)}
+        {
+            "session_id": state.interview_id,
+            "answer": "A4",
+            "last_question": "Q4",
+            "cwd": str(tmp_path),
+        }
     )
 
     assert result.is_ok
@@ -373,7 +210,7 @@ async def test_without_a_store_the_full_briefs_stay_inline(tmp_path: Path) -> No
 
     registry = FanoutRegistry(tmp_path / "fanout")
     engine = _engine(tmp_path)
-    state = _answered_state("pm_batch_inline", pending="Q4")
+    state = _answered_state("pm_batch_inline")
     assert (await engine.save_state(state)).is_ok
     _save_pm_meta(state.interview_id, engine, cwd=str(tmp_path), data_dir=tmp_path)
     engine.plan_next_turns = AsyncMock(return_value=Result.ok([_plan(Q_PRIMARY), _plan(Q_SECOND)]))
@@ -384,7 +221,12 @@ async def test_without_a_store_the_full_briefs_stay_inline(tmp_path: Path) -> No
     )
 
     result = await handler.handle(
-        {"session_id": state.interview_id, "answer": "A4", "cwd": str(tmp_path)}
+        {
+            "session_id": state.interview_id,
+            "answer": "A4",
+            "last_question": "Q4",
+            "cwd": str(tmp_path),
+        }
     )
 
     assert result.is_ok
@@ -394,35 +236,20 @@ async def test_without_a_store_the_full_briefs_stay_inline(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
-async def test_two_members_answered_concurrently_both_survive(tmp_path: Path) -> None:
-    """Answers to one turn's members do not overwrite each other.
+async def test_two_turns_answered_concurrently_both_survive(tmp_path: Path) -> None:
+    """Two calls for one interview do not overwrite each other's rounds.
 
-    Recording an answer reads interview state and PM meta, then writes both.
-    A batched turn is the first shape where a host holds two answerable
-    questions at once, so two answers can be in flight together; unserialized,
-    the later write carries a state that never saw the earlier answer and the
-    user's words are gone while their question comes back as still pending.
-
-    ``save_state`` is made to yield here so the interleave is scheduled rather
-    than hoped for — without the per-interview lock this test loses a round.
+    A turn is one write now, but two of them can still be in flight: a host
+    that retried, or two sessions on one interview. Unserialized, the later
+    write carries a state that never saw the earlier one and those answers are
+    gone. ``save_state`` is made to yield so the interleave is scheduled rather
+    than hoped for — without the per-interview lock this test loses a turn.
     """
     engine = _engine(tmp_path)
     state = _answered_state("pm_batch_concurrent")
     assert (await engine.save_state(state)).is_ok
-    _save_pm_meta(
-        state.interview_id,
-        engine,
-        cwd=str(tmp_path),
-        data_dir=tmp_path,
-        extra={
-            "pending_batch": [
-                {"question": Q_PRIMARY, "classification": "passthrough", "skip_eligible": False},
-                {"question": Q_SECOND, "classification": "passthrough", "skip_eligible": False},
-                {"question": Q_THIRD, "classification": "passthrough", "skip_eligible": False},
-            ]
-        },
-    )
-    engine.plan_next_turns = AsyncMock()
+    _save_pm_meta(state.interview_id, engine, cwd=str(tmp_path), data_dir=tmp_path)
+    engine.plan_next_turns = AsyncMock(return_value=Result.ok([_plan("Next question?")]))
 
     inner_save = engine.save_state
 
@@ -437,16 +264,14 @@ async def test_two_members_answered_concurrently_both_survive(tmp_path: Path) ->
         handler.handle(
             {
                 "session_id": state.interview_id,
-                "answer": "The review workflow.",
-                "last_question": Q_PRIMARY,
+                "answers": [{"question": Q_PRIMARY, "answer": "The review workflow."}],
                 "cwd": str(tmp_path),
             }
         ),
         handler.handle(
             {
                 "session_id": state.interview_id,
-                "answer": "Retention is 90 days.",
-                "last_question": Q_SECOND,
+                "answers": [{"question": Q_SECOND, "answer": "Retention is 90 days."}],
                 "cwd": str(tmp_path),
             }
         ),
@@ -457,59 +282,129 @@ async def test_two_members_answered_concurrently_both_survive(tmp_path: Path) ->
     answered = {r.question: r.user_response for r in reloaded.rounds}
     assert answered[Q_PRIMARY] == "The review workflow."
     assert answered[Q_SECOND] == "Retention is 90 days."
-    # Only the untouched member is still pending.
-    saved = _load_meta(state.interview_id, tmp_path)
-    assert [entry["question"] for entry in saved["pending_batch"]] == [Q_THIRD]
-    engine.plan_next_turns.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_an_answerless_resume_is_serialized_because_it_also_writes(
-    tmp_path: Path,
-) -> None:
-    """A resume without an answer is not a read, so it is not exempt.
+async def test_a_turn_is_recorded_whole(tmp_path: Path) -> None:
+    """Three questions asked, three answers back in one call, three rounds.
 
-    It looks like one — it re-displays what is pending — but with no pending
-    batch and no unanswered round it plans the next turn and persists it. Two
-    of them concurrently are two answers concurrently under another name, so
-    the round one of them appends must survive the other.
+    This is the shape that removed the pending list: a turn arrives complete,
+    so there is no interval in which some of it is recorded and the rest is
+    remembered somewhere else.
     """
     engine = _engine(tmp_path)
-    state = _answered_state("pm_batch_answerless")
+    state = _answered_state("pm_batch_whole")
     assert (await engine.save_state(state)).is_ok
     _save_pm_meta(state.interview_id, engine, cwd=str(tmp_path), data_dir=tmp_path)
-
-    planned = ["First planned question?", "Second planned question?"]
-
-    async def _plan_in_turn(_state: InterviewState) -> object:
-        await asyncio.sleep(0)
-        return Result.ok([_plan(planned.pop(0))])
-
-    engine.plan_next_turns = _plan_in_turn  # type: ignore[method-assign]
-    inner_save = engine.save_state
-
-    async def _yielding_save(saved_state: InterviewState) -> object:
-        await asyncio.sleep(0)
-        return await inner_save(saved_state)
-
-    engine.save_state = _yielding_save  # type: ignore[method-assign]
+    engine.plan_next_turns = AsyncMock(return_value=Result.ok([_plan("Next question?")]))
     handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
 
-    first, second = await asyncio.gather(
-        handler.handle({"session_id": state.interview_id, "cwd": str(tmp_path)}),
-        handler.handle({"session_id": state.interview_id, "cwd": str(tmp_path)}),
+    result = await handler.handle(
+        {
+            "session_id": state.interview_id,
+            "answers": [
+                {"question": Q_PRIMARY, "answer": "The review workflow."},
+                {"question": Q_SECOND, "answer": "Retention is 90 days."},
+                {"question": Q_THIRD, "answer": "[decide_later]"},
+            ],
+            "cwd": str(tmp_path),
+        }
     )
 
-    assert first.is_ok and second.is_ok
-    # Serialized, the second call finds the first one's question already
-    # pending and re-displays it. Concurrent, both would plan and the later
-    # save would drop the earlier round.
-    assert first.value.meta["question"] == "First planned question?"
-    assert second.value.meta["question"] == "First planned question?"
-    assert planned == ["Second planned question?"], "the retry planned a second turn"
+    assert result.is_ok
     reloaded = (await engine.load_state(state.interview_id)).value
-    assert [r.question for r in reloaded.rounds][-1] == "First planned question?"
-    assert len(reloaded.rounds) == 4
+    recorded = [(r.question, r.user_response) for r in reloaded.rounds[3:]]
+    assert [q for q, _ in recorded] == [Q_PRIMARY, Q_SECOND, Q_THIRD]
+    assert recorded[0][1] == "The review workflow."
+    assert all(r.user_response is not None for r in reloaded.rounds)
+    # The turn resolved, so the next one was planned.
+    engine.plan_next_turns.assert_awaited_once()
+    assert "pending_batch" not in _load_meta(state.interview_id, tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_an_answer_without_its_question_is_refused(tmp_path: Path) -> None:
+    """Nothing is remembered to file it under, so nothing is guessed.
+
+    The round behind an unnamed answer is one somebody already answered;
+    binding a second answer to it would overwrite a decision that was made.
+    """
+    engine = _engine(tmp_path)
+    state = _answered_state("pm_batch_unnamed")
+    assert (await engine.save_state(state)).is_ok
+    _save_pm_meta(state.interview_id, engine, cwd=str(tmp_path), data_dir=tmp_path)
+    engine.plan_next_turns = AsyncMock()
+    handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
+
+    result = await handler.handle(
+        {"session_id": state.interview_id, "answer": "A decision.", "cwd": str(tmp_path)}
+    )
+
+    assert result.is_err
+    assert "last_question" in str(result.error)
+    reloaded = (await engine.load_state(state.interview_id)).value
+    assert len(reloaded.rounds) == 3
+
+
+@pytest.mark.asyncio
+async def test_a_question_whose_text_recurs_is_just_another_round(tmp_path: Path) -> None:
+    """No answer is suppressed for resembling an older one.
+
+    The guard that did that existed to make an interrupted retry idempotent
+    across two files. With one write there is no interruption to repair, and a
+    PM who is asked something again and answers it again has made a decision
+    that belongs in the transcript.
+    """
+    engine = _engine(tmp_path)
+    state = _answered_state("pm_batch_recurs")
+    state.rounds.append(
+        InterviewRound(round_number=4, question=Q_PRIMARY, user_response="The review workflow.")
+    )
+    assert (await engine.save_state(state)).is_ok
+    _save_pm_meta(state.interview_id, engine, cwd=str(tmp_path), data_dir=tmp_path)
+    engine.plan_next_turns = AsyncMock(return_value=Result.ok([_plan("Next question?")]))
+    handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
+
+    result = await handler.handle(
+        {
+            "session_id": state.interview_id,
+            "answers": [{"question": Q_PRIMARY, "answer": "The review workflow."}],
+            "cwd": str(tmp_path),
+        }
+    )
+
+    assert result.is_ok
+    reloaded = (await engine.load_state(state.interview_id)).value
+    assert [r.question for r in reloaded.rounds].count(Q_PRIMARY) == 2
+    assert len(reloaded.rounds) == 5
+
+
+@pytest.mark.asyncio
+async def test_a_reconnect_plans_a_fresh_turn_and_leaves_nothing_half_written(
+    tmp_path: Path,
+) -> None:
+    """A host that lost its turn gets a new one, not the old one restored.
+
+    Restoring it would need the turn to have been remembered somewhere, which
+    is the second place revision 4 removed. Planning again costs one question
+    and leaves the transcript what it always is: finished rounds.
+    """
+    engine = _engine(tmp_path)
+    state = _answered_state("pm_batch_reconnect")
+    assert (await engine.save_state(state)).is_ok
+    _save_pm_meta(state.interview_id, engine, cwd=str(tmp_path), data_dir=tmp_path)
+    engine.plan_next_turns = AsyncMock(
+        return_value=Result.ok([_plan("A freshly planned question?")])
+    )
+    handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
+
+    result = await handler.handle({"session_id": state.interview_id, "cwd": str(tmp_path)})
+
+    assert result.is_ok
+    assert result.value.meta["question"] == "A freshly planned question?"
+    reloaded = (await engine.load_state(state.interview_id)).value
+    assert len(reloaded.rounds) == 3
+    assert all(r.user_response is not None for r in reloaded.rounds)
 
 
 @pytest.mark.asyncio
@@ -546,106 +441,3 @@ async def test_plugin_mode_never_enters_the_batch_contract(tmp_path: Path) -> No
     engine.plan_next_turns.assert_not_called()
     assert "pending_batch" not in _load_meta(state.interview_id, tmp_path)
     assert "question_batch" not in (result.value.meta or {})
-
-
-@pytest.mark.asyncio
-async def test_a_retry_after_an_interrupted_meta_write_repairs_it(tmp_path: Path) -> None:
-    """The decision is recorded once, and the retry heals the pending list.
-
-    Two files carry one turn and the state is written first, so a meta write
-    that fails leaves a member marked pending whose answer is already durable.
-    The host sees the error and retries the same answer. Recording it again
-    would put two rounds under one question — the transcript would say the PM
-    answered twice, and the seed would read both.
-    """
-    engine = _engine(tmp_path)
-    state = _answered_state("pm_batch_replay")
-    # What the interrupted call left behind: the answer committed to state...
-    state.rounds.append(
-        InterviewRound(
-            round_number=4,
-            question=Q_PRIMARY,
-            user_response="The review workflow.",
-        )
-    )
-    assert (await engine.save_state(state)).is_ok
-    # ...while the metadata still marks that member pending.
-    _save_pm_meta(
-        state.interview_id,
-        engine,
-        cwd=str(tmp_path),
-        data_dir=tmp_path,
-        extra={
-            "pending_batch": [
-                {"question": Q_PRIMARY, "classification": "passthrough", "skip_eligible": False},
-                {"question": Q_SECOND, "classification": "passthrough", "skip_eligible": False},
-            ]
-        },
-    )
-    engine.plan_next_turns = AsyncMock()
-    handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
-
-    result = await handler.handle(
-        {
-            "session_id": state.interview_id,
-            "answer": "The review workflow.",
-            "last_question": Q_PRIMARY,
-            "cwd": str(tmp_path),
-        }
-    )
-
-    assert result.is_ok
-    reloaded = (await engine.load_state(state.interview_id)).value
-    assert [r.question for r in reloaded.rounds].count(Q_PRIMARY) == 1
-    assert len(reloaded.rounds) == 4
-    # The metadata is repaired: only the genuinely unanswered member is left.
-    saved = _load_meta(state.interview_id, tmp_path)
-    assert [entry["question"] for entry in saved["pending_batch"]] == [Q_SECOND]
-    engine.plan_next_turns.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_a_different_answer_to_a_repeated_question_is_still_recorded(
-    tmp_path: Path,
-) -> None:
-    """The replay guard must not swallow a decision the user has not made yet.
-
-    It fires on the same answer or on a sentinel, which carries no words of
-    the user's. A question whose text repeats but whose answer differs is a new
-    decision and is recorded as one.
-    """
-    engine = _engine(tmp_path)
-    state = _answered_state("pm_batch_repeat")
-    state.rounds.append(
-        InterviewRound(round_number=4, question=Q_PRIMARY, user_response="An older decision.")
-    )
-    assert (await engine.save_state(state)).is_ok
-    _save_pm_meta(
-        state.interview_id,
-        engine,
-        cwd=str(tmp_path),
-        data_dir=tmp_path,
-        extra={
-            "pending_batch": [
-                {"question": Q_PRIMARY, "classification": "passthrough", "skip_eligible": False},
-                {"question": Q_SECOND, "classification": "passthrough", "skip_eligible": False},
-            ]
-        },
-    )
-    engine.plan_next_turns = AsyncMock()
-    handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
-
-    result = await handler.handle(
-        {
-            "session_id": state.interview_id,
-            "answer": "The review workflow, actually.",
-            "last_question": Q_PRIMARY,
-            "cwd": str(tmp_path),
-        }
-    )
-
-    assert result.is_ok
-    reloaded = (await engine.load_state(state.interview_id)).value
-    assert reloaded.rounds[-1].question == Q_PRIMARY
-    assert reloaded.rounds[-1].user_response == "The review workflow, actually."
-    assert len(reloaded.rounds) == 5

--- a/tests/unit/mcp/tools/test_pm_question_advisory.py
+++ b/tests/unit/mcp/tools/test_pm_question_advisory.py
@@ -41,10 +41,10 @@ QUESTION = "What happens today when a subscription lapses mid-period?"
 def _found_policy(roster: list[dict[str, str]], **overrides: Any) -> dict[str, Any]:
     """Return a well-formed ``PolicyCarried`` answer for the code lane.
 
-    Built in one place because the carried state is the one that holds the
-    forwarding fields: a test that spells them out by hand records today's
-    contract in a dozen places, and the last round's lesson is that a payload
-    with more than one spelling is a payload whose rules stop agreeing.
+    Built in one place: a test that spells the carried state out by hand
+    records today's contract in a dozen places, and the last round's lesson is
+    that a payload with more than one spelling is a payload whose rules stop
+    agreeing.
     """
     payload: dict[str, Any] = {
         "question_identity": stable_pm_question_identity(QUESTION),
@@ -53,13 +53,14 @@ def _found_policy(roster: list[dict[str, str]], **overrides: Any) -> dict[str, A
             {
                 "repo_id": roster[0]["repo_id"] if roster else "api-12345678",
                 "policy_claims": [
-                    {"path": "src/billing.py", "policy_claim": "grace period applies"}
+                    {
+                        "path": "src/billing.py",
+                        "policy_claim": "grace period applies",
+                        "plain_statement": "a grace period applies after lapse",
+                    }
                 ],
             }
         ],
-        "answer_prefix": "[from-code]",
-        "requires_user_confirmation": True,
-        "user_confirmation_prompt": "Record this finding as what the code does today?",
     }
     payload.update(overrides)
     return payload
@@ -242,34 +243,33 @@ def test_the_emitted_prompt_renders_the_catalog_answer_rule(
     assert rule and rule in _code_lane_prompt(roster)
 
 
-def test_the_emitted_prompt_does_not_retract_the_confirmation_it_asks_for(
+def test_the_emitted_prompt_speaks_evidence_only(
     roster: list[dict[str, str]],
 ) -> None:
-    """One prompt told the child both to produce and not to produce a finding.
+    """One rule with one spelling: the finding is evidence beside the question.
 
-    The task preamble said the finding is shown for confirmation and recorded;
-    the lane brief, still carrying the retired design, said there was nothing to
-    confirm. A child following the second omits the fields the contract requires
-    and the required lane is rejected.
+    The prompt once told the child its finding would be shown for confirmation
+    and recorded; that flow is retired (RFC #2222), and a prompt still saying
+    so would instruct the child toward a recording that no longer exists.
     """
     prompt = _code_lane_prompt(roster)
-    assert "shown to the user for confirmation" in prompt
-    assert "nothing to confirm" not in prompt
-    assert "no answer to send" not in prompt
+    assert "shown to the user for confirmation" not in prompt
+    assert "adopted fact" not in prompt
+    assert "evidence beside the question" in prompt
 
 
-def test_the_emitted_prompt_names_the_fields_a_carried_finding_requires(
+def test_the_emitted_prompt_carries_no_forwarding_instruction(
     roster: list[dict[str, str]],
 ) -> None:
-    """A schema the child is never shown is one it satisfies by luck.
+    """Findings are evidence, never answers (RFC #2222).
 
-    The three forwarding fields are required by the contract and were named
-    nowhere in the emitted prompt, so removing the contradiction alone would
-    have left the child with no instruction at all about them.
+    The v1 forwarding fields gated a recorded adopted fact; with nothing
+    recorded, a prompt still naming them would instruct the child toward a
+    shape the contract now rejects.
     """
     prompt = _code_lane_prompt(roster)
     for field in ("answer_prefix", "requires_user_confirmation", "user_confirmation_prompt"):
-        assert field in prompt
+        assert field not in prompt
 
 
 def _prompt_json_block(prompt: str, heading: str) -> Any:
@@ -416,64 +416,57 @@ def test_no_tool_parameter_holds_a_finding_beside_the_answer() -> None:
     assert {"answer", "last_question"} <= pm_params
 
 
-def test_the_only_answer_prefix_is_the_one_that_has_to_be_confirmed() -> None:
-    """Auto-confirm is unspellable rather than forbidden.
+def test_no_state_carries_a_forwarding_field() -> None:
+    """Findings are evidence, never answers (RFC #2222).
 
-    The interview's exception, ``[from-code][auto-confirmed]``, rests on the
-    premise that the person being asked wrote the code. A PRD has no such
-    premise, so PM keeps the field and drops the exception by giving the enum
-    one element — there is no rule to find, and nothing to reword past.
-
-    The confidence grade goes with it: a grade exists to decide which answers
-    earn the exception, and there is no exception to earn.
+    The v1 confirmation machinery — ``answer_prefix``,
+    ``requires_user_confirmation``, ``user_confirmation_prompt`` — gated a
+    recorded adopted fact. With nothing recorded there is nothing to gate, and
+    the closed shapes make an answer that still carries those fields rejected
+    rather than quietly honoured.
     """
     schema = pm_code_context_answer_contract()["response_model_schema"]
-    found = _state(schema, "PolicyCarried")
 
-    assert found["properties"]["answer_prefix"]["enum"] == ["[from-code]"]
-    assert found["properties"]["requires_user_confirmation"]["const"] is True
-    assert "confidence" not in found["properties"]
-    assert {"answer_prefix", "requires_user_confirmation", "user_confirmation_prompt"} <= set(
-        found["required"]
-    )
-    # Nothing to forward, so no way to say how to forward it.
-    for title in ("NothingExamined", "NoPolicyInExaminedRepositories"):
-        assert "answer_prefix" not in _state(schema, title)["properties"]
-    # And no free-text answer field: what the host forwards is composed from the
-    # ``examined`` entries, so every claim keeps the repository it was read in.
     for state in schema["oneOf"]:
         assert state["additionalProperties"] is False
-        assert "answer_text" not in state["properties"]
+        for field in (
+            "answer_prefix",
+            "requires_user_confirmation",
+            "user_confirmation_prompt",
+            "confidence",
+            "answer_text",
+        ):
+            assert field not in state["properties"], (state["title"], field)
 
 
-def test_the_confirmed_prefix_is_accepted_and_the_auto_confirmed_one_is_not(
+def test_a_carried_policy_is_accepted_and_a_forwarding_field_is_not(
     registry: FanoutRegistry, roster: list[dict[str, str]]
 ) -> None:
-    """Both directions, because the enum has to admit as well as refuse."""
+    """Both directions: the plain carried state admits; a v1 relic refuses."""
     accepted = _submit(registry, _attach(registry, roster), _found_policy(roster))
     assert accepted["status"] == "complete"
 
     refused = _submit(
         registry,
         _attach(registry, roster, session_id="pm-2"),
-        _found_policy(roster, answer_prefix="[from-code][auto-confirmed]"),
+        _found_policy(roster, answer_prefix="[from-code]"),
         session_id="pm-2",
     )
     assert refused["status"] == "partial"
-    assert "answer_prefix" in str(refused["contract_violations"]["code_context"])
+    assert "code_context" in refused["contract_violations"]
 
 
-def test_a_finding_that_declares_itself_pre_confirmed_is_rejected(
+def test_a_finding_carrying_the_retired_confirmation_flag_is_rejected(
     registry: FanoutRegistry, roster: list[dict[str, str]]
 ) -> None:
-    """The flag is constant, so the lane cannot lower it either."""
+    """The field is gone, so any value of it — True or False — is unspellable."""
     result = _submit(
         registry,
         _attach(registry, roster),
         _found_policy(roster, requires_user_confirmation=False),
     )
     assert result["status"] == "partial"
-    assert "requires_user_confirmation" in str(result["contract_violations"]["code_context"])
+    assert "code_context" in result["contract_violations"]
 
 
 # ── Decision 3: the lane speaks about itself ─────────────────────────────
@@ -575,7 +568,13 @@ def test_evidence_from_outside_the_roster_is_rejected(
             examined=[
                 {
                     "repo_id": "elsewhere-deadbeef",
-                    "policy_claims": [{"path": "src/x.py", "policy_claim": "something"}],
+                    "policy_claims": [
+                        {
+                            "path": "src/x.py",
+                            "policy_claim": "something",
+                            "plain_statement": "something, plainly",
+                        }
+                    ],
                 }
             ],
         ),
@@ -622,7 +621,11 @@ def test_one_repository_cannot_hold_two_entries(
                 {
                     "repo_id": roster[0]["repo_id"],
                     "policy_claims": [
-                        {"path": "src/billing.py", "policy_claim": "grace period applies"}
+                        {
+                            "path": "src/billing.py",
+                            "policy_claim": "grace period applies",
+                            "plain_statement": "a grace period applies after lapse",
+                        }
                     ],
                 },
                 {"repo_id": roster[0]["repo_id"], "policy_claims": []},
@@ -658,6 +661,7 @@ def test_a_claim_cannot_name_a_repository_the_answer_did_not_examine(
                             "repo_id": roster[1]["repo_id"],
                             "path": "src/checkout.ts",
                             "policy_claim": "revoked immediately",
+                            "plain_statement": "access ends immediately",
                         }
                     ],
                 }
@@ -711,7 +715,11 @@ def test_a_repository_read_and_clean_is_not_a_repository_unread(
         ]
     )
     carried = [
-        {"path": "src/billing.py", "policy_claim": "grace period applies"},
+        {
+            "path": "src/billing.py",
+            "policy_claim": "grace period applies",
+            "plain_statement": "a grace period applies after lapse",
+        },
     ]
 
     def scan(session_id: str, read: list[dict[str, str]]) -> dict[str, Any]:
@@ -772,7 +780,11 @@ def test_a_cited_repository_need_not_be_the_only_one_examined(
                 {
                     "repo_id": roster[0]["repo_id"],
                     "policy_claims": [
-                        {"path": "src/billing.py", "policy_claim": "grace period applies"}
+                        {
+                            "path": "src/billing.py",
+                            "policy_claim": "grace period applies",
+                            "plain_statement": "a grace period applies after lapse",
+                        }
                     ],
                 },
                 {"repo_id": roster[1]["repo_id"], "policy_claims": []},
@@ -804,6 +816,7 @@ def test_cross_repo_disagreement_survives_as_structure(
                         {
                             "path": "src/billing.py",
                             "policy_claim": "access continues until period end",
+                            "plain_statement": "access continues to the end of the paid period",
                         }
                     ],
                 },
@@ -813,6 +826,7 @@ def test_cross_repo_disagreement_survives_as_structure(
                         {
                             "path": "src/checkout.ts",
                             "policy_claim": "access is revoked immediately",
+                            "plain_statement": "access ends immediately",
                         }
                     ],
                 },
@@ -1193,7 +1207,11 @@ def test_a_citation_path_that_is_not_repository_relative_is_rejected() -> None:
     validator = Draft202012Validator(schema)
 
     def accepted(path: str) -> bool:
-        item = {"path": path, "policy_claim": "access ends"}
+        item = {
+            "path": path,
+            "policy_claim": "access ends",
+            "plain_statement": "access ends",
+        }
         return not list(validator.iter_errors(item))
 
     # What a lane is supposed to cite, including dotfiles and a literal '..'

--- a/tests/unit/mcp/tools/test_pm_question_advisory.py
+++ b/tests/unit/mcp/tools/test_pm_question_advisory.py
@@ -991,24 +991,30 @@ async def test_a_confirmed_finding_takes_its_own_round_and_the_decision_takes_th
     """
     handler = PMInterviewHandler(data_dir=tmp_path, agent_runtime_backend="claude")
     state = InterviewState(interview_id="pm-shape", initial_context="ctx")
-    state.rounds.append(InterviewRound(round_number=1, question="Q1", user_response=None))
     engine = _stub_engine(state, ("Q2", "Q3"))
 
     first = await handler._handle_answer(
-        engine, "pm-shape", "[from-code] api: counted by service date", str(tmp_path)
+        engine,
+        "pm-shape",
+        "[from-code] api: counted by service date",
+        str(tmp_path),
+        last_question="Q1",
     )
     assert first.is_ok
-    assert [r.question for r in state.rounds] == ["Q1", "Q2"]
+    # A turn persists nothing when it asks (RFC #2222 r4), so the transcript
+    # holds finished rounds only — Q2 is on the wire, not on disk.
+    assert [r.question for r in state.rounds] == ["Q1"]
     assert state.rounds[0].user_response == "[from-code] api: counted by service date"
     assert state.rounds[0].provenance == "observation"
 
     second = await handler._handle_answer(
-        engine, "pm-shape", "cancellations free the slot", str(tmp_path)
+        engine, "pm-shape", "cancellations free the slot", str(tmp_path), last_question="Q2"
     )
     assert second.is_ok
+    assert state.rounds[1].question == "Q2"
     assert state.rounds[1].user_response == "cancellations free the slot"
     assert state.rounds[1].provenance == "user"
-    assert [r.question for r in state.rounds if r.user_response is None] == ["Q3"]
+    assert [r for r in state.rounds if r.user_response is None] == []
 
 
 @pytest.mark.asyncio
@@ -1075,7 +1081,6 @@ async def test_no_second_field_can_carry_a_finding_past_the_answer(tmp_path: Pat
     """
     handler = PMInterviewHandler(data_dir=tmp_path, agent_runtime_backend="claude")
     state = InterviewState(interview_id="pm-caseB", initial_context="ctx")
-    state.rounds.append(InterviewRound(round_number=1, question="Q1", user_response=None))
     engine = _stub_engine(state, ("Q2",))
     handler.pm_engine = engine  # type: ignore[assignment]
 
@@ -1083,6 +1088,7 @@ async def test_no_second_field_can_carry_a_finding_past_the_answer(tmp_path: Pat
         {
             "session_id": "pm-caseB",
             "answer": "[from-code] api: counted by service date",
+            "last_question": "Q1",
             "evidence": "SECOND-PAYLOAD",
         }
     )
@@ -1172,21 +1178,27 @@ async def test_the_plugin_runtime_records_a_finding_the_same_way(tmp_path: Path)
 
 
 @pytest.mark.asyncio
-async def test_a_bare_reconnect_is_still_allowed(tmp_path: Path) -> None:
-    """``answer`` stays optional: a reconnect re-shows the pending question.
+async def test_a_bare_reconnect_asks_a_fresh_question(tmp_path: Path) -> None:
+    """``answer`` stays optional, and a reconnect plans rather than restores.
 
-    Kept from the refused-combination era, because the guard above is about a
-    missing *question* and this is the call with a missing *answer*. Blocking it
-    would close a normal path.
+    The guard above is about a missing *question*; this is the call with a
+    missing *answer*, and blocking it would close a normal path. What it
+    returns changed with RFC #2222 revision 4: a turn persists nothing when it
+    asks, so there is no in-flight question to re-show — the host that lost its
+    turn gets a new one planned from the finished transcript.
     """
     handler = PMInterviewHandler(data_dir=tmp_path, agent_runtime_backend="claude")
     state = InterviewState(interview_id="pm-rc2", initial_context="ctx")
-    state.rounds.append(InterviewRound(round_number=1, question="Q1", user_response=None))
+    state.rounds.append(InterviewRound(round_number=1, question="Q1", user_response="A1"))
 
-    result = await handler._handle_answer(_stub_engine(state), "pm-rc2", None, str(tmp_path))
+    result = await handler._handle_answer(
+        _stub_engine(state, ("Q2",)), "pm-rc2", None, str(tmp_path)
+    )
 
     assert result.is_ok
-    assert result.value.meta["question"] == "Q1"
+    assert result.value.meta["question"] == "Q2"
+    # Nothing half-written was left behind by asking.
+    assert [r.user_response for r in state.rounds] == ["A1"]
 
 
 def test_a_citation_path_that_is_not_repository_relative_is_rejected() -> None:
@@ -1233,19 +1245,6 @@ def test_a_citation_path_that_is_not_repository_relative_is_rejected() -> None:
     assert not accepted("./x")
     # A newline would smuggle a second line into a rendered citation.
     assert not accepted("src/x.py\nrm -rf /")
-
-
-def test_reconnect_returns_the_unanswered_question_not_a_new_one() -> None:
-    """Pending is found by being unanswered, wherever it sits in the stream."""
-    from ouroboros.bigbang.interview import InterviewRound, InterviewState
-    from ouroboros.mcp.tools.pm_handler import _pending_round
-
-    state = InterviewState(interview_id="pm-rc", initial_context="ctx")
-    state.rounds.append(InterviewRound(round_number=1, question="Q1", user_response=None))
-    state.rounds.append(InterviewRound(round_number=2, question="Q2", user_response="A2"))
-
-    pending = _pending_round(state)
-    assert pending is not None and pending.question == "Q1"
 
 
 def test_readiness_counts_decisions_not_records() -> None:

--- a/tests/unit/mcp/tools/test_recent_findings.py
+++ b/tests/unit/mcp/tools/test_recent_findings.py
@@ -171,16 +171,20 @@ def test_only_the_lane_that_produced_a_finding_is_offered_it(
             assert "## Recently Found Here" not in prompt, lane_id
 
 
-def test_a_lane_answering_under_a_closed_contract_is_offered_none(
+def test_a_contracted_lane_is_offered_its_findings_without_the_reporting_duty(
     roster: list[dict[str, str]], store: ArtifactStore
 ) -> None:
-    """It has nowhere to put a finding, and nowhere to say it could not fetch one.
+    """Eligibility follows what a lane produces, not the shape of its answer (#2223).
 
-    Its answer shape rejects any field it does not name, so "I could not reach
-    the tool" discards the whole answer -- and those lanes are required, so the
-    fan-out then cannot complete. Staying silent instead reports having found
-    nothing, which is the confusion this is built to prevent. The PM lanes are
-    the case that made this visible: both of theirs are closed.
+    The offer was gated on answer shape once: a contracted lane had no field in
+    which to confess a failed fetch, so it was offered nothing -- which withheld
+    the head start from exactly the lanes doing the most repeated work (both PM
+    lanes are contracted). The confession is what the shape decides, not the
+    offer: a contracted answer carries no reuse statement a reader could be
+    misled by, a failed fetch degrades to the investigation the lane would have
+    run anyway, and the server sees the fetch calls either way. So the prose
+    lane keeps the in-band duty, and the contracted lane is told to keep its
+    shape instead.
     """
     _publish(store)
 
@@ -189,15 +193,28 @@ def test_a_lane_answering_under_a_closed_contract_is_offered_none(
     interview = _lane_prompts(interview_meta)
     pm = _lane_prompts(pm_meta)
 
-    assert "## Recently Found Here" in interview["code_context"]
-    assert "## Recently Found Here" not in interview["data_context"]
-    for prompt in pm.values():
-        assert "## Recently Found Here" not in prompt
+    for prompt in (
+        interview["code_context"],
+        interview["data_context"],
+        pm["code_context"],
+        pm["data_context"],
+    ):
+        assert "## Recently Found Here" in prompt
 
-    # And the request carries no key for a lane that will never render one: a
-    # key nothing reads is a promise the schema makes and the prompt never keeps.
-    assert list(interview_meta["question_advisory_request"]["recent_findings"]) == ["code_context"]
-    assert "recent_findings" not in pm_meta["question_advisory_request"]
+    # The in-band duty exists only where the answer has a place for it.
+    assert "reporting nothing to reuse would be false" in interview["code_context"]
+    for prompt in (interview["data_context"], pm["code_context"], pm["data_context"]):
+        assert "reporting nothing to reuse would be false" not in prompt
+        assert "do not add fields about reuse" in prompt
+
+    assert sorted(interview_meta["question_advisory_request"]["recent_findings"]) == [
+        "code_context",
+        "data_context",
+    ]
+    assert sorted(pm_meta["question_advisory_request"]["recent_findings"]) == [
+        "code_context",
+        "data_context",
+    ]
 
 
 def test_the_eligible_lanes_do_not_read_each_other(store: ArtifactStore) -> None:

--- a/tests/unit/mcp/tools/test_recent_findings.py
+++ b/tests/unit/mcp/tools/test_recent_findings.py
@@ -582,3 +582,34 @@ def test_the_request_schema_makes_a_mismatched_lane_pairing_unrepresentable(
     assert list(validator.iter_errors(request)) == []
     request["recent_findings"]["code_context"][0]["lane_id"] = "data_context"
     assert list(validator.iter_errors(request)) != []
+
+
+def test_a_lane_alone_lists_that_lane_own_recent_findings(store: ArtifactStore) -> None:
+    """A lane may ask which of its findings exist instead of being handed the ids.
+
+    Sending the list in every prompt spent a fifth of it on identifiers a child
+    has no way to choose between, and a lane wanting none of them paid for it
+    anyway. Asking is the same answer, pulled: the window, the eligible kind
+    and the cap stay the query's, so a lane cannot ask for a wider read than it
+    was ever offered — only for its own, and only from the last day.
+    """
+    contract_id = _publish_distinguishable(store)
+    handler = _fetch_handler(store)
+
+    result = asyncio.run(handler.handle({"lane_id": "code_context"}))
+
+    assert result.is_ok
+    listing = result.value.meta
+    assert listing["lane_id"] == "code_context"
+    assert [entry["contract_id"] for entry in listing["recent"]] == [contract_id]
+    assert {"contract_id", "lane_id", "published_at"} == set(listing["recent"][0])
+    # Bodies stay in the store: what is listed is what to read, never the read.
+    assert "output" not in json.dumps(listing)
+
+
+def test_neither_a_contract_nor_a_lane_is_refused(store: ArtifactStore) -> None:
+    """An empty request names both ways to ask rather than guessing one."""
+    result = asyncio.run(_fetch_handler(store).handle({}))
+
+    assert result.is_err
+    assert "contract_id" in str(result.error) and "lane_id" in str(result.error)

--- a/tests/unit/orchestrator/test_capabilities.py
+++ b/tests/unit/orchestrator/test_capabilities.py
@@ -239,7 +239,11 @@ _EXPECTED_OUROBOROS_REQUIRED_CONTEXT_KEYS = {
         "session_id",
     ),
     "ouroboros_start_ralph": ("lineage_id",),
-    "ouroboros_fetch_artifact": ("contract_id",),
+    # Empty because neither parameter is required on its own: a `contract_id`
+    # reads one artifact, a `lane_id` alone lists what a lane published here
+    # recently, and an MCP schema cannot say "one of these". The handler is
+    # where the pair is judged, and it refuses a request carrying neither.
+    "ouroboros_fetch_artifact": (),
     "ouroboros_submit_fanout_results": ("fanout_id", "results"),
 }
 


### PR DESCRIPTION
Closes #2223. Implements RFC #2222 (revision 6).

**Why.** A PM interview session paid a full turn — fan-out latency, evidence block, gates — per question, even when questions never depended on each other's answers; and the evidence a PM saw before answering was the record format (file paths, class names, flag values), written for a reader they are not. This PR makes a turn carry one to three independent questions and makes the evidence speak product language, with the machinery cost that made both affordable fixed on the way.

Two pieces the RFC's own cost accounting binds together: the recent-findings gate fix (#2223) is what makes RFC #2222's batched turns affordable, and the RFC cites this branch's fix as the machinery its cost argument stands on. All RFC #2222 behavior is scoped to the PM tool; the regular interview's only change is the deliberate, shared #2223 fix (its contracted `data_context` lane now receives recent-findings offers).

## Part 1 — Recent findings reach contracted lanes (#2223) — `bdf0fa50`

Every piece of PM findings reuse already existed and ran — write side published each completed fan-out into the project `ArtifactStore`, and `create_fanout_wiring` handed both handlers that same store — except the last step: `recent_findings_by_lane(store, lanes=_open_contract_lanes(catalog))` offered findings only to lanes *without* a closed answer contract. Both PM lanes are contracted, so the offer set was always `∅` — written every turn, read never. The interview's contracted `data_context` was cut off the same way.

`_declared_lanes` replaces the gate: eligibility follows what a lane *produces* (RFC #2167's criterion), never the shape of its answer. The one real hazard — a contracted lane told to confess a failed fetch in-band would fail its own contract — is handled in the offer *text*: prose lanes keep the in-band duty; contracted lanes get "investigate as usual; your answer keeps its contracted shape — do not add fields about reuse."

**Verified live**: a later lane was offered prior rounds' contract ids, fetched its own lane's scoped body, and narrowed its investigation to the one fact not already recorded; cross-topic offers were triaged by the child ("covers booking-limit policy, not the trial-lesson funnel") exactly as "a head start, not a substitute" intends.

## Part 2 — RFC #2222 (PM tool only) — `0f690e78`

### Batched turns (decision 1, `pm_interview.py`)

`plan_next_turns` rides the existing atomic planner call: companions arrive in the same JSON payload (requested through the same `extra_response_contract` hook PM already uses) and pass through the same `_apply_classification` path as the primary. Enforced in code, not trusted to the generator: closure mode (ambiguity ≤ 0.25) is single-question; duplicate normalized question identities are dropped (fan-out isolation keys on them); three is a ceiling. Zero extra LLM calls.

### A turn is atomic (decision 2, revision 4)

Three review rounds found the same seam at three addresses — an interleaved write, an interrupted one, and an answer matched to the wrong round — because a batch kept its pending questions in `pm_meta` beside the transcript, keyed by question text. Revision 4 removes the seam instead of guarding it: **a turn persists nothing when it asks, and its answers arrive together**, so a round is written only when it is whole and there is no second place a turn is remembered. A call carrying no answers is a host that lost its turn; the next turn is planned from the transcript rather than restored.

What that deleted: the question-only round, `pending_batch` and its per-member routing, the text match from answer to member, the partial-batch response, the replay reconciliation, and the reconnect re-display. What it added: `answers: [{question, answer}]` on the tool, and one function that records them. `pm_handler.py` went from the 2000-line cap to 1809.

### The interview core is untouched (decision 2)

`git diff origin/main...HEAD` over the enumerated boundary (`interview.py`, `turn_planner.py`, `ambiguity.py`, `answer_provenance.py`, `inner_guidance.py`, `interview_schemas.py`, `authoring_handlers.py`) is **empty**. The invariant that makes it possible: the engine's `record_answer` fills the *trailing* unanswered round, so a PM turn leaves none — **it persists nothing when it asks** (RFC revision 4). No question-only round, no pending-member list. A turn's answers arrive together and each round is written whole, through the public API.

### Every question keeps its evidence; the plumbing does not travel (decisions 3 & 6, `pm_handler.py`, `pm_batch.py`)

One advisory envelope per question (`meta.question_advisories`), each with its own payloads and fan-out id. The turn's answers come back together as `answers: [{question, answer}]` — each answer names its own question, so correlation is structural rather than a lookup against remembered state, and completion and the next turn follow the one write that records them.

What made batches receivable at all: a turn's response used to carry each lane's full brief **twice** (meta + dispatch text) plus a per-envelope copy of the tool capability metadata — ~120k chars for one question; a batch outgrew what a host accepts inline and hosts improvised file surgery. The briefs are published to the artifact store (`advisory_prompt_bundle`, keyed by fan-out id, a kind the reuse query never offers as a finding) and each payload prompt is a stub. Capability metadata rides as a name. **Fail-open on every edge**: no store, no fan-out id, or a failed publish leaves the full prompts inline.

**What the stub carries** (revision 6). The first cut put everything behind the fetch, so a lane that could not reach the store had no shape to answer in and nowhere it was allowed to look — one call was the single point of failure for a whole lane. The line is now drawn at what a child cannot derive or ask for:

- **The answer's shape, named rather than specified.** Field names and nesting, the empty state and its literals read out of the contract's own schema, the enum vocabularies, and the two conventions a child gets wrong by default (a path is repository-relative; a plain statement is in the question's language). Not the JSON Schema — its bounds restate what the validator already refuses. Not a worked example either: an example is a claim already written in the answer's shape, and a lane short on evidence would hold a draft needing only its identifiers changed.
- **Where it may look** — the roster for a lane whose answer cites repositories, the host's data tools for one that does not. The branch reads each lane's own answer shape, never its name.
- **The order of work** — no-op if the question does not need this lane; otherwise read what this lane already found and *carry it as it stands*; investigate **only if** that turned up nothing that bears on the question.

**Which findings exist is asked for, not sent.** Twenty contract ids rode in every prompt so a child could choose among them, and an entry is an id and a time — nothing to choose by. `ouroboros_fetch_artifact` now accepts a `lane_id` alone and lists that lane's recent findings; reading one back by `contract_id` is unchanged. The window, the eligible kind and the cap stay inside the query, so asking reaches no further than being offered did. **Additive**: every existing call behaves exactly as before, and the regular interview keeps rendering its own offers.

A lane prompt is ~2k characters, against ~14.7k inline on `main` for the same question, and no longer grows with how much the project has found. `UNDISPATCHED` remains for a child that cannot work at all — a failed fetch is no longer one of those cases.

### Findings are evidence, never answers (decision 4, `pm_schemas.py`, `skills/pm/SKILL.md`)

The adopted-fact flow is retired: recording a confirmed finding as a `[from-code]` observation duplicated the published fan-out (already addressable and re-offered via #2223) and cost the user a confirmation turn. The v2 code-lane contract sheds `answer_prefix` / `requires_user_confirmation` / `user_confirmation_prompt` — with nothing recorded there is nothing to gate, and the closed shape rejects an answer that still carries them. Each claim gains a required lane-authored `plain_statement` (product language, the question's language, no paths or identifiers): the screen renders plain statements only; citations stay in the published fan-out. Interview rounds carry only the user's answers — their own words, or the refine-gate structure they confirmed.

### pm_handler split

Batch/report/externalization logic lives in a new PM-owned module `pm_batch.py`; `pm_handler.py` stays at the module-size cap (≤ 2000 lines) without grandfathering.

## What this does not change

- The regular interview: single-question turns, inline payload prompts, its own contracts and skill — untouched by everything in Part 2 (`git diff` over `authoring_handlers.py`, `interview_schemas.py`, `interview.py`, `turn_planner.py` is empty). Its one behavior change is Part 1's, by that issue's explicit scope: the contracted `data_context` lane is now offered its own recent findings, with the contracted offer text. Its identical wire weight is named in RFC #2222 decision 6 as that tool's own future decision.
- Answer validation, roster guards, per-lane findings scoping, ids-only transport, recency window: intact and pinned by tests — the listing moved behind a request, its bounds did not move with it.
- Single-question PM turns: same flow as before, now with stub payloads.
- `ouroboros_fetch_artifact` called with a `contract_id`, with or without a `lane_id`: byte-identical behaviour.

## Tests

- `test_recent_findings.py`: gate inversion pinned — all four eligible lane instances offered; in-band duty only where the answer has a place for it.
- `test_pm_interview.py`: batch planning — companions classified and reframe-tracked; closure mode single; duplicates/malformed dropped without trace.
- `test_pm_handler_batch.py` (new): batch issue (per-question envelopes, **nothing persisted by asking**), a turn recorded whole, an answer without its question refused, a question whose text recurs recorded as its own round, a reconnect planning a fresh turn, two turns answered concurrently, plugin mode never entering the batch producer, briefs-by-reference (stub on the wire, full brief one scoped fetch away), no-store inline fallback.
- `test_pm_question_advisory.py`: v2 contract — no forwarding fields in any state, a v1 relic answer is rejected, prompts carry `plain_statement` and no confirmation instruction.
- Stub content: every field a contract *requires* is named in what the child is shown (so the text cannot go stale as the contract gains one), step 3 follows the lane's answer shape rather than its name, and the wire carries no JSON block for a lane to copy.
- Tool listing: a `lane_id` alone returns that lane's own recent findings as ids and times and no bodies; neither argument is refused with both named.
- Changed-boundary suites (`tests/unit/mcp/tools`, `tests/unit/bigbang`): **2,509 passed**. Ruff and mypy clean; skill mirror and module-size gates green.

Verified live in lane sessions across two product topics: stub wire on start and answer paths, children fetching their own lane's prior findings by request, cross-topic reuse triage, a 3-question batch received inline, evidence blocks in product language with no confirmation turn. Publish → offer → scoped fetch was also exercised end to end against a real store, including the refusal of a lane the artifact does not carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


