### PR TITLE
fix(orchestrator): stop emitting known-wrong drift measurements

### DIFF
--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -73,7 +73,6 @@ from ouroboros.core.seed_contract_prompt import (
 )
 from ouroboros.core.types import Result
 from ouroboros.core.worktree import TaskWorkspace, heartbeat_lock, release_lock
-from ouroboros.observability.drift import DriftMeasurement
 from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.adapter import (
     DEFAULT_TOOLS,
@@ -104,7 +103,6 @@ from ouroboros.orchestrator.decomposition_limits import (
     validate_max_decomposition_depth,
 )
 from ouroboros.orchestrator.events import (
-    create_drift_measured_event,
     create_execution_terminal_event,
     create_guidance_injected_event,
     create_mcp_tools_loaded_event,
@@ -9554,25 +9552,17 @@ class OrchestratorRunner:
                             )
                             await self._event_store.append(progress_event)
 
-                        # Measure and emit drift periodically
-                        if messages_processed % PROGRESS_EMIT_INTERVAL == 0:
-                            # Measure and emit drift
-                            drift_measurement = DriftMeasurement()
-                            drift_metrics = drift_measurement.measure(
-                                current_output=message.content,
-                                constraint_violations=[],  # TODO: track violations
-                                current_concepts=[],  # TODO: extract concepts
-                                seed=seed,
-                            )
-                            drift_event = create_drift_measured_event(
-                                execution_id=exec_id,
-                                goal_drift=drift_metrics.goal_drift,
-                                constraint_drift=drift_metrics.constraint_drift,
-                                ontology_drift=drift_metrics.ontology_drift,
-                                combined_drift=drift_metrics.combined_drift,
-                                is_acceptable=drift_metrics.is_acceptable,
-                            )
-                            await self._event_store.append(drift_event)
+                        # NOTE: periodic drift measurement used to be emitted here
+                        # every PROGRESS_EMIT_INTERVAL messages, but the two inputs
+                        # it needs are not tracked anywhere in this loop. Passing
+                        # empty lists pinned constraint_drift to 0.0 (dropping 30%
+                        # of the weighted score) and ontology_drift to 1.0 (a fixed
+                        # +0.2 penalty), so combined_drift was always
+                        # goal_drift * 0.5 + 0.2 and is_acceptable (<= 0.3) was
+                        # effectively always False. Emitting nothing is preferable
+                        # to persisting a measurement we know is wrong; re-enable
+                        # only once constraint violations and ontology concepts are
+                        # actually tracked for the message being measured.
 
                         # Handle final message
                         if message.is_final:


### PR DESCRIPTION
## Problem

`OrchestratorRunner` measured and emitted drift every `PROGRESS_EMIT_INTERVAL` messages with two hardcoded empty inputs:

```python
drift_metrics = drift_measurement.measure(
    current_output=message.content,
    constraint_violations=[],  # TODO: track violations
    current_concepts=[],       # TODO: extract concepts
    seed=seed,
)
```

Both placeholders are load-bearing:

- `calculate_constraint_drift([])` short-circuits to `0.0`. With `CONSTRAINT_DRIFT_WEIGHT = 0.3`, **30% of the combined score was pinned to zero** — a constraint violation could never raise drift.
- `calculate_ontology_drift([])` hits `if not current_concepts: return 1.0` *before* the seed-ontology comparison. With `ONTOLOGY_DRIFT_WEIGHT = 0.2`, every measurement carried a fixed **+0.2** penalty.

Net: `combined_drift == goal_drift * 0.5 + 0.2`. Since `is_acceptable` requires `<= 0.3` (`DRIFT_THRESHOLD`), passing needed `goal_drift <= 0.2` — i.e. Jaccard word-set similarity >= 0.8 between a single streamed message and the seed goal, which for real prose is effectively never. **Every emitted event reported `is_acceptable=false`.**

This is worse than no signal, because it looks live: `tui/app.py` consumes these events, so the drift panel showed a permanent alarm derived from inputs that measured nothing.

## Fix

Removed the emission rather than fabricating inputs.

I checked whether a real extractor could be wired in instead. It cannot, today:

- No concept extractor exists anywhere in `src/`.
- Nothing in `orchestrator/` tracks constraint violations.
- The only call sites supplying real values are in `mcp/tools/evaluation_handlers.py`, which reads them from caller-provided MCP arguments.

A guard like `if concepts and violations:` would be permanently false at this call site — dead code that reads as if the feature works. Removal states the same behavior honestly, and a comment records the exact distortion plus the precondition for re-enabling.

`calculate_ontology_drift`'s empty-input semantics are deliberately left alone: "output contains zero concepts ⇒ maximal drift" is defensible for a *real* measurement. The defect was fabricating the input, not the function.

## Testing

- `ruff check src/ouroboros/orchestrator/runner.py` — clean
- `pytest tests/unit/observability` — 147 passed
- `pytest tests/unit/observability tests/unit/evolution/test_drift_recording.py` — 150 passed
- No test referenced the removed emission

## Known follow-up (not in this PR)

`evolution/drift_recording.py:25-30` has the identical defect at the generation boundary. Per `crates/ouroboros-tui/src/db.rs:188-192` the Rust TUI queries drift events for *lineage* aggregates, which is that path — so the Rust TUI's drift display is still fed by fabricated inputs. Kept out of this PR to keep the change reviewable; tracked in `backlog.md` as B1/B2.