### PR TITLE
fix(core): make is_on_protected_branch fail closed

### DIFF
--- a/src/ouroboros/core/git_workflow.py
+++ b/src/ouroboros/core/git_workflow.py
@@ -11,6 +11,10 @@ from dataclasses import dataclass
 from pathlib import Path
 import re
 
+import structlog
+
+log = structlog.get_logger()
+
 
 @dataclass(frozen=True, slots=True)
 class GitWorkflowConfig:
@@ -114,14 +118,34 @@ def detect_git_workflow(project_root: Path) -> GitWorkflowConfig:
 
 
 def is_on_protected_branch(project_root: Path, config: GitWorkflowConfig) -> bool:
-    """Check if the current git branch is protected.
+    """Check whether the current git branch must be treated as protected.
+
+    This is a safety guard whose only purpose is to stop automation from
+    committing to a branch the user declared off-limits. It therefore **fails
+    closed**: whenever the branch cannot be positively determined, the branch
+    is reported as protected so that automation declines to commit.
+
+    Returns ``True`` when:
+
+    * git reports a branch listed in ``config.protected_branches``;
+    * HEAD is detached -- ``git rev-parse --abbrev-ref HEAD`` prints the
+      literal ``HEAD`` and exits 0 -- because an automated commit there would
+      not be reachable from any branch;
+    * the branch cannot be determined at all: git is missing, the call times
+      out, ``project_root`` is not a git repository, git exits non-zero, or
+      git returns empty output. Each of these is logged as a warning with the
+      reason.
+
+    Returns ``False`` only when git successfully reports a concrete branch name
+    that is not in ``config.protected_branches``.
 
     Args:
         project_root: Root directory of the project.
         config: Git workflow configuration.
 
     Returns:
-        True if on a protected branch.
+        True if the branch is protected or could not be determined, False only
+        when git confirms a concrete non-protected branch.
     """
     import subprocess  # noqa: S404
 
@@ -133,10 +157,60 @@ def is_on_protected_branch(project_root: Path, config: GitWorkflowConfig) -> boo
             cwd=project_root,
             timeout=5,
         )
-        if result.returncode == 0:
-            current_branch = result.stdout.strip()
-            return current_branch in config.protected_branches
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        pass
+    except subprocess.TimeoutExpired:
+        log.warning(
+            "git_workflow.protected_branch_undetermined",
+            project_root=str(project_root),
+            reason="timeout",
+            detail="git rev-parse did not complete within 5s",
+            fail_closed=True,
+        )
+        return True
+    except OSError as exc:
+        # Covers FileNotFoundError (git not installed, or project_root does
+        # not exist) and other OS-level failures spawning the subprocess.
+        log.warning(
+            "git_workflow.protected_branch_undetermined",
+            project_root=str(project_root),
+            reason="git_spawn_failed",
+            detail=f"{type(exc).__name__}: {exc}",
+            project_root_exists=project_root.is_dir(),
+            fail_closed=True,
+        )
+        return True
 
-    return False
+    if result.returncode != 0:
+        # Most commonly: project_root is not a git repository.
+        log.warning(
+            "git_workflow.protected_branch_undetermined",
+            project_root=str(project_root),
+            reason="git_error",
+            returncode=result.returncode,
+            detail=(result.stderr or "").strip()[:200],
+            fail_closed=True,
+        )
+        return True
+
+    current_branch = result.stdout.strip()
+
+    if not current_branch:
+        log.warning(
+            "git_workflow.protected_branch_undetermined",
+            project_root=str(project_root),
+            reason="empty_output",
+            detail="git rev-parse succeeded but reported no branch name",
+            fail_closed=True,
+        )
+        return True
+
+    if current_branch == "HEAD":
+        log.warning(
+            "git_workflow.protected_branch_undetermined",
+            project_root=str(project_root),
+            reason="detached_head",
+            detail="HEAD is detached; automated commits would be unreachable",
+            fail_closed=True,
+        )
+        return True
+
+    return current_branch in config.protected_branches

--- a/tests/unit/core/test_git_workflow.py
+++ b/tests/unit/core/test_git_workflow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import subprocess
 from unittest.mock import patch
 
 from ouroboros.core.git_workflow import (
@@ -146,7 +147,7 @@ class TestIsOnProtectedBranch:
         assert result is True
 
     def test_on_feature_branch(self, tmp_path: Path) -> None:
-        """Returns False when on a feature branch."""
+        """Returns False only when git confirms a concrete non-protected branch."""
         config = GitWorkflowConfig(use_branches=True, protected_branches=("main", "master"))
 
         with patch("subprocess.run") as mock_run:
@@ -158,10 +159,73 @@ class TestIsOnProtectedBranch:
         assert result is False
 
     def test_git_not_available(self, tmp_path: Path) -> None:
-        """Returns False when git is not available."""
+        """Fails closed (True) when git is not installed."""
         config = GitWorkflowConfig(use_branches=True)
 
         with patch("subprocess.run", side_effect=FileNotFoundError):
             result = is_on_protected_branch(tmp_path, config)
 
-        assert result is False
+        assert result is True
+
+    def test_git_timeout(self, tmp_path: Path) -> None:
+        """Fails closed (True) when the git call times out."""
+        config = GitWorkflowConfig(use_branches=True)
+
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="git", timeout=5),
+        ):
+            result = is_on_protected_branch(tmp_path, config)
+
+        assert result is True
+
+    def test_os_error(self, tmp_path: Path) -> None:
+        """Fails closed (True) on OS-level failures reaching project_root."""
+        config = GitWorkflowConfig(use_branches=True)
+
+        with patch("subprocess.run", side_effect=OSError("cwd is gone")):
+            result = is_on_protected_branch(tmp_path, config)
+
+        assert result is True
+
+    def test_not_a_git_repository(self, tmp_path: Path) -> None:
+        """Fails closed (True) when git exits non-zero, e.g. not a repo."""
+        config = GitWorkflowConfig(use_branches=True, protected_branches=("main", "master"))
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 128
+            mock_run.return_value.stdout = ""
+            mock_run.return_value.stderr = "fatal: not a git repository"
+
+            result = is_on_protected_branch(tmp_path, config)
+
+        assert result is True
+
+    def test_detached_head(self, tmp_path: Path) -> None:
+        """Fails closed (True) on detached HEAD.
+
+        ``git rev-parse --abbrev-ref HEAD`` exits 0 and prints the literal
+        "HEAD" when detached, so this would otherwise be read as a normal
+        non-protected branch name.
+        """
+        config = GitWorkflowConfig(use_branches=True, protected_branches=("main", "master"))
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = "HEAD\n"
+
+            result = is_on_protected_branch(tmp_path, config)
+
+        assert result is True
+
+    def test_empty_branch_output(self, tmp_path: Path) -> None:
+        """Fails closed (True) when git reports success but no branch name."""
+        config = GitWorkflowConfig(use_branches=True, protected_branches=("main", "master"))
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = "  \n"
+
+            result = is_on_protected_branch(tmp_path, config)
+
+        assert result is True


### PR DESCRIPTION
## Problem

`is_on_protected_branch` exists for one reason: to stop automation from committing to `main`. It returned `False` — "not protected, go ahead" — on every failure path:

```python
try:
    result = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], ..., timeout=5)
    if result.returncode == 0:
        return result.stdout.strip() in config.protected_branches
except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
    pass
return False
```

Git missing, git timing out, cwd not a repo, or git exiting non-zero all produced "safe to commit". That is fail-**open** on a safety guard.

There was also a second, undiagnosed fail-open path. I probed real git rather than assuming: on a detached HEAD, `git rev-parse --abbrev-ref HEAD` prints the literal `HEAD` **and exits 0**. So it reached the membership test, `"HEAD" in ("main", "master")` → `False`. Committing to a detached HEAD from automation is not safe either.

## Fix

`True` (treat as protected) whenever branch state cannot be determined. `False` is now returned **only** when git exits 0 and reports a concrete branch name absent from `protected_branches`.

The blanket `except: pass` is split into explicit branches, each logging `log.warning("git_workflow.protected_branch_undetermined", reason=...)`:

| `reason` | Trigger | Extra context |
| :--- | :--- | :--- |
| `timeout` | `TimeoutExpired` (5s) | — |
| `git_spawn_failed` | `OSError`/`FileNotFoundError` | `project_root_exists` distinguishes a missing dir from a missing git binary |
| `git_error` | non-zero exit (typically not a repo) | `returncode`, stderr trimmed to 200 chars |
| `empty_output` | exit 0, no branch name | — |
| `detached_head` | output is `HEAD` | — |

Added a `structlog` logger, matching sibling `core/` modules (`worktree.py`, `pm_snapshot.py`, `context.py`). Docstring rewritten to state the fail-closed contract and enumerate both outcomes.

## Caller analysis

No production callers. The only references are `core/__init__.py:133` (a lazy-export table entry, not a call) and the test module. I also grepped `protected_branch`, `detect_git_workflow`, and `GitWorkflowConfig` to catch indirect use — the module has no internal consumers yet, though it is public API via `ouroboros.core`.

No caller inverts the boolean (`if not is_on_protected_branch(...)`), so the flip cannot break a legitimate flow. Nothing needs "unknown" distinguished from "protected", so a plain `bool` remains the right shape — the `reason` field carries the diagnostic detail that would otherwise argue for a tri-state.

## One test asserted the old behavior

`test_git_not_available` asserted `result is False` when git is missing — encoding the fail-open bug. Flipped to `is True`. Added 5 regression tests (timeout, `OSError`, non-zero exit, detached HEAD, empty output) and tightened `test_on_feature_branch` to record that `False` is still genuinely reachable.

## Testing

- `pytest tests/unit/core -k git_workflow` — 20 passed
- `ruff check` and `mypy` clean
- Verified end-to-end against **real git** in a throwaway repo, not only mocks: on `main` → True, on `feature/x` → False, detached HEAD → True, non-repo → True, nonexistent cwd → True, each with the expected warning