### PR TITLE
fix(seed): reject empty reference-aware Seed contracts

### DIFF
--- a/src/ouroboros/bigbang/requirement_distillation.py
+++ b/src/ouroboros/bigbang/requirement_distillation.py
@@ -326,8 +326,12 @@ def build_promoted_reference_seed(
 ) -> Seed:
     """Build a Seed without exposing reference-aware sessions to LLM extraction."""
     applied = apply_requirement_distillation({}, distillation)
-    if applied.promotion.blockers:
-        raise ValueError(seed_readiness_details(applied.promotion))
+    readiness = seed_readiness_details(
+        applied.promotion,
+        require_promoted_acceptance_criteria=True,
+    )
+    if readiness["blockers"]:
+        raise ValueError(readiness)
     requirements = applied.requirements
     constraints = _normalized_requirement_values(requirements.get("constraints"))
     criteria = _normalized_requirement_values(requirements.get("acceptance_criteria"))
@@ -374,8 +378,12 @@ def build_promoted_reference_seed(
     )
 
 
-def seed_readiness_details(promotion: PromotionResult) -> dict[str, Any]:
-    """Return typed caller metadata for a blocking promotion result."""
+def seed_readiness_details(
+    promotion: PromotionResult,
+    *,
+    require_promoted_acceptance_criteria: bool = False,
+) -> dict[str, Any]:
+    """Return typed caller metadata for Seed readiness blockers."""
     blockers = []
     for decision in promotion.blockers:
         candidate = decision.candidate
@@ -392,6 +400,23 @@ def seed_readiness_details(promotion: PromotionResult) -> dict[str, Any]:
                 "reason": decision.reason,
                 "section": candidate.section.value,
                 "reference_ids": list(candidate.reference_ids),
+            }
+        )
+    if (
+        not blockers
+        and require_promoted_acceptance_criteria
+        and not any(
+            candidate.section is RequirementSection.ACCEPTANCE_CRITERION
+            for candidate in promotion.promoted
+        )
+    ):
+        blockers.append(
+            {
+                "candidate_id": "promoted-acceptance-criteria",
+                "code": "no_promoted_acceptance_criteria",
+                "reason": "no_promoted_acceptance_criteria",
+                "section": RequirementSection.ACCEPTANCE_CRITERION.value,
+                "reference_ids": [],
             }
         )
     return {

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -1705,16 +1705,21 @@ class SeedGenerator:
 
         distillation = build_requirement_distillation(state)
         preflight = apply_requirement_distillation({}, distillation)
-        if preflight.promotion.blockers:
+        reference_aware = is_reference_aware_distillation(distillation)
+        readiness = seed_readiness_details(
+            preflight.promotion,
+            require_promoted_acceptance_criteria=reference_aware,
+        )
+        if readiness["blockers"]:
             return Result.err(
                 ValidationError(
                     "Interview must be reopened before Seed generation",
                     field="requirement_distillation",
-                    details=seed_readiness_details(preflight.promotion),
+                    details=readiness,
                 )
             )
         state.requirement_distillation = distillation
-        if is_reference_aware_distillation(distillation):
+        if reference_aware:
             return Result.ok(
                 build_promoted_reference_seed(
                     state,

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -1308,8 +1308,12 @@ class GenerateSeedHandler:
             from ouroboros.core.requirement_candidate import evaluate_promotion
 
             promotion = evaluate_promotion(distillation)
-            if promotion.blockers:
-                details = seed_readiness_details(promotion)
+            reference_aware = is_reference_aware_distillation(distillation)
+            details = seed_readiness_details(
+                promotion,
+                require_promoted_acceptance_criteria=reference_aware,
+            )
+            if details["blockers"]:
                 return Result.err(
                     MCPToolError(
                         f"Interview must be reopened before Seed generation: {details}",
@@ -1325,7 +1329,7 @@ class GenerateSeedHandler:
                     error=str(cache_save_result.error),
                 )
 
-            if is_reference_aware_distillation(distillation):
+            if reference_aware:
                 reference_seed = build_promoted_reference_seed(
                     interview_state,
                     distillation,

--- a/tests/unit/bigbang/test_requirement_distillation.py
+++ b/tests/unit/bigbang/test_requirement_distillation.py
@@ -257,6 +257,13 @@ def test_promoted_reference_seed_preserves_literal_pipe_in_constraint() -> None:
     state = _reference_state(
         confirmation="The CLI must accept only --lang ko|en as the language flag."
     )
+    state.rounds.append(
+        InterviewRound(
+            round_number=4,
+            question="How is successful language selection confirmed?",
+            user_response="The confirmed requirement is that the selected language is printed.",
+        )
+    )
     distillation = build_requirement_distillation(state)
 
     seed = build_promoted_reference_seed(state, distillation, ambiguity_score=0.1)
@@ -275,6 +282,14 @@ def test_promoted_reference_seed_preserves_literal_pipe_in_acceptance_criterion(
     assert tuple(str(item) for item in seed.acceptance_criteria) == (
         "The confirmed requirement is that output must show ko|en verbatim.",
     )
+
+
+def test_promoted_reference_seed_rejects_empty_contract() -> None:
+    state = _reference_state()
+    distillation = build_requirement_distillation(state)
+
+    with pytest.raises(ValueError, match="no_promoted_acceptance_criteria"):
+        build_promoted_reference_seed(state, distillation, ambiguity_score=0.1)
 
 
 def test_reference_cue_merge_changes_fingerprint_and_revision() -> None:
@@ -298,7 +313,7 @@ def test_reference_cue_merge_changes_fingerprint_and_revision() -> None:
 
 
 @pytest.mark.asyncio
-async def test_seed_generator_filters_unconfirmed_reference_acs(tmp_path) -> None:
+async def test_seed_generator_reopens_when_no_reference_acs_are_promoted(tmp_path) -> None:
     adapter = AsyncMock()
     adapter.complete.return_value = Result.ok(_extraction_response())
     generator = SeedGenerator(
@@ -309,8 +324,74 @@ async def test_seed_generator_filters_unconfirmed_reference_acs(tmp_path) -> Non
 
     result = await generator.generate(_reference_state(), _low_ambiguity())
 
-    assert result.is_ok
-    assert result.value.acceptance_criteria == ()
+    assert result.is_err
+    assert result.error.details["code"] == "interview_reopen_required"
+    assert result.error.details["blockers"][0]["code"] == "no_promoted_acceptance_criteria"
+    adapter.complete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reference_seed_never_succeeds_with_an_empty_contract(tmp_path) -> None:
+    cue = ReferenceCue(
+        reference_id="dashboard-shot",
+        label="dashboard reference screenshot",
+        origin=ReferenceOrigin.FILE_REFERENCE,
+        excerpt="A dense desktop dashboard with a sidebar and review queue.",
+    )
+    contrast_question = build_reference_contrast_question(cue)
+    contrast_answer = (
+        "Copy the compact hierarchy and sidebar placement; avoid the reference colors and branding."
+    )
+    rounds = [
+        InterviewRound(
+            round_number=1,
+            question=contrast_question,
+            user_response=contrast_answer,
+        )
+    ]
+    rounds.extend(
+        InterviewRound(
+            round_number=index,
+            question=f"Clarify dashboard behavior {index}.",
+            user_response=f"""[from-user][refined]
+Decision: Panel {index} stays visible after refresh.
+
+Constraints (user-stated):
+- Panel {index} uses the shared spacing scale.
+
+Out of scope (user-stated):
+- Custom themes for panel {index}.""",
+        )
+        for index in range(2, 12)
+    )
+    state = InterviewState(
+        interview_id="synthetic-reference-refined",
+        initial_context="Create a responsive review dashboard from a reference screenshot.",
+        rounds=rounds,
+        reference_cues=(cue,),
+        reference_resolutions=(
+            ReferenceContrastResolution(
+                reference_id=cue.reference_id,
+                status=ReferenceResolutionStatus.RESOLVED,
+                asked_question=contrast_question,
+                answer=contrast_answer,
+            ),
+        ),
+    )
+    adapter = AsyncMock()
+    generator = SeedGenerator(
+        llm_adapter=adapter,
+        model="test-model",
+        output_dir=tmp_path,
+    )
+
+    result = await generator.generate(state, _low_ambiguity())
+
+    assert len(state.rounds) == 11
+    assert result.is_err
+    assert result.error.details["code"] == "interview_reopen_required"
+    assert result.error.details["blockers"][0]["code"] == "no_promoted_acceptance_criteria"
+    adapter.complete.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/tools/test_interview_reference_context.py
+++ b/tests/unit/mcp/tools/test_interview_reference_context.py
@@ -142,7 +142,7 @@ def test_seed_subagent_payload_separates_promoted_and_omitted_candidates() -> No
 
 
 @pytest.mark.asyncio
-async def test_plugin_reference_seed_is_built_server_side_without_child_leakage() -> None:
+async def test_plugin_reference_seed_reopens_when_no_acs_are_promoted() -> None:
     cue = ReferenceCue(
         reference_id="linear",
         label="Linear-like",
@@ -186,7 +186,7 @@ async def test_plugin_reference_seed_is_built_server_side_without_child_leakage(
         patch(
             "ouroboros.mcp.tools.authoring_handlers._plugin_save_state",
             AsyncMock(return_value=Result.ok(MagicMock())),
-        ),
+        ) as save_state,
         patch(
             "ouroboros.mcp.tools.authoring_handlers.dispatch_plugin_terminal",
             AsyncMock(),
@@ -194,10 +194,10 @@ async def test_plugin_reference_seed_is_built_server_side_without_child_leakage(
     ):
         result = await handler.handle({"session_id": state.interview_id})
 
-    assert result.is_ok
-    assert "Seed Generated Successfully" in result.value.text_content
-    assert "Keyboard-first command menu" not in result.value.text_content
-    assert result.value.meta["requirement_distillation"]
+    assert result.is_err
+    assert "interview_reopen_required" in str(result.error)
+    assert "no_promoted_acceptance_criteria" in str(result.error)
+    save_state.assert_not_awaited()
     dispatch.assert_not_awaited()
 
 


### PR DESCRIPTION
## Summary

- Reject reference-aware Seed generation with a typed interview_reopen_required result when no acceptance criteria were promoted.
- Apply the same readiness decision at the shared builder, SeedGenerator, and MCP entry points.
- Add regressions for canonical refined interview answers and preserve explicitly confirmed reference requirements.

## Verification

- uv run pytest tests/unit/bigbang/test_requirement_distillation.py tests/unit/bigbang/test_answer_provenance.py tests/unit/mcp/tools/test_interview_reference_context.py -q - 65 passed
- env -u CODEX_HOME uv run --group mcp-test pytest tests/unit/bigbang tests/unit/mcp/tools -q - 2492 passed
- env -u CODEX_HOME uv run --group mcp-test pytest tests/unit/ -q -n 4 - 20663 passed, 89 skipped, 2 unrelated failures in macOS Python startup-poison guards under tests/unit/skills/test_skill_artifacts.py; current uv with Python 3.14 no longer fails startup for PYTHONEXECUTABLE or __PYVENV_LAUNCHER__ poison
- uv run ruff check on all five changed files - passed
- uv run ruff format --check on all five changed files - passed
- git diff --check - passed

## Related issues

Closes #2216