### PR TITLE
fix(core): release file locks independently of ContextVar reset

### DIFF
--- a/src/ouroboros/core/file_lock.py
+++ b/src/ouroboros/core/file_lock.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from contextlib import contextmanager
-from contextvars import ContextVar
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager, suppress
+from contextvars import ContextVar, Token
 from dataclasses import dataclass
 import errno
 import os
@@ -46,6 +46,60 @@ _DIRECTORY_FD_LOCK_OPEN_SUPPORTED = bool(
 )
 
 
+def _run_release_steps(
+    *steps: Callable[[], None],
+    suppress_errors: bool,
+) -> None:
+    """Attempt every release step, even when an earlier step raises.
+
+    Release work runs inside ``finally`` blocks, where a bare sequence of
+    statements silently breaks two independent guarantees:
+
+    * A step that raises must not skip the remaining steps. Locks, leases and
+      descriptors are separate resources, so failing to unwind one must never
+      leave another one held.
+    * A release failure must not replace an exception raised by the locked
+      body. The body error is what the caller needs in order to diagnose the
+      failure; a bookkeeping error raised on the way out would mask it.
+
+    Callers pass ``suppress_errors=True`` when a body exception is already
+    propagating. Otherwise the first release failure is re-raised once every
+    step has been attempted, so genuine release faults still surface.
+    """
+    first_error: Exception | None = None
+    for step in steps:
+        try:
+            step()
+        except Exception as exc:
+            if first_error is None:
+                first_error = exc
+    if first_error is not None and not suppress_errors:
+        raise first_error
+
+
+def _reset_stable_parent_authority(
+    token: Token[tuple[_StableParentAuthorityLease, ...]],
+) -> None:
+    """Restore the authority stack, tolerating a token from another context.
+
+    ``ContextVar.reset()`` raises ``ValueError`` when the token was created in
+    a different ``Context`` than the one resetting it. That happens whenever a
+    lock is entered and exited under different logical contexts -- for example
+    ``asyncio.to_thread``, an explicit ``contextvars.copy_context().run(...)``,
+    or generator finalization performed by the garbage collector instead of by
+    the frame that entered the lock. ``_StableParentAuthorityLease`` exists
+    precisely to share authority across copied logical contexts, so this is a
+    reachable runtime state and not a programming error.
+
+    A foreign token set no value in *this* context, so this context has nothing
+    to restore, and the lease has already been marked inactive by the caller.
+    Raising here would abort the remaining release steps and mask the caller's
+    real exception, so the failure is deliberately absorbed.
+    """
+    with suppress(ValueError):
+        _HELD_STABLE_PARENT_AUTHORITIES.reset(token)
+
+
 @contextmanager
 def file_lock(
     file_path: Path,
@@ -70,12 +124,21 @@ def file_lock(
         with _open_lockfile(lock_path, parent_fd=parent_fd) as handle:
             _ensure_lockfile_content(handle)
             _acquire_lock(handle, exclusive=exclusive, blocking=blocking)
+            body_failed = True
             try:
                 _validate_active_lockfile(handle, lock_path, directory_fd=authority_fd)
                 yield
                 _validate_active_lockfile(handle, lock_path, directory_fd=authority_fd)
+                body_failed = False
             finally:
-                _release_lock(handle)
+                # Routed through _run_release_steps so that an unlock failure
+                # cannot replace the body's exception. Closing the handle just
+                # below drops the lock regardless, so the caller's error is the
+                # more useful one to propagate.
+                _run_release_steps(
+                    lambda: _release_lock(handle),
+                    suppress_errors=body_failed,
+                )
 
 
 @contextmanager
@@ -200,14 +263,30 @@ def _lock_parent_authority(
         token = _HELD_STABLE_PARENT_AUTHORITIES.set(
             (*(held for held in held_authorities if held.active), lease)
         )
+        body_failed = True
         try:
             _validate_lock_parent_binding(directory_fd, lock_path.parent)
             yield directory_fd
             _validate_lock_parent_binding(directory_fd, lock_path.parent)
+            body_failed = False
         finally:
+            # Do not collapse this back into three plain statements. Each step
+            # has to be attempted independently and in this order:
+            #
+            # 1. Deactivating the lease first makes the authority unusable to
+            #    any copied logical context that can still observe it.
+            # 2. The POSIX lock is released before the ContextVar bookkeeping
+            #    because the reset is the step that can fail on a cross-context
+            #    exit (see _reset_stable_parent_authority). With reset first, a
+            #    ValueError there skipped the release of a real OS-level lock.
+            # 3. Both steps run through _run_release_steps so one failing does
+            #    not skip the other and neither masks the body's exception.
             lease.active = False
-            _HELD_STABLE_PARENT_AUTHORITIES.reset(token)
-            _release_posix_lock(directory_fd)
+            _run_release_steps(
+                lambda: _release_posix_lock(directory_fd),
+                lambda: _reset_stable_parent_authority(token),
+                suppress_errors=body_failed,
+            )
     finally:
         os.close(directory_fd)
 

--- a/tests/unit/core/test_file_lock.py
+++ b/tests/unit/core/test_file_lock.py
@@ -11,7 +11,12 @@ from unittest.mock import MagicMock
 import pytest
 
 import ouroboros.core.file_lock as file_lock_module
-from ouroboros.core.file_lock import _acquire_lock, _release_lock, file_lock
+from ouroboros.core.file_lock import (
+    _acquire_lock,
+    _release_lock,
+    _run_release_steps,
+    file_lock,
+)
 
 
 def test_file_lock_creates_lockfile(tmp_path: Path) -> None:
@@ -109,6 +114,141 @@ def test_copied_context_cannot_reuse_released_parent_authority(tmp_path: Path) -
     with file_lock(current, stable_parent_authority=True):
         with pytest.raises(BlockingIOError):
             stale_context.run(acquire_from_stale_context)
+
+
+def _enter_in_copied_context(manager: object) -> None:
+    """Enter a context manager under a copied context, as asyncio.to_thread does."""
+    copy_context().run(manager.__enter__)  # type: ignore[attr-defined]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX stable-parent authority only")
+def test_cross_context_exit_releases_authority_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A lock entered and exited in different contexts must still unwind cleanly.
+
+    ContextVar tokens are context-bound, so resetting one from a foreign context
+    raises ValueError. That must neither surface to the caller nor skip the
+    explicit release of the parent authority lock.
+    """
+    target = tmp_path / "state.json"
+    released: list[int] = []
+    original_release = file_lock_module._release_posix_lock
+
+    def record_release(file_descriptor: int) -> None:
+        released.append(file_descriptor)
+        original_release(file_descriptor)
+
+    monkeypatch.setattr(file_lock_module, "_release_posix_lock", record_release)
+
+    manager = file_lock(target, stable_parent_authority=True)
+    _enter_in_copied_context(manager)
+
+    assert manager.__exit__(None, None, None) in {None, False}
+    # Both the lockfile lock and the parent authority lock are released
+    # explicitly; before the fix the parent release was skipped entirely.
+    assert len(released) == 2
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX stable-parent authority only")
+def test_cross_context_exit_does_not_mask_body_exception(tmp_path: Path) -> None:
+    """A foreign-context token must not replace the caller's real exception."""
+    target = tmp_path / "state.json"
+
+    manager = file_lock(target, stable_parent_authority=True)
+    _enter_in_copied_context(manager)
+
+    body_error = RuntimeError("the caller's real failure")
+    handled = manager.__exit__(type(body_error), body_error, body_error.__traceback__)
+
+    # Exiting must not raise on its own, and must not claim to have handled the
+    # body error -- the caller keeps propagating its own exception.
+    assert not handled
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX stable-parent authority only")
+def test_cross_context_exit_leaves_authority_reacquirable(tmp_path: Path) -> None:
+    """After a cross-context exit the parent authority must be free again."""
+    target = tmp_path / "state.json"
+    contender = tmp_path / "contender.json"
+
+    manager = file_lock(target, stable_parent_authority=True)
+    _enter_in_copied_context(manager)
+    manager.__exit__(None, None, None)
+
+    with file_lock(contender, blocking=False, stable_parent_authority=True):
+        pass
+
+
+def test_release_failure_does_not_mask_body_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "state.json"
+
+    def failing_release(handle: object) -> None:
+        raise OSError(errno.EBADF, "bad descriptor")
+
+    monkeypatch.setattr(file_lock_module, "_release_lock", failing_release)
+
+    with pytest.raises(RuntimeError, match="the caller's real failure"):
+        with file_lock(target):
+            raise RuntimeError("the caller's real failure")
+
+
+def test_release_failure_surfaces_when_body_succeeded(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Suppression is scoped to masking only; a lone release fault still raises."""
+    target = tmp_path / "state.json"
+
+    def failing_release(handle: object) -> None:
+        raise OSError(errno.EBADF, "bad descriptor")
+
+    monkeypatch.setattr(file_lock_module, "_release_lock", failing_release)
+
+    with pytest.raises(OSError) as raised:
+        with file_lock(target):
+            pass
+
+    assert raised.value.errno == errno.EBADF
+
+
+def test_run_release_steps_attempts_every_step_and_reraises_first_error() -> None:
+    attempted: list[str] = []
+
+    def first() -> None:
+        attempted.append("first")
+        raise OSError(errno.EBADF, "first failed")
+
+    def second() -> None:
+        attempted.append("second")
+        raise ValueError("second failed")
+
+    def third() -> None:
+        attempted.append("third")
+
+    with pytest.raises(OSError, match="first failed"):
+        _run_release_steps(first, second, third, suppress_errors=False)
+
+    assert attempted == ["first", "second", "third"]
+
+
+def test_run_release_steps_suppresses_errors_for_a_failing_body() -> None:
+    attempted: list[str] = []
+
+    def failing() -> None:
+        attempted.append("failing")
+        raise OSError(errno.EBADF, "release failed")
+
+    def following() -> None:
+        attempted.append("following")
+
+    _run_release_steps(failing, following, suppress_errors=True)
+
+    assert attempted == ["failing", "following"]
 
 
 def test_file_lock_windows_nonblocking_uses_fail_fast_mode(


### PR DESCRIPTION
## Problem

In `_lock_parent_authority`, the cleanup block ran three statements in sequence where the middle one can raise:

```python
finally:
    lease.active = False
    _HELD_STABLE_PARENT_AUTHORITIES.reset(token)   # can raise ValueError
    _release_posix_lock(directory_fd)              # then skipped
```

`ContextVar.reset(token)` raises `ValueError: <Token ...> was created in a different Context` when `.set()` and `.reset()` happen in different contexts — `asyncio.to_thread`, `contextvars.copy_context()`, or generator finalization by GC rather than by the entering frame. The `_StableParentAuthorityLease` docstring explicitly anticipates copied logical contexts, so this is reachable by design, not by misuse.

Reproduced with a throwaway harness entering via `copy_context().run(cm.__enter__)` and exiting in the outer context:

- `ValueError` escaped `__exit__`
- only **1 of 2** expected `_release_posix_lock` calls happened
- a body `RuntimeError` was **replaced** by the `ValueError`

The outer `os.close(directory_fd)` does drop the flock (closing an fd releases it), so there is no permanent OS-level leak — but the explicit release is bypassed and the caller's real error is masked by an opaque `ValueError`.

## Fix

Two module-level helpers:

- **`_run_release_steps(*steps, suppress_errors)`** — attempts every release step even if an earlier one raises, records the first `Exception`, and re-raises it only when `suppress_errors=False`. Callers pass `suppress_errors=True` when a body exception is already propagating, so cleanup never masks the caller's error, while a *lone* release fault on a clean body still surfaces.
- **`_reset_stable_parent_authority(token)`** — the `reset` wrapped in `contextlib.suppress(ValueError)`, documented: a foreign-context token set no value in *this* context, so there is nothing to restore and raising would only mask the caller's error.

`_lock_parent_authority`'s finally now releases the **flock before** the ContextVar bookkeeping, since the reset is the step that can fail. A numbered comment states the required ordering and warns against collapsing it back into three plain statements.

`file_lock`'s `finally: _release_lock(handle)` got the same non-masking treatment — it can raise `OSError`/`msvcrt` errors, and the handle close immediately after drops the lock regardless, so the body error is the more useful one to propagate.

Both sites use a `body_failed` flag cleared only after post-yield validation succeeds — no `sys.exc_info()` guessing, and `GeneratorExit` correctly counts as a failed body.

## Testing

7 new tests in `tests/unit/core/test_file_lock.py`:

- cross-context exit does not raise and performs **both** explicit releases (spies on `_release_posix_lock`)
- cross-context exit does not mask a body exception
- authority is reacquirable afterwards (non-blocking)
- release failure does not mask a body exception / does surface when the body succeeded
- two unit tests for `_run_release_steps` itself

Regression value verified by temporarily reverting only the buggy `finally`: the three cross-context tests failed with the original `ValueError`, then passed once restored.

- `pytest tests/unit/core -k lock` — all pass
- `ruff check` clean · `ruff format --check` already formatted · `mypy` clean

## Left alone deliberately

`os.close(directory_fd)` in the outer `finally` can theoretically raise `EBADF` and mask a body exception too. Kept out of scope to keep this change focused on the release paths; worth a follow-up for full consistency.