### PR TITLE
fix(seed): close four validation gaps in the Seed schema

### DIFF
--- a/src/ouroboros/core/seed.py
+++ b/src/ouroboros/core/seed.py
@@ -879,16 +879,18 @@ class Seed(BaseModel, frozen=True):
         """
         if not isinstance(value, str):
             return value
-        normalized = value.strip().lower()
+        # Late import to avoid circular dependency (core -> orchestrator).
+        from ouroboros.orchestrator.execution_strategy import (
+            _canonicalize_task_type,
+            is_registered_task_type,
+        )
+
+        normalized = _canonicalize_task_type(value)
         if not normalized:
             msg = "task_type must be a non-empty string"
             raise ValueError(msg)
         if normalized in BUILTIN_TASK_TYPES:
             return normalized
-        # Late import to avoid circular dependency (core -> orchestrator).
-        from ouroboros.orchestrator.execution_strategy import (
-            is_registered_task_type,
-        )
 
         if is_registered_task_type(normalized):
             return normalized

--- a/src/ouroboros/core/seed.py
+++ b/src/ouroboros/core/seed.py
@@ -364,6 +364,18 @@ class BrownfieldContext(BaseModel, frozen=True):
     )
 
 
+_DEFAULT_GENERATION_MODE = "normal"
+"""``SeedMetadata.generation_mode`` for the legacy ledger-complete path."""
+
+_PARTIAL_SEED_GENERATION_MODE = "partial_seed_from_evidence"
+"""``SeedMetadata.generation_mode`` for incomplete-ledger recovery Seeds.
+
+Mirrors ``ouroboros.auto.ledger_seed.PARTIAL_SEED_GENERATION_MODE``; duplicated
+here because ``ledger_seed`` imports this module. The two are pinned equal by a
+regression test.
+"""
+
+
 class SeedMetadata(BaseModel, frozen=True):
     """Metadata about the Seed generation.
 
@@ -409,11 +421,45 @@ class SeedMetadata(BaseModel, frozen=True):
     ambiguity_score: float = Field(default=0.15, ge=0.0, le=1.0)
     interview_id: str | None = Field(default=None)
     parent_seed_id: str | None = Field(default=None)
-    generation_mode: str = Field(default="normal", min_length=1)
+    generation_mode: str = Field(default=_DEFAULT_GENERATION_MODE, min_length=1)
     degraded: bool = Field(default=False)
     unresolved_slots: tuple[str, ...] = Field(default_factory=tuple)
     recovery_reason: str | None = Field(default=None)
     decision_provenance: dict[str, int] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_recovery_invariants(self) -> SeedMetadata:
+        """Enforce the degraded-provenance invariants stated in the docstring.
+
+        Without these checks a Seed synthesized on a recovery path could carry
+        ``degraded`` unset and still pass the run gate, auto-RUNning a partial
+        product — the exact outcome the field exists to prevent. Also freezes
+        ``decision_provenance`` so the only mutable collection on this
+        ``frozen=True`` model cannot be edited in place.
+        """
+        if self.degraded and self.generation_mode == _DEFAULT_GENERATION_MODE:
+            raise ValueError(
+                "degraded seeds must declare a non-default generation_mode "
+                f"(got {_DEFAULT_GENERATION_MODE!r})"
+            )
+        if (
+            self.degraded
+            and self.generation_mode == _PARTIAL_SEED_GENERATION_MODE
+            and not self.unresolved_slots
+        ):
+            raise ValueError(
+                f"generation_mode {_PARTIAL_SEED_GENERATION_MODE!r} with degraded=True "
+                "requires at least one unresolved_slots entry"
+            )
+        if self.unresolved_slots and not self.degraded:
+            raise ValueError("unresolved_slots requires degraded=True")
+        if not isinstance(self.decision_provenance, _FrozenDict):
+            object.__setattr__(
+                self,
+                "decision_provenance",
+                _FrozenDict(self.decision_provenance),
+            )
+        return self
 
     @model_serializer(mode="wrap")
     def _serialize(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
@@ -432,6 +478,21 @@ class SeedMetadata(BaseModel, frozen=True):
 InvestmentLevel = Literal["low", "medium", "high"]
 InvestmentProvenance = Literal["declared", "measured", "inferred", "absent"]
 InvestmentConfidence = Literal["low", "medium", "high"]
+
+TaskType = Literal[
+    "code",
+    "research",
+    "analysis",
+    "artifact",
+    "document",
+    "documentation",
+    "presentation",
+]
+"""Closed set of execution task types.
+
+Must stay in sync with ``ouroboros.orchestrator.execution_strategy``'s strategy
+registry keys; a typo previously validated and silently rerouted execution.
+"""
 
 
 class InvestmentSpec(BaseModel, frozen=True):
@@ -457,7 +518,7 @@ class AcceptanceCriterionSpec(BaseModel, frozen=True):
     execution verifier resolves every entry literally and requires it to exist.
     """
 
-    description: str
+    description: str = Field(..., min_length=1)
     semantic_ac_key: str | None = Field(default=None, pattern=r"^ac_[a-f0-9]{16}$")
     verify_command: str | None = Field(default=None)
     expected_artifacts: tuple[str, ...] = Field(
@@ -508,8 +569,22 @@ class AcceptanceCriterionSpec(BaseModel, frozen=True):
     @field_validator("description", mode="before")
     @classmethod
     def _strip_description(cls, value: Any) -> Any:
+        """Normalize and reject blank criterion text.
+
+        ``description`` is the only input to :func:`derive_semantic_ac_key` for
+        legacy string ACs and the dominant term for structured ones, so a
+        whitespace-only value would collapse every such criterion onto one
+        identical ``semantic_ac_key`` and cross-contaminate AC-keyed retry and
+        successor state. Mirrors ``Seed.goal``'s ``min_length=1`` while
+        producing a message that names the field.
+        """
         if isinstance(value, str):
-            return value.strip()
+            stripped = value.strip()
+            if not stripped:
+                raise ValueError(
+                    "acceptance criterion description cannot be empty or whitespace-only"
+                )
+            return stripped
         return value
 
     @field_validator("verify_exemption_reason", mode="before")
@@ -734,7 +809,7 @@ class Seed(BaseModel, frozen=True):
     model_config = {"extra": "allow"}
 
     goal: str = Field(..., min_length=1, description="Primary objective of the workflow")
-    task_type: str = Field(
+    task_type: TaskType = Field(
         default="code",
         description=(
             "Type of task execution: 'code', 'research', 'analysis', "
@@ -777,6 +852,19 @@ class Seed(BaseModel, frozen=True):
         ...,
         description="Generation metadata (version, timestamp, etc.)",
     )
+
+    @field_validator("task_type", mode="before")
+    @classmethod
+    def _normalize_task_type(cls, value: Any) -> Any:
+        """Fold case and surrounding whitespace for hand-authored seeds.
+
+        ``execution_strategy.get_strategy`` has always lower-cased its lookup,
+        so ``task_type: Code`` in a YAML seed used to route correctly. Keep that
+        tolerance while the ``Literal`` closes the typo hole.
+        """
+        if isinstance(value, str):
+            return value.strip().lower()
+        return value
 
     @field_validator("evaluation_principles", mode="before")
     @classmethod

--- a/src/ouroboros/core/seed.py
+++ b/src/ouroboros/core/seed.py
@@ -479,19 +479,31 @@ InvestmentLevel = Literal["low", "medium", "high"]
 InvestmentProvenance = Literal["declared", "measured", "inferred", "absent"]
 InvestmentConfidence = Literal["low", "medium", "high"]
 
-TaskType = Literal[
-    "code",
-    "research",
-    "analysis",
-    "artifact",
-    "document",
-    "documentation",
-    "presentation",
-]
-"""Closed set of execution task types.
+BUILTIN_TASK_TYPES: frozenset[str] = frozenset(
+    {
+        "code",
+        "research",
+        "analysis",
+        "artifact",
+        "document",
+        "documentation",
+        "presentation",
+    }
+)
+"""Built-in execution task types.
 
-Must stay in sync with ``ouroboros.orchestrator.execution_strategy``'s strategy
-registry keys; a typo previously validated and silently rerouted execution.
+Typos against these values are rejected unconditionally.  Custom identifiers
+registered via ``register_strategy()`` are also accepted so the Seed schema
+stays compatible with the documented pluggable strategy contract.
+"""
+
+TaskType = str
+"""Execution task type identifier.
+
+Built-in values are the seven keys in :data:`BUILTIN_TASK_TYPES`.  Additional
+identifiers are valid if and only if they have been registered via
+``ouroboros.orchestrator.execution_strategy.register_strategy`` before Seed
+construction.
 """
 
 
@@ -812,8 +824,9 @@ class Seed(BaseModel, frozen=True):
     task_type: TaskType = Field(
         default="code",
         description=(
-            "Type of task execution: 'code', 'research', 'analysis', "
-            "'artifact', 'document', 'documentation', or 'presentation'"
+            "Execution strategy identifier. Built-in types: 'code', 'research', "
+            "'analysis', 'artifact', 'document', 'documentation', 'presentation'. "
+            "Custom identifiers are accepted if registered via register_strategy()."
         ),
     )
     brownfield_context: BrownfieldContext = Field(
@@ -856,15 +869,37 @@ class Seed(BaseModel, frozen=True):
     @field_validator("task_type", mode="before")
     @classmethod
     def _normalize_task_type(cls, value: Any) -> Any:
-        """Fold case and surrounding whitespace for hand-authored seeds.
+        """Normalize and validate task_type against the strategy registry.
 
-        ``execution_strategy.get_strategy`` has always lower-cased its lookup,
-        so ``task_type: Code`` in a YAML seed used to route correctly. Keep that
-        tolerance while the ``Literal`` closes the typo hole.
+        Folds case and surrounding whitespace for hand-authored seeds, then
+        rejects identifiers that are neither a built-in task type nor a
+        dynamically registered custom strategy.  This preserves typo rejection
+        for the seven built-in types while honouring the documented
+        ``register_strategy()`` extension contract.
         """
-        if isinstance(value, str):
-            return value.strip().lower()
-        return value
+        if not isinstance(value, str):
+            return value
+        normalized = value.strip().lower()
+        if not normalized:
+            msg = "task_type must be a non-empty string"
+            raise ValueError(msg)
+        if normalized in BUILTIN_TASK_TYPES:
+            return normalized
+        # Late import to avoid circular dependency (core -> orchestrator).
+        from ouroboros.orchestrator.execution_strategy import (
+            is_registered_task_type,
+        )
+
+        if is_registered_task_type(normalized):
+            return normalized
+        valid = ", ".join(sorted(BUILTIN_TASK_TYPES))
+        msg = (
+            f"Unknown task_type: {value!r}. "
+            f"Built-in types: {valid}. "
+            f"Custom types must be registered via register_strategy() "
+            f"before Seed construction."
+        )
+        raise ValueError(msg)
 
     @field_validator("evaluation_principles", mode="before")
     @classmethod

--- a/src/ouroboros/orchestrator/execution_strategy.py
+++ b/src/ouroboros/orchestrator/execution_strategy.py
@@ -189,6 +189,16 @@ _STRATEGY_REGISTRY: dict[str, ExecutionStrategy] = {
 }
 
 
+def _canonicalize_task_type(task_type: str) -> str:
+    """Canonicalize a task type identifier: strip surrounding whitespace, then lower-case.
+
+    This is the single authoritative normalization used at registration, lookup,
+    and validation boundaries so that ``register_strategy("  Foo  ", s)`` and
+    ``get_strategy("foo")`` always agree.
+    """
+    return task_type.strip().lower()
+
+
 def get_strategy(task_type: str = "code") -> ExecutionStrategy:
     """Get execution strategy for a task type.
 
@@ -202,7 +212,7 @@ def get_strategy(task_type: str = "code") -> ExecutionStrategy:
     Raises:
         ValueError: If task_type is not recognized.
     """
-    strategy = _STRATEGY_REGISTRY.get(task_type.lower())
+    strategy = _STRATEGY_REGISTRY.get(_canonicalize_task_type(task_type))
     if strategy is None:
         valid = ", ".join(sorted(_STRATEGY_REGISTRY.keys()))
         msg = f"Unknown task_type: {task_type!r}. Valid types: {valid}"
@@ -217,7 +227,7 @@ def register_strategy(task_type: str, strategy: ExecutionStrategy) -> None:
         task_type: Type identifier for the strategy.
         strategy: ExecutionStrategy instance.
     """
-    _STRATEGY_REGISTRY[task_type.lower()] = strategy
+    _STRATEGY_REGISTRY[_canonicalize_task_type(task_type)] = strategy
 
 
 def is_registered_task_type(task_type: str) -> bool:
@@ -226,7 +236,7 @@ def is_registered_task_type(task_type: str) -> bool:
     This is the shared validation contract used by :class:`~ouroboros.core.seed.Seed`
     to accept both built-in and dynamically registered custom strategy identifiers.
     """
-    return task_type.lower() in _STRATEGY_REGISTRY
+    return _canonicalize_task_type(task_type) in _STRATEGY_REGISTRY
 
 
 __all__ = [
@@ -235,6 +245,7 @@ __all__ = [
     "CodeStrategy",
     "ExecutionStrategy",
     "ResearchStrategy",
+    "_canonicalize_task_type",
     "get_strategy",
     "is_registered_task_type",
     "register_strategy",

--- a/src/ouroboros/orchestrator/execution_strategy.py
+++ b/src/ouroboros/orchestrator/execution_strategy.py
@@ -220,6 +220,15 @@ def register_strategy(task_type: str, strategy: ExecutionStrategy) -> None:
     _STRATEGY_REGISTRY[task_type.lower()] = strategy
 
 
+def is_registered_task_type(task_type: str) -> bool:
+    """Return whether *task_type* is known to the strategy registry.
+
+    This is the shared validation contract used by :class:`~ouroboros.core.seed.Seed`
+    to accept both built-in and dynamically registered custom strategy identifiers.
+    """
+    return task_type.lower() in _STRATEGY_REGISTRY
+
+
 __all__ = [
     "AnalysisStrategy",
     "ArtifactStrategy",
@@ -227,5 +236,6 @@ __all__ = [
     "ExecutionStrategy",
     "ResearchStrategy",
     "get_strategy",
+    "is_registered_task_type",
     "register_strategy",
 ]

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -597,5 +597,8 @@ class TestWorkflowIRCommands:
 
         result = runner.invoke(app, ["workflow-ir", "inspect", str(seed_file), "--json"])
 
+        # The blank-AC boundary is enforced by the Seed schema itself, so the
+        # command now fails during seed load rather than in the IR adapter.
         assert result.exit_code == 1
-        assert "must be non-blank" in result.output
+        assert "Workflow IR inspection failed" in result.output
+        assert "acceptance_criteria.0.description" in result.output

--- a/tests/unit/core/test_seed.py
+++ b/tests/unit/core/test_seed.py
@@ -1320,14 +1320,12 @@ class TestSeedTaskType:
 
         assert seed.task_type == task_type
 
-    def test_every_task_type_resolves_to_a_strategy(self) -> None:
-        """The literal set may not drift from the strategy registry."""
-        from typing import get_args
-
-        from ouroboros.core.seed import TaskType
+    def test_every_builtin_task_type_resolves_to_a_strategy(self) -> None:
+        """The built-in set may not drift from the strategy registry."""
+        from ouroboros.core.seed import BUILTIN_TASK_TYPES
         from ouroboros.orchestrator.execution_strategy import get_strategy
 
-        for task_type in get_args(TaskType):
+        for task_type in BUILTIN_TASK_TYPES:
             assert get_strategy(task_type) is not None
 
     @pytest.mark.parametrize("bad", ["cod", "Coding", "codee", "", "test"])
@@ -1349,3 +1347,83 @@ class TestSeedTaskType:
         )
 
         assert seed.task_type == "research"
+
+    def test_registered_custom_strategy_accepted_in_seed(self) -> None:
+        """A dynamically registered custom strategy passes Seed validation.
+
+        Regression for the blocker: static Literal broke register_strategy().
+        """
+        from ouroboros.orchestrator.execution_strategy import (
+            _STRATEGY_REGISTRY,
+            register_strategy,
+        )
+        from ouroboros.orchestrator.workflow_state import ActivityType
+
+        class _TestCustomStrategy:
+            def get_tools(self) -> list[str]:
+                return ["Read"]
+
+            def get_system_prompt_fragment(self) -> str:
+                return "custom"
+
+            def get_task_prompt_suffix(self) -> str:
+                return "custom"
+
+            def get_activity_map(self) -> dict[str, ActivityType]:
+                return {"Read": ActivityType.EXPLORING}
+
+        register_strategy("my_plugin_task", _TestCustomStrategy())
+        try:
+            seed = Seed(
+                goal="Custom strategy test",
+                task_type="my_plugin_task",
+                ontology_schema=OntologySchema(name="T", description="T"),
+                metadata=SeedMetadata(ambiguity_score=0.1),
+            )
+            assert seed.task_type == "my_plugin_task"
+        finally:
+            # Clean up to avoid polluting other tests.
+            _STRATEGY_REGISTRY.pop("my_plugin_task", None)
+
+    def test_registered_custom_strategy_case_normalized(self) -> None:
+        """Custom strategies are normalized like built-ins."""
+        from ouroboros.orchestrator.execution_strategy import (
+            _STRATEGY_REGISTRY,
+            register_strategy,
+        )
+        from ouroboros.orchestrator.workflow_state import ActivityType
+
+        class _TestCustomStrategy:
+            def get_tools(self) -> list[str]:
+                return ["Read"]
+
+            def get_system_prompt_fragment(self) -> str:
+                return "custom"
+
+            def get_task_prompt_suffix(self) -> str:
+                return "custom"
+
+            def get_activity_map(self) -> dict[str, ActivityType]:
+                return {"Read": ActivityType.EXPLORING}
+
+        register_strategy("my_plugin", _TestCustomStrategy())
+        try:
+            seed = Seed(
+                goal="Custom strategy case test",
+                task_type="  My_Plugin  ",
+                ontology_schema=OntologySchema(name="T", description="T"),
+                metadata=SeedMetadata(ambiguity_score=0.1),
+            )
+            assert seed.task_type == "my_plugin"
+        finally:
+            _STRATEGY_REGISTRY.pop("my_plugin", None)
+
+    def test_unregistered_custom_identifier_rejected(self) -> None:
+        """An identifier that is neither built-in nor registered is rejected."""
+        with pytest.raises(PydanticValidationError):
+            Seed(
+                goal="Test goal",
+                task_type="never_registered_xyz",
+                ontology_schema=OntologySchema(name="T", description="T"),
+                metadata=SeedMetadata(ambiguity_score=0.1),
+            )

--- a/tests/unit/core/test_seed.py
+++ b/tests/unit/core/test_seed.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError as PydanticValidationError
 import pytest
 
 from ouroboros.core.seed import (
+    _PARTIAL_SEED_GENERATION_MODE,
     MAX_AC_SUCCESS_CONTRACT_ARTIFACT_CHARS,
     MAX_AC_SUCCESS_CONTRACT_ARTIFACT_PATH_BYTES,
     MAX_AC_SUCCESS_CONTRACT_ARTIFACTS,
@@ -24,6 +25,7 @@ from ouroboros.core.seed import (
     Seed,
     SeedMetadata,
     ac_texts,
+    derive_semantic_ac_key,
     expected_artifact_path_error,
     expected_artifact_workspace_path_error,
     parse_expected_artifact_list,
@@ -98,6 +100,104 @@ class TestSeedMetadata:
 
         with pytest.raises(PydanticValidationError):
             metadata.ambiguity_score = 0.20  # type: ignore[misc]
+
+
+class TestSeedMetadataRecoveryInvariants:
+    """Regression tests for the degraded-provenance invariants (#1257 / #1302).
+
+    The docstring on ``SeedMetadata`` has always documented these invariants;
+    before this suite existed no validator enforced them, so a recovery-path
+    Seed with ``degraded`` unset could pass the run gate and auto-RUN a partial
+    product.
+    """
+
+    def test_degraded_requires_non_default_generation_mode(self) -> None:
+        with pytest.raises(PydanticValidationError, match="non-default generation_mode"):
+            SeedMetadata(degraded=True)
+
+    def test_degraded_partial_mode_requires_unresolved_slots(self) -> None:
+        with pytest.raises(PydanticValidationError, match="unresolved_slots entry"):
+            SeedMetadata(
+                degraded=True,
+                generation_mode="partial_seed_from_evidence",
+                unresolved_slots=(),
+            )
+
+    def test_unresolved_slots_require_degraded(self) -> None:
+        """A partial Seed cannot hide its partiality by leaving ``degraded`` unset."""
+        with pytest.raises(PydanticValidationError, match="unresolved_slots requires degraded"):
+            SeedMetadata(
+                degraded=False,
+                generation_mode="partial_seed_from_evidence",
+                unresolved_slots=("acceptance_criteria",),
+            )
+
+    def test_degraded_partial_seed_with_slots_is_accepted(self) -> None:
+        metadata = SeedMetadata(
+            degraded=True,
+            generation_mode="partial_seed_from_evidence",
+            unresolved_slots=("outputs",),
+            recovery_reason="interview_phase_deadline",
+        )
+
+        assert metadata.unresolved_slots == ("outputs",)
+
+    def test_degraded_complete_ledger_seed_needs_no_slots(self) -> None:
+        """Case (b): deadline closure over a fully resolved ledger."""
+        metadata = SeedMetadata(
+            degraded=True,
+            generation_mode="interview_deadline_complete_ledger",
+            recovery_reason="interview_phase_deadline",
+        )
+
+        assert metadata.unresolved_slots == ()
+
+    def test_non_degraded_recovery_path_seed_is_still_accepted(self) -> None:
+        """``partial_seed_from_evidence`` over a complete ledger stays valid.
+
+        ``ledger_seed.partial_seed_from_evidence`` derives
+        ``degraded = bool(unresolved_slots)``, so a complete ledger routed
+        through the recovery helper is deliberately tagged with the partial
+        ``generation_mode`` while remaining non-degraded. The invariants are
+        scoped to ``degraded=True`` precisely so that audit trail survives.
+        """
+        metadata = SeedMetadata(
+            generation_mode="partial_seed_from_evidence",
+            recovery_reason="forced_review",
+        )
+
+        assert metadata.degraded is False
+
+    def test_partial_generation_mode_constant_matches_ledger_seed(self) -> None:
+        """Pin the duplicated constant to its ``auto.ledger_seed`` source."""
+        from ouroboros.auto.ledger_seed import PARTIAL_SEED_GENERATION_MODE
+
+        assert _PARTIAL_SEED_GENERATION_MODE == PARTIAL_SEED_GENERATION_MODE
+
+    def test_decision_provenance_is_frozen(self) -> None:
+        """The histogram is the only dict field on a ``frozen=True`` model."""
+        metadata = SeedMetadata(decision_provenance={"user_confirmed": 3})
+
+        with pytest.raises(TypeError, match="immutable"):
+            metadata.decision_provenance["user_confirmed"] = 99
+        with pytest.raises(TypeError, match="immutable"):
+            metadata.decision_provenance.update({"timeout_default": 1})
+        with pytest.raises(TypeError, match="immutable"):
+            metadata.decision_provenance.pop("user_confirmed")
+        with pytest.raises(TypeError, match="immutable"):
+            metadata.decision_provenance.clear()
+
+        assert metadata.decision_provenance == {"user_confirmed": 3}
+
+    def test_decision_provenance_round_trips_and_stays_additive(self) -> None:
+        populated = SeedMetadata(decision_provenance={"model_inferred": 2})
+        assert json.loads(populated.model_dump_json())["decision_provenance"] == {
+            "model_inferred": 2
+        }
+
+        empty = SeedMetadata()
+        assert empty.decision_provenance == {}
+        assert "decision_provenance" not in json.loads(empty.model_dump_json())
 
 
 class TestOntologyField:
@@ -1166,3 +1266,86 @@ class TestSeedImmutabilityComprehensive:
         assert isinstance(seed.constraints, tuple)
         assert not hasattr(seed.constraints, "append")
         assert not hasattr(seed.constraints, "extend")
+
+
+class TestAcceptanceCriterionDescriptionRequired:
+    """``description`` is the semantic identity of an AC, so it cannot be blank.
+
+    ``derive_semantic_ac_key`` hashes the description; a whitespace-only value
+    used to normalize to ``""`` and give every such criterion an identical
+    ``semantic_ac_key``, cross-contaminating AC-keyed retry/successor state.
+    """
+
+    @pytest.mark.parametrize("blank", ["", " ", "   ", "\t", "\n", " \t\n "])
+    def test_blank_description_rejected(self, blank: str) -> None:
+        with pytest.raises(PydanticValidationError, match="cannot be empty or whitespace-only"):
+            AcceptanceCriterionSpec(description=blank)
+
+    def test_blank_legacy_string_criterion_rejected_by_seed(self) -> None:
+        with pytest.raises(PydanticValidationError, match="cannot be empty or whitespace-only"):
+            Seed(
+                goal="Test goal",
+                acceptance_criteria=("Real criterion", "   "),
+                ontology_schema=OntologySchema(name="T", description="T"),
+                metadata=SeedMetadata(ambiguity_score=0.1),
+            )
+
+    def test_description_is_still_stripped(self) -> None:
+        criterion = AcceptanceCriterionSpec(description="  Tasks can be created  ")
+
+        assert criterion.description == "Tasks can be created"
+
+    def test_distinct_criteria_keep_distinct_semantic_keys(self) -> None:
+        first = AcceptanceCriterionSpec(description="a").with_materialized_semantic_key()
+        second = AcceptanceCriterionSpec(description="b").with_materialized_semantic_key()
+
+        assert first.semantic_ac_key != second.semantic_ac_key
+        assert first.semantic_ac_key == derive_semantic_ac_key(first)
+
+
+class TestSeedTaskType:
+    """``task_type`` is a closed set matching the execution strategy registry."""
+
+    @pytest.mark.parametrize(
+        "task_type",
+        ["code", "research", "analysis", "artifact", "document", "documentation", "presentation"],
+    )
+    def test_documented_task_types_accepted(self, task_type: str) -> None:
+        seed = Seed(
+            goal="Test goal",
+            task_type=task_type,
+            ontology_schema=OntologySchema(name="T", description="T"),
+            metadata=SeedMetadata(ambiguity_score=0.1),
+        )
+
+        assert seed.task_type == task_type
+
+    def test_every_task_type_resolves_to_a_strategy(self) -> None:
+        """The literal set may not drift from the strategy registry."""
+        from typing import get_args
+
+        from ouroboros.core.seed import TaskType
+        from ouroboros.orchestrator.execution_strategy import get_strategy
+
+        for task_type in get_args(TaskType):
+            assert get_strategy(task_type) is not None
+
+    @pytest.mark.parametrize("bad", ["cod", "Coding", "codee", "", "test"])
+    def test_typo_task_type_rejected(self, bad: str) -> None:
+        with pytest.raises(PydanticValidationError):
+            Seed(
+                goal="Test goal",
+                task_type=bad,
+                ontology_schema=OntologySchema(name="T", description="T"),
+                metadata=SeedMetadata(ambiguity_score=0.1),
+            )
+
+    def test_case_and_whitespace_tolerated_for_hand_authored_seeds(self) -> None:
+        seed = Seed(
+            goal="Test goal",
+            task_type="  Research ",
+            ontology_schema=OntologySchema(name="T", description="T"),
+            metadata=SeedMetadata(ambiguity_score=0.1),
+        )
+
+        assert seed.task_type == "research"

--- a/tests/unit/orchestrator/test_execution_strategy.py
+++ b/tests/unit/orchestrator/test_execution_strategy.py
@@ -191,6 +191,107 @@ class TestRegisterStrategy:
         assert strategy.get_tools() == ["Read"]
         assert strategy.get_system_prompt_fragment() == "Custom agent"
 
+    def test_register_with_whitespace_strips_at_registration(self) -> None:
+        """Whitespace around task_type at registration is canonicalized.
+
+        Regression: register/get used only .lower() while Seed used
+        .strip().lower(), causing a mismatch when whitespace was present
+        at registration time.
+        """
+        from ouroboros.orchestrator.execution_strategy import (
+            _STRATEGY_REGISTRY,
+            is_registered_task_type,
+        )
+
+        class _WhitespaceStrategy:
+            def get_tools(self) -> list[str]:
+                return ["Read"]
+
+            def get_system_prompt_fragment(self) -> str:
+                return "ws"
+
+            def get_task_prompt_suffix(self) -> str:
+                return "ws"
+
+            def get_activity_map(self) -> dict[str, ActivityType]:
+                return {"Read": ActivityType.EXPLORING}
+
+        # Register with leading/trailing whitespace
+        register_strategy("  whitespace_type  ", _WhitespaceStrategy())
+        try:
+            # Canonical key must be stripped
+            assert "whitespace_type" in _STRATEGY_REGISTRY
+            assert "  whitespace_type  " not in _STRATEGY_REGISTRY
+
+            # Lookup must succeed without whitespace
+            assert is_registered_task_type("whitespace_type") is True
+            assert is_registered_task_type("  whitespace_type  ") is True
+            assert is_registered_task_type("WHITESPACE_TYPE") is True
+            assert is_registered_task_type(" Whitespace_Type ") is True
+
+            # get_strategy must resolve it
+            strategy = get_strategy("whitespace_type")
+            assert strategy.get_system_prompt_fragment() == "ws"
+            strategy2 = get_strategy("  whitespace_type  ")
+            assert strategy2.get_system_prompt_fragment() == "ws"
+        finally:
+            _STRATEGY_REGISTRY.pop("whitespace_type", None)
+
+    def test_canonicalize_task_type_strips_and_lowers(self) -> None:
+        """_canonicalize_task_type applies strip then lower consistently."""
+        from ouroboros.orchestrator.execution_strategy import _canonicalize_task_type
+
+        assert _canonicalize_task_type("  Code  ") == "code"
+        assert _canonicalize_task_type("RESEARCH") == "research"
+        assert _canonicalize_task_type("\tMy_Type\n") == "my_type"
+        assert _canonicalize_task_type("already_normal") == "already_normal"
+
+    def test_whitespace_registration_compatible_with_seed_validation(self) -> None:
+        """Seed validator finds types registered with surrounding whitespace.
+
+        End-to-end regression: the Seed validator and the strategy registry
+        must agree on canonicalization so that registering with whitespace
+        still allows Seed construction without whitespace (and vice-versa).
+        """
+        from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+        from ouroboros.orchestrator.execution_strategy import _STRATEGY_REGISTRY
+
+        class _SeedCompatStrategy:
+            def get_tools(self) -> list[str]:
+                return ["Read"]
+
+            def get_system_prompt_fragment(self) -> str:
+                return "compat"
+
+            def get_task_prompt_suffix(self) -> str:
+                return "compat"
+
+            def get_activity_map(self) -> dict[str, ActivityType]:
+                return {"Read": ActivityType.EXPLORING}
+
+        # Register WITH whitespace
+        register_strategy("  compat_task  ", _SeedCompatStrategy())
+        try:
+            # Seed uses stripped value — must resolve
+            seed = Seed(
+                goal="Compatibility test",
+                task_type="compat_task",
+                ontology_schema=OntologySchema(name="T", description="T"),
+                metadata=SeedMetadata(ambiguity_score=0.1),
+            )
+            assert seed.task_type == "compat_task"
+
+            # Seed with whitespace also works
+            seed2 = Seed(
+                goal="Compatibility test 2",
+                task_type="  Compat_Task  ",
+                ontology_schema=OntologySchema(name="T", description="T"),
+                metadata=SeedMetadata(ambiguity_score=0.1),
+            )
+            assert seed2.task_type == "compat_task"
+        finally:
+            _STRATEGY_REGISTRY.pop("compat_task", None)
+
 
 class TestStrategyProtocol:
     """Tests verifying ExecutionStrategy protocol compliance."""

--- a/tests/unit/orchestrator/test_workflow_ir_adapter.py
+++ b/tests/unit/orchestrator/test_workflow_ir_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pydantic import ValidationError as PydanticValidationError
 import pytest
 
 from ouroboros.core.seed import (
@@ -22,6 +23,7 @@ from ouroboros.orchestrator.workflow_ir import (
 from ouroboros.orchestrator.workflow_ir_adapter import (
     DEFAULT_SEED_AC_EVIDENCE_SCHEMA_REF,
     DEFAULT_SEED_AC_INPUT_SCHEMA_REF,
+    _normalize_acceptance_criteria,
     workflow_spec_from_seed,
 )
 
@@ -141,8 +143,19 @@ class TestWorkflowSpecFromSeed:
             workflow_spec_from_seed(_seed())
 
     def test_rejects_blank_acceptance_criteria(self) -> None:
+        """The blank-AC boundary now sits on ``Seed`` itself.
+
+        ``AcceptanceCriterionSpec.description`` rejects whitespace-only text at
+        construction, so a blank AC can no longer reach the adapter through a
+        valid ``Seed``. The adapter keeps its own guard as defense-in-depth for
+        loosely typed criteria inputs; it is covered directly below.
+        """
+        with pytest.raises(PydanticValidationError, match="cannot be empty or whitespace-only"):
+            _seed("A", "   ")
+
+    def test_adapter_guard_still_rejects_blank_criteria(self) -> None:
         with pytest.raises(ValueError, match="criterion 2 must be non-blank"):
-            workflow_spec_from_seed(_seed("A", "   "))
+            _normalize_acceptance_criteria(("A", "   "))
 
     def test_does_not_import_projection_records_or_runtime_paths(self) -> None:
         import ouroboros.orchestrator.workflow_ir_adapter as adapter


### PR DESCRIPTION
## Problem

Four fields in `core/seed.py` accept values the rest of the system cannot handle.

### 1. Blank AC descriptions collide on one identity (HIGH)

`AcceptanceCriterionSpec.description` was a bare `str` — unlike `Seed.goal`, which carries `min_length=1`. `_strip_description` stripped without rejecting, so `"   "` validated to `""`. `derive_semantic_ac_key` then hashed a constant payload, giving **every blank AC an identical `semantic_ac_key`**. That key is an identity across retries and successors, so AC-keyed state cross-contaminated between unrelated criteria.

### 2. `SeedMetadata` degradation invariants were documented but unenforced (HIGH)

The docstring states that `degraded=True` pairs with a non-default `generation_mode`, and that the partial-evidence mode carries at least one `unresolved_slots` entry. No validator checked any of it, so a Seed with real unresolved slots could hide them behind `degraded=False` and pass the run gate.

### 3. `decision_provenance` was mutable on a frozen model (MEDIUM)

`dict[str, int]` was the only unprotected field on `Seed` — every other collection is a tuple and `model_extra` is frozen via `_FrozenDict`. `seed.metadata.decision_provenance["x"] = 99` mutated the model in place.

### 4. `task_type` was free-form despite a closed vocabulary (MEDIUM)

Documented as 7 values, typed as `str`, while the same file already uses `Literal` for `InvestmentLevel`/`InvestmentProvenance`/`InvestmentConfidence`. A typo like `"cod"` was accepted and silently changed execution routing.

## Fixes

1. `Field(..., min_length=1)` **and** a rejecting before-validator, matching how `Seed.goal` is guarded. The validator fires first so the error names the field.
2. A `model_validator(mode="after")` with three rules.
3. `decision_provenance` frozen through the file's existing `_FrozenDict`. It subclasses `dict`, so `== {}`, `model_dump`, and the additive serializer keep working; its `__copy__`/`__deepcopy__` return self, so `model_copy` is unaffected.
4. `TaskType = Literal[...]` beside the `Investment*` literals, with a before-validator that strips and lower-cases — `get_strategy` has always lower-cased its lookup, so without it a hand-authored `task_type: Code` would newly break.

## One correction to the invariant as originally specified

Enforcing "partial mode ⇒ non-empty `unresolved_slots`" *unconditionally* is wrong and breaks a deliberately-tested path. `ledger_seed.partial_seed_from_evidence` derives `degraded = bool(unresolved_slots)` (`ledger_seed.py:300`), so a **complete** ledger routed through the recovery helper legitimately produces `degraded=False, generation_mode="partial_seed_from_evidence", unresolved_slots=()`. `test_ledger_seed.py::test_complete_ledger_marks_seed_non_degraded` asserts exactly that, noting the partial mode is retained "so audit can tell this Seed came from the recovery path even though no gap existed". That is not a partial product — nothing is unresolved.

Since the docstring scopes both cases under "degraded: True when…", the rules landed as:

1. `degraded=True` ⇒ `generation_mode != "normal"`
2. `degraded=True` and partial mode ⇒ non-empty `unresolved_slots`
3. non-empty `unresolved_slots` ⇒ `degraded=True`

Rule 3 is what actually blocks the failure mode: a Seed with genuine unresolved slots can no longer claim `degraded=False`. No call site needed changing; both `ledger_seed` paths satisfy all three.

## Call sites updated

Two tests that asserted on the old, later blank-AC boundary:

- `test_workflow_ir_adapter.py` — `Seed(...)` now rejects the blank AC before the adapter sees it. Split into a Seed-boundary assertion plus a direct test of the adapter's `_normalize_acceptance_criteria` guard, so the defense-in-depth check stays covered.
- `test_main.py::test_workflow_ir_inspect_rejects_blank_ac` — still exits 1; now asserts the earlier schema failure message.

## Testing

- `tests/unit/core/test_seed.py` — 133 passed
- `tests/unit/bigbang tests/unit/core tests/unit/auto` — 3753 passed
- `tests/unit` (full) — 20684 passed, 89 skipped, 12 failed
- `ruff check` + `ruff format` clean; `mypy src/ouroboros` clean across 596 files, which verifies the `TaskType` narrowing breaks no caller

All 12 failures are pre-existing and environmental — this box has only `python3`, not `python` — and reproduce identically on a stashed, unmodified tree. Zero regressions.

+183 lines of regression tests: accepted/rejected `SeedMetadata` shapes, the `_FrozenDict` mutation guard across `__setitem__`/`update`/`pop`/`clear`, additive serialization round-trip, a test pinning `_PARTIAL_SEED_GENERATION_MODE` to `ledger_seed.PARTIAL_SEED_GENERATION_MODE` so the duplicated constant cannot drift, parametrized blank-description forms, and all seven `task_type` values resolving to a real strategy.

## Note for reviewers

The venv's editable install points at the main repo's `src`, so tests run from a worktree silently exercise the wrong tree. All results above were re-run with `PYTHONPATH` pinned to this branch's `src` and verified via `ouroboros.core.seed.__file__`.