### PR TITLE
feat(hooks): pin the repository PR body template

### DIFF
--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -160,6 +160,34 @@ KEYWORD_MAP = [
     },
 ]
 
+_PR_CREATION_RE = re.compile(
+    r"(?:"
+    r"\bgh\s+pr\s+create\b"
+    r"|\b(?:create|open|submit|raise)\s+(?:a\s+)?(?:pr|pull request)\b"
+    r"|\b(?:pr|pull request)\s+(?:create|open|submit)\b"
+    r"|(?:pr|풀\s*리퀘스트)(?:도|를|을)?\s*(?:올려|열어|만들어|생성|쏴|제출)"
+    r")",
+    re.IGNORECASE,
+)
+
+PROJECT_PR_TEMPLATE_CONTEXT = """<project-pr-template>
+When creating a pull request for this repository, use this body structure:
+
+## Summary
+- State what changed and why in 1-3 bullets.
+
+## Verification
+- List the exact commands run and their exact results.
+- Report failed checks and why they are unrelated. Never claim an unrun check passed.
+
+## Related issues
+- Use `Closes #<issue-number>` when the PR fully resolves an issue.
+- Use `Refs #<issue-number>` when it is related without closing it.
+- Use `N/A` when there is no related issue.
+
+Add the repository's R-run comparison section before Related issues only when files under src/ouroboros/auto/ changed.
+</project-pr-template>"""
+
 
 def is_mcp_configured() -> bool:
     """Check if MCP server is registered in ~/.claude/mcp.json."""
@@ -281,6 +309,22 @@ def detect_keywords(text: str) -> dict:
     return {"detected": False, "keyword": None, "suggested_skill": None}
 
 
+def is_pr_creation_request(text: str) -> bool:
+    """Return whether the prompt asks the agent to create a pull request."""
+    return bool(_PR_CREATION_RE.search(text))
+
+
+def is_ouroboros_project() -> bool:
+    """Return whether the current directory belongs to this repository."""
+    cwd = Path.cwd()
+    return any(
+        (directory / "pyproject.toml").is_file()
+        and (directory / "src" / "ouroboros").is_dir()
+        and (directory / ".github" / "PULL_REQUEST_TEMPLATE.md").is_file()
+        for directory in (cwd, *cwd.parents)
+    )
+
+
 def _extract_prompt_and_host(hook_input: str) -> tuple[str, str]:
     """Extract a prompt and identify the hook host from its wire envelope."""
 
@@ -326,15 +370,21 @@ def main() -> None:
     user_input, host = _extract_prompt_and_host(hook_input)
 
     result = detect_keywords(user_input)
+    project_context = (
+        PROJECT_PR_TEMPLATE_CONTEXT
+        if is_pr_creation_request(user_input) and is_ouroboros_project()
+        else ""
+    )
 
     # First-time user: add welcome context to their first message.
     if not result["detected"] and is_first_time():
         skill_name = "welcome"
-        _emit_context(f"""<skill-suggestion>
+        welcome_context = f"""<skill-suggestion>
 🎯 MATCHED SKILLS (use AskUserQuestion to let user choose):
 - /ouroboros:{skill_name} - First time using Ouroboros! Starting welcome experience.
 IMPORTANT: Auto-triggering welcome experience now. Use AskUserQuestion to confirm or skip.
-</skill-suggestion>""")
+</skill-suggestion>"""
+        _emit_context("\n\n".join(item for item in (project_context, welcome_context) if item))
         return
 
     if result["detected"]:
@@ -345,16 +395,19 @@ IMPORTANT: Auto-triggering welcome experience now. Use AskUserQuestion to confir
         # layers, so a child hook process cannot reconstruct its effective MCP state.
         needs_setup = host != "codex" and not is_mcp_configured()
         if skill not in SETUP_BYPASS_SKILLS and needs_setup:
-            _emit_context("""<skill-suggestion>
+            skill_context = """<skill-suggestion>
 🎯 REQUIRED SKILL:
 - /ouroboros:setup - Ouroboros setup required. Run "ooo setup" first to register the MCP server.
-</skill-suggestion>""")
+</skill-suggestion>"""
         else:
             skill_name = skill.replace("/ouroboros:", "")
-            _emit_context(f"""<skill-suggestion>
+            skill_context = f"""<skill-suggestion>
 🎯 MATCHED SKILLS:
 - /ouroboros:{skill_name} - Detected "{keyword}"
-</skill-suggestion>""")
+</skill-suggestion>"""
+        _emit_context("\n\n".join(item for item in (project_context, skill_context) if item))
+    elif project_context:
+        _emit_context(project_context)
 
 
 if __name__ == "__main__":

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -15,6 +15,7 @@ detect_keywords = _mod.detect_keywords
 SETUP_BYPASS_SKILLS = _mod.SETUP_BYPASS_SKILLS
 main = _mod.main
 is_first_time = _mod.is_first_time
+is_pr_creation_request = _mod.is_pr_creation_request
 
 
 class TestFirstTimePrefs:
@@ -147,6 +148,13 @@ class TestDetectKeywords:
     def test_no_match(self):
         result = detect_keywords("hello world")
         assert result["detected"] is False
+
+    def test_pr_creation_request_detection(self):
+        for prompt in ("PR 올려줘", "create a PR", "open pull request", "gh pr create"):
+            assert is_pr_creation_request(prompt) is True
+
+    def test_pr_status_question_does_not_request_creation(self):
+        assert is_pr_creation_request("PR도 쐈어?") is False
 
     def test_ooo_auto_with_goal(self):
         result = detect_keywords('ooo auto "Add /healthz endpoint"')
@@ -347,6 +355,40 @@ class TestHookProtocol:
             "session_id": "ooo status",
             "turn_id": "turn-1",
             "prompt": "hello world",
+            "hook_event_name": "UserPromptSubmit",
+        }
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = json.dumps(payload)
+            main()
+
+        assert capsys.readouterr().out == ""
+
+    @patch.object(_mod, "is_first_time", return_value=False)
+    @patch.object(_mod, "is_ouroboros_project", return_value=True)
+    def test_pr_creation_request_injects_fixed_project_template(self, _project, _first, capsys):
+        payload = {
+            "session_id": "test-session",
+            "turn_id": "test-turn",
+            "prompt": "PR 올려줘",
+            "hook_event_name": "UserPromptSubmit",
+        }
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = json.dumps(payload)
+            main()
+
+        context = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+        assert "## Summary" in context
+        assert "## Verification" in context
+        assert "## Related issues" in context
+        assert "src/ouroboros/auto/" in context
+
+    @patch.object(_mod, "is_first_time", return_value=False)
+    @patch.object(_mod, "is_ouroboros_project", return_value=False)
+    def test_pr_template_does_not_leak_into_other_projects(self, _project, _first, capsys):
+        payload = {
+            "session_id": "test-session",
+            "turn_id": "test-turn",
+            "prompt": "create a PR",
             "hook_event_name": "UserPromptSubmit",
         }
         with patch("sys.stdin") as mock_stdin:


### PR DESCRIPTION
## Summary

- Inject the fixed Summary, Verification, and Related issues body structure through the existing UserPromptSubmit hook when a prompt requests PR creation.
- Scope the context to Ouroboros checkouts so the installed plugin cannot leak repository-specific R-run guidance into other projects.
- Keep PR status questions and unrelated prompts unchanged.

## Verification

- uv run pytest tests/unit/scripts -q - 523 passed
- uv run ruff check scripts/keyword-detector.py tests/unit/scripts/test_keyword_detector.py - passed
- uv run ruff format --check scripts/keyword-detector.py tests/unit/scripts/test_keyword_detector.py - passed
- git diff --check - passed

## Related issues

N/A