### PR TITLE
fix: bound every subprocess wait that could hang indefinitely

### DIFF
--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -1278,6 +1278,33 @@ def _looks_like_url(target: str) -> bool:
     )
 
 
+# `git clone` reaches the network, so it gets a generous ceiling; `git rev-parse`
+# is a local object-store read that either answers immediately or is wedged.
+# Both are bounded because `capture_output=True` hides a credential prompt: an
+# untimed call turns an unreachable host into a silent, permanent hang of
+# `ooo plugin add`.
+_GIT_CLONE_TIMEOUT_SECONDS = 300
+_GIT_REV_PARSE_TIMEOUT_SECONDS = 30
+
+
+def _git_noninteractive_env() -> dict[str, str]:
+    """Environment that makes Git fail instead of prompting for credentials.
+
+    `GIT_TERMINAL_PROMPT=0` is Git's own kill switch for terminal prompts.
+    Pointing `GIT_ASKPASS`/`SSH_ASKPASS` at `true` stops a GUI helper from
+    waiting on input off-screen, and `ssh -oBatchMode=yes` does the same for
+    the SSH transport.  Combined with a `DEVNULL` stdin, a private or moved
+    repository fails fast with a real stderr message instead of blocking on a
+    prompt nobody can see.
+    """
+    env = os.environ.copy()
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["GIT_ASKPASS"] = "true"
+    env["SSH_ASKPASS"] = "true"
+    env["GIT_SSH_COMMAND"] = "ssh -oBatchMode=yes"
+    return env
+
+
 def _normalize_clone_url(target: str) -> str:
     """Strip the Python-style `git+` prefix that pip/uv accept but Git itself
     does not understand.
@@ -1301,6 +1328,9 @@ def _shallow_clone(repo_url: str, dest: Path) -> str:
         check=True,
         capture_output=True,
         text=True,
+        timeout=_GIT_CLONE_TIMEOUT_SECONDS,
+        stdin=subprocess.DEVNULL,
+        env=_git_noninteractive_env(),
     )
     sha = subprocess.run(
         ["git", "rev-parse", "HEAD"],
@@ -1308,6 +1338,9 @@ def _shallow_clone(repo_url: str, dest: Path) -> str:
         check=True,
         capture_output=True,
         text=True,
+        timeout=_GIT_REV_PARSE_TIMEOUT_SECONDS,
+        stdin=subprocess.DEVNULL,
+        env=_git_noninteractive_env(),
     ).stdout.strip()
     return sha
 
@@ -1872,7 +1905,7 @@ def add_command(
             git_sha = plugin_cache.stage_url_cache_refresh(
                 lambda staging: _shallow_clone(target, staging), clone_dest
             )
-        except (subprocess.CalledProcessError, OSError) as exc:
+        except (subprocess.SubprocessError, OSError) as exc:
             print_error(plugin_cache.url_cache_refresh_error(exc, clone_dest))
             raise typer.Exit(code=1) from exc
         repo_root = clone_dest
@@ -2463,7 +2496,7 @@ def _install_named_from_url(
         git_sha = plugin_cache.stage_url_cache_refresh(
             lambda staging: _shallow_clone(repo_url, staging), clone_dest
         )
-    except (subprocess.CalledProcessError, OSError) as exc:
+    except (subprocess.SubprocessError, OSError) as exc:
         print_error(plugin_cache.url_cache_refresh_error(exc, clone_dest))
         raise typer.Exit(code=1) from exc
 

--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -1278,33 +1278,6 @@ def _looks_like_url(target: str) -> bool:
     )
 
 
-# `git clone` reaches the network, so it gets a generous ceiling; `git rev-parse`
-# is a local object-store read that either answers immediately or is wedged.
-# Both are bounded because `capture_output=True` hides a credential prompt: an
-# untimed call turns an unreachable host into a silent, permanent hang of
-# `ooo plugin add`.
-_GIT_CLONE_TIMEOUT_SECONDS = 300
-_GIT_REV_PARSE_TIMEOUT_SECONDS = 30
-
-
-def _git_noninteractive_env() -> dict[str, str]:
-    """Environment that makes Git fail instead of prompting for credentials.
-
-    `GIT_TERMINAL_PROMPT=0` is Git's own kill switch for terminal prompts.
-    Pointing `GIT_ASKPASS`/`SSH_ASKPASS` at `true` stops a GUI helper from
-    waiting on input off-screen, and `ssh -oBatchMode=yes` does the same for
-    the SSH transport.  Combined with a `DEVNULL` stdin, a private or moved
-    repository fails fast with a real stderr message instead of blocking on a
-    prompt nobody can see.
-    """
-    env = os.environ.copy()
-    env["GIT_TERMINAL_PROMPT"] = "0"
-    env["GIT_ASKPASS"] = "true"
-    env["SSH_ASKPASS"] = "true"
-    env["GIT_SSH_COMMAND"] = "ssh -oBatchMode=yes"
-    return env
-
-
 def _normalize_clone_url(target: str) -> str:
     """Strip the Python-style `git+` prefix that pip/uv accept but Git itself
     does not understand.
@@ -1328,9 +1301,9 @@ def _shallow_clone(repo_url: str, dest: Path) -> str:
         check=True,
         capture_output=True,
         text=True,
-        timeout=_GIT_CLONE_TIMEOUT_SECONDS,
+        timeout=plugin_cache.GIT_CLONE_TIMEOUT_SECONDS,
         stdin=subprocess.DEVNULL,
-        env=_git_noninteractive_env(),
+        env=plugin_cache.git_noninteractive_env(),
     )
     sha = subprocess.run(
         ["git", "rev-parse", "HEAD"],
@@ -1338,9 +1311,9 @@ def _shallow_clone(repo_url: str, dest: Path) -> str:
         check=True,
         capture_output=True,
         text=True,
-        timeout=_GIT_REV_PARSE_TIMEOUT_SECONDS,
+        timeout=plugin_cache.GIT_REV_PARSE_TIMEOUT_SECONDS,
         stdin=subprocess.DEVNULL,
-        env=_git_noninteractive_env(),
+        env=plugin_cache.git_noninteractive_env(),
     ).stdout.strip()
     return sha
 

--- a/src/ouroboros/cli/commands/plugin_cache.py
+++ b/src/ouroboros/cli/commands/plugin_cache.py
@@ -29,6 +29,32 @@ GIT_CLONE_TIMEOUT_SECONDS = 300
 GIT_REV_PARSE_TIMEOUT_SECONDS = 30
 
 
+def _ssh_command_with_batch_mode(existing: str | None) -> str:
+    """Build a GIT_SSH_COMMAND that preserves caller settings and adds BatchMode.
+
+    When the caller has already set GIT_SSH_COMMAND (e.g. for a custom
+    identity file, proxy jump, or nonstandard port), we append
+    ``-oBatchMode=yes`` so the SSH transport fails on prompts without
+    discarding the operator's transport configuration.
+
+    If no GIT_SSH_COMMAND is inherited, we fall back to the minimal
+    ``ssh -oBatchMode=yes``.
+
+    The option is appended using shlex.quote on the existing value is
+    unnecessary — ``-oBatchMode=yes`` is a literal flag with no
+    shell-metacharacter content — and the existing command is already a
+    shell-interpreted string (Git invokes it via ``sh -c "$GIT_SSH_COMMAND"
+    host``). We therefore concatenate with a single space, which is safe
+    because ``-oBatchMode=yes`` contains no characters requiring quoting.
+    """
+    if not existing:
+        return "ssh -oBatchMode=yes"
+    # If the caller already specifies BatchMode, respect it as-is.
+    if "-oBatchMode=" in existing or "-o BatchMode=" in existing:
+        return existing
+    return f"{existing} -oBatchMode=yes"
+
+
 def git_noninteractive_env() -> dict[str, str]:
     """Environment that makes Git fail instead of prompting for credentials.
 
@@ -38,12 +64,17 @@ def git_noninteractive_env() -> dict[str, str]:
     the SSH transport.  Combined with a `DEVNULL` stdin, a private or moved
     repository fails fast with a real stderr message instead of blocking on a
     prompt nobody can see.
+
+    Caller-supplied ``GIT_SSH_COMMAND`` is preserved: we append
+    ``-oBatchMode=yes`` rather than replacing the entire value, so custom
+    identity files, proxy jumps, wrapper scripts, and other transport
+    settings continue to work.
     """
     env = os.environ.copy()
     env["GIT_TERMINAL_PROMPT"] = "0"
     env["GIT_ASKPASS"] = "true"
     env["SSH_ASKPASS"] = "true"
-    env["GIT_SSH_COMMAND"] = "ssh -oBatchMode=yes"
+    env["GIT_SSH_COMMAND"] = _ssh_command_with_batch_mode(os.environ.get("GIT_SSH_COMMAND"))
     return env
 
 

--- a/src/ouroboros/cli/commands/plugin_cache.py
+++ b/src/ouroboros/cli/commands/plugin_cache.py
@@ -29,8 +29,15 @@ class CacheRefreshRecoveryError(OSError):
         self.backup_path = backup_path
 
 
-def url_cache_refresh_error(exc: subprocess.CalledProcessError | OSError, dest: Path) -> str:
+def url_cache_refresh_error(exc: subprocess.SubprocessError | OSError, dest: Path) -> str:
     """Render clone and filesystem failures through one public CLI contract."""
+    if isinstance(exc, subprocess.TimeoutExpired):
+        cmd = exc.cmd if isinstance(exc.cmd, str) else " ".join(str(part) for part in exc.cmd)
+        return (
+            f"git command timed out after {exc.timeout}s: {cmd}. "
+            "The remote may be unreachable or the repository may require "
+            "credentials that cannot be prompted for non-interactively."
+        )
     if isinstance(exc, subprocess.CalledProcessError):
         detail = exc.stderr.strip() if exc.stderr else exc
         return f"git clone failed: {detail}"

--- a/src/ouroboros/cli/commands/plugin_cache.py
+++ b/src/ouroboros/cli/commands/plugin_cache.py
@@ -20,6 +20,32 @@ import secrets
 import shutil
 import subprocess
 
+# `git clone` reaches the network, so it gets a generous ceiling; `git rev-parse`
+# is a local object-store read that either answers immediately or is wedged.
+# Both are bounded because `capture_output=True` hides a credential prompt: an
+# untimed call turns an unreachable host into a silent, permanent hang of
+# `ooo plugin add`.
+GIT_CLONE_TIMEOUT_SECONDS = 300
+GIT_REV_PARSE_TIMEOUT_SECONDS = 30
+
+
+def git_noninteractive_env() -> dict[str, str]:
+    """Environment that makes Git fail instead of prompting for credentials.
+
+    `GIT_TERMINAL_PROMPT=0` is Git's own kill switch for terminal prompts.
+    Pointing `GIT_ASKPASS`/`SSH_ASKPASS` at `true` stops a GUI helper from
+    waiting on input off-screen, and `ssh -oBatchMode=yes` does the same for
+    the SSH transport.  Combined with a `DEVNULL` stdin, a private or moved
+    repository fails fast with a real stderr message instead of blocking on a
+    prompt nobody can see.
+    """
+    env = os.environ.copy()
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["GIT_ASKPASS"] = "true"
+    env["SSH_ASKPASS"] = "true"
+    env["GIT_SSH_COMMAND"] = "ssh -oBatchMode=yes"
+    return env
+
 
 class CacheRefreshRecoveryError(OSError):
     """Promotion failed and the previous cache remains at ``backup_path``."""

--- a/src/ouroboros/providers/codex_cli_adapter.py
+++ b/src/ouroboros/providers/codex_cli_adapter.py
@@ -945,9 +945,11 @@ class CodexCliLLMAdapter(RuntimeStreamMixin):
     async def _collect_legacy_process_output(
         self,
         process: Any,
+        *,
+        deadline: float,
     ) -> tuple[list[str], list[str], str | None, str]:
         """Fallback for tests or wrappers that only expose communicate()."""
-        async with asyncio.timeout(self._effective_timeout_seconds()):
+        async with asyncio.timeout_at(deadline):
             stdout_bytes, stderr_bytes = await process.communicate()
         stdout = stdout_bytes.decode("utf-8", errors="replace")
         stderr = stderr_bytes.decode("utf-8", errors="replace")
@@ -1081,23 +1083,54 @@ class CodexCliLLMAdapter(RuntimeStreamMixin):
                 )
             )
 
-        # Feed prompt via stdin when the backend expects stdin delivery.
-        if process.stdin is not None and prompt_stdin_bytes is not None:
-            process.stdin.write(prompt_stdin_bytes)
-            await process.stdin.drain()
-            process.stdin.close()
-        elif process.stdin is not None:
-            process.stdin.close()
+        timeout_seconds = self._effective_timeout_seconds()
+        completion_deadline = asyncio.get_running_loop().time() + timeout_seconds
+
+        # Prompt delivery is part of the completion lifecycle: a child that
+        # stops reading stdin must not escape the same deadline as its output.
+        try:
+            async with asyncio.timeout_at(completion_deadline):
+                if process.stdin is not None and prompt_stdin_bytes is not None:
+                    process.stdin.write(prompt_stdin_bytes)
+                    await process.stdin.drain()
+                    process.stdin.close()
+                elif process.stdin is not None:
+                    process.stdin.close()
+        except TimeoutError:
+            await self._terminate_process(process)
+            output_path.unlink(missing_ok=True)
+            if schema_path:
+                schema_path.unlink(missing_ok=True)
+            return Result.err(
+                ProviderError(
+                    message=f"{self._display_name} request timed out after {timeout_seconds:.1f}s",
+                    provider=self._provider_name,
+                    details={
+                        "timed_out": True,
+                        "timeout_seconds": timeout_seconds,
+                        "timeout_was_default": self._timeout_is_default_ceiling(),
+                        "returncode": getattr(process, "returncode", None),
+                    },
+                )
+            )
+        except asyncio.CancelledError:
+            await self._terminate_process(process)
+            output_path.unlink(missing_ok=True)
+            if schema_path:
+                schema_path.unlink(missing_ok=True)
+            raise
 
         if not hasattr(process, "stdout") or not callable(getattr(process, "wait", None)):
-            timeout_seconds = self._effective_timeout_seconds()
             try:
                 (
                     stdout_lines,
                     stderr_lines,
                     session_id,
                     last_content,
-                ) = await self._collect_legacy_process_output(process)
+                ) = await self._collect_legacy_process_output(
+                    process,
+                    deadline=completion_deadline,
+                )
             except TimeoutError:
                 await self._terminate_process(process)
                 output_path.unlink(missing_ok=True)
@@ -1202,10 +1235,9 @@ class CodexCliLLMAdapter(RuntimeStreamMixin):
                 last_content = self._update_last_content(last_content, event_content)
 
         stdout_task = asyncio.create_task(_read_stdout())
-        timeout_seconds = self._effective_timeout_seconds()
 
         try:
-            async with asyncio.timeout(timeout_seconds):
+            async with asyncio.timeout_at(completion_deadline):
                 await process.wait()
                 await stdout_task
                 stderr_lines = await stderr_task

--- a/src/ouroboros/providers/codex_cli_adapter.py
+++ b/src/ouroboros/providers/codex_cli_adapter.py
@@ -947,10 +947,7 @@ class CodexCliLLMAdapter(RuntimeStreamMixin):
         process: Any,
     ) -> tuple[list[str], list[str], str | None, str]:
         """Fallback for tests or wrappers that only expose communicate()."""
-        if self._timeout is not None:
-            async with asyncio.timeout(self._timeout):
-                stdout_bytes, stderr_bytes = await process.communicate()
-        else:
+        async with asyncio.timeout(self._effective_timeout_seconds()):
             stdout_bytes, stderr_bytes = await process.communicate()
         stdout = stdout_bytes.decode("utf-8", errors="replace")
         stderr = stderr_bytes.decode("utf-8", errors="replace")
@@ -1183,13 +1180,11 @@ class CodexCliLLMAdapter(RuntimeStreamMixin):
                 last_content = self._update_last_content(last_content, event_content)
 
         stdout_task = asyncio.create_task(_read_stdout())
+        timeout_seconds = self._effective_timeout_seconds()
 
         try:
-            if self._timeout is None:
+            async with asyncio.timeout(timeout_seconds):
                 await process.wait()
-            else:
-                async with asyncio.timeout(self._timeout):
-                    await process.wait()
             await stdout_task
             stderr_lines = await stderr_task
         except ProviderError as exc:
@@ -1244,11 +1239,12 @@ class CodexCliLLMAdapter(RuntimeStreamMixin):
 
             return Result.err(
                 ProviderError(
-                    message=f"{self._display_name} request timed out after {self._timeout:.1f}s",
+                    message=f"{self._display_name} request timed out after {timeout_seconds:.1f}s",
                     provider=self._provider_name,
                     details={
                         "timed_out": True,
-                        "timeout_seconds": self._timeout,
+                        "timeout_seconds": timeout_seconds,
+                        "timeout_was_default": self._timeout_is_default_ceiling(),
                         "session_id": session_id,
                         "partial_content": content,
                         "returncode": getattr(process, "returncode", None),

--- a/src/ouroboros/providers/codex_cli_adapter.py
+++ b/src/ouroboros/providers/codex_cli_adapter.py
@@ -1090,12 +1090,34 @@ class CodexCliLLMAdapter(RuntimeStreamMixin):
             process.stdin.close()
 
         if not hasattr(process, "stdout") or not callable(getattr(process, "wait", None)):
-            (
-                stdout_lines,
-                stderr_lines,
-                session_id,
-                last_content,
-            ) = await self._collect_legacy_process_output(process)
+            timeout_seconds = self._effective_timeout_seconds()
+            try:
+                (
+                    stdout_lines,
+                    stderr_lines,
+                    session_id,
+                    last_content,
+                ) = await self._collect_legacy_process_output(process)
+            except TimeoutError:
+                await self._terminate_process(process)
+                output_path.unlink(missing_ok=True)
+                if schema_path:
+                    schema_path.unlink(missing_ok=True)
+                return Result.err(
+                    ProviderError(
+                        message=(
+                            f"{self._display_name} legacy request timed out"
+                            f" after {timeout_seconds:.1f}s"
+                        ),
+                        provider=self._provider_name,
+                        details={
+                            "timed_out": True,
+                            "timeout_seconds": timeout_seconds,
+                            "timeout_was_default": self._timeout_is_default_ceiling(),
+                            "returncode": getattr(process, "returncode", None),
+                        },
+                    )
+                )
             content = self._read_output_message(output_path)
             output_path.unlink(missing_ok=True)
             if schema_path:
@@ -1185,8 +1207,8 @@ class CodexCliLLMAdapter(RuntimeStreamMixin):
         try:
             async with asyncio.timeout(timeout_seconds):
                 await process.wait()
-            await stdout_task
-            stderr_lines = await stderr_task
+                await stdout_task
+                stderr_lines = await stderr_task
         except ProviderError as exc:
             await self._terminate_process(process)
             if not stdout_task.done():

--- a/src/ouroboros/providers/codex_cli_stream.py
+++ b/src/ouroboros/providers/codex_cli_stream.py
@@ -24,6 +24,14 @@ from ouroboros.core.errors import ProviderError
 
 _MAX_STREAM_LINE_BUFFER_BYTES = 50 * 1024 * 1024
 _MAX_STREAM_CAPTURE_BYTES = 50 * 1024 * 1024
+# CLI-backed completion adapters take an optional ``timeout`` that defaults to
+# ``None``.  No production call site sets it, so the unbounded
+# ``await process.wait()`` branch was the *default* path: a wedged CLI (auth
+# prompt, hung network call, orphaned child holding the pipe) blocked the whole
+# generation forever with no diagnostic.  This ceiling bounds that wait.  It
+# matches the 1800s per-iteration bound the Ralph loop already enforces, so a
+# single completion can never outlive the iteration that owns it.
+DEFAULT_CLI_COMPLETION_TIMEOUT_SECONDS = 1800.0
 # Orchestrator runtimes parse JSONL stdout; cap the line buffer so newline-free
 # output (or a stuck stream) cannot grow memory without bound.  Matches the
 # value the codex/opencode/pi runtimes already enforced inline.
@@ -422,6 +430,24 @@ class RuntimeStreamMixin:
 
     _provider_name: str
     _process_shutdown_timeout_seconds: float
+    _default_completion_timeout_seconds: float = DEFAULT_CLI_COMPLETION_TIMEOUT_SECONDS
+
+    def _effective_timeout_seconds(self) -> float:
+        """Resolve the completion timeout ceiling; never returns ``None``.
+
+        An explicit positive ``timeout`` wins.  ``None`` (the constructor
+        default) falls back to :data:`DEFAULT_CLI_COMPLETION_TIMEOUT_SECONDS`
+        so no wait on a child CLI process is ever unbounded.
+        """
+        timeout = getattr(self, "_timeout", None)
+        if timeout is not None and timeout > 0:
+            return float(timeout)
+        return self._default_completion_timeout_seconds
+
+    def _timeout_is_default_ceiling(self) -> bool:
+        """Whether the effective timeout came from the module default."""
+        timeout = getattr(self, "_timeout", None)
+        return not (timeout is not None and timeout > 0)
 
     def _stream_line_reader(self) -> Callable[..., AsyncIterator[str]]:
         return iter_stream_lines
@@ -462,6 +488,7 @@ class RuntimeStreamMixin:
 
 
 __all__ = [
+    "DEFAULT_CLI_COMPLETION_TIMEOUT_SECONDS",
     "RuntimeStreamMixin",
     "collect_stream_lines",
     "iter_runtime_stream_lines",

--- a/src/ouroboros/providers/copilot_cli_adapter.py
+++ b/src/ouroboros/providers/copilot_cli_adapter.py
@@ -708,12 +708,31 @@ class CopilotCliLLMAdapter(RuntimeStreamMixin):
         normalized_model: str | None,
         response_format: dict[str, object] | None,
     ) -> Result[CompletionResponse, ProviderError]:
-        (
-            stdout_lines,
-            stderr_lines,
-            session_id,
-            last_content,
-        ) = await self._collect_legacy_process_output(process)
+        timeout_seconds = self._effective_timeout_seconds()
+        try:
+            (
+                stdout_lines,
+                stderr_lines,
+                session_id,
+                last_content,
+            ) = await self._collect_legacy_process_output(process)
+        except TimeoutError:
+            await self._terminate_process(process)
+            return Result.err(
+                ProviderError(
+                    message=(
+                        f"{self._display_name} legacy request timed out"
+                        f" after {timeout_seconds:.1f}s"
+                    ),
+                    provider=self._provider_name,
+                    details={
+                        "timed_out": True,
+                        "timeout_seconds": timeout_seconds,
+                        "timeout_was_default": self._timeout_is_default_ceiling(),
+                        "returncode": getattr(process, "returncode", None),
+                    },
+                )
+            )
         preserve_structured_json = self._is_structured_response_format(response_format)
         fallback_content = self._plain_text_stdout_fallback(
             stdout_lines,
@@ -800,8 +819,8 @@ class CopilotCliLLMAdapter(RuntimeStreamMixin):
         try:
             async with asyncio.timeout(timeout_seconds):
                 await process.wait()
-            await stdout_task
-            stderr_lines = await stderr_task
+                await stdout_task
+                stderr_lines = await stderr_task
         except ProviderError as exc:
             await self._terminate_process(process)
             await self._cancel_tasks(stdout_task, stderr_task)

--- a/src/ouroboros/providers/copilot_cli_adapter.py
+++ b/src/ouroboros/providers/copilot_cli_adapter.py
@@ -597,10 +597,7 @@ class CopilotCliLLMAdapter(RuntimeStreamMixin):
         process: Any,
     ) -> tuple[list[str], list[str], str | None, str]:
         """Fallback path for tests/wrappers that only expose ``communicate()``."""
-        if self._timeout is not None:
-            async with asyncio.timeout(self._timeout):
-                stdout_bytes, stderr_bytes = await process.communicate()
-        else:
+        async with asyncio.timeout(self._effective_timeout_seconds()):
             stdout_bytes, stderr_bytes = await process.communicate()
         stdout = stdout_bytes.decode("utf-8", errors="replace")
         stderr = stderr_bytes.decode("utf-8", errors="replace")
@@ -798,13 +795,11 @@ class CopilotCliLLMAdapter(RuntimeStreamMixin):
                         last_content = event_content
 
         stdout_task = asyncio.create_task(_read_stdout())
+        timeout_seconds = self._effective_timeout_seconds()
 
         try:
-            if self._timeout is None:
+            async with asyncio.timeout(timeout_seconds):
                 await process.wait()
-            else:
-                async with asyncio.timeout(self._timeout):
-                    await process.wait()
             await stdout_task
             stderr_lines = await stderr_task
         except ProviderError as exc:
@@ -829,11 +824,12 @@ class CopilotCliLLMAdapter(RuntimeStreamMixin):
             content = last_content or "\n".join(stderr_lines).strip()
             return Result.err(
                 ProviderError(
-                    message=f"{self._display_name} request timed out after {self._timeout:.1f}s",
+                    message=f"{self._display_name} request timed out after {timeout_seconds:.1f}s",
                     provider=self._provider_name,
                     details={
                         "timed_out": True,
-                        "timeout_seconds": self._timeout,
+                        "timeout_seconds": timeout_seconds,
+                        "timeout_was_default": self._timeout_is_default_ceiling(),
                         "session_id": session_id,
                         "partial_content": content,
                         "returncode": getattr(process, "returncode", None),

--- a/src/ouroboros/providers/gjc_llm_adapter.py
+++ b/src/ouroboros/providers/gjc_llm_adapter.py
@@ -280,6 +280,7 @@ class GjcLLMAdapter(CodexCliLLMAdapter):
         content = ""
         final_content = ""
         prompt_id = f"prompt-{uuid4().hex}"
+        timeout_seconds = self._effective_timeout_seconds()
 
         async def fail(
             message: str, details: dict[str, object] | None = None
@@ -397,11 +398,8 @@ class GjcLLMAdapter(CodexCliLLMAdapter):
                         final_content = self._extract_agent_end_text(event)
                         return
 
-            if self._timeout is None:
+            async with asyncio.timeout(timeout_seconds):
                 await run_protocol()
-            else:
-                async with asyncio.timeout(self._timeout):
-                    await run_protocol()
         except ProviderError as exc:
             if stderr_task is not None and not stderr_task.done():
                 stderr_task.cancel()
@@ -421,8 +419,13 @@ class GjcLLMAdapter(CodexCliLLMAdapter):
             if stderr_task is not None and not stderr_task.done():
                 stderr_task.cancel()
             return await fail(
-                f"{self._display_name} request timed out after {self._timeout:.1f}s",
-                {"timed_out": True, "timeout_seconds": self._timeout, "partial_content": content},
+                f"{self._display_name} request timed out after {timeout_seconds:.1f}s",
+                {
+                    "timed_out": True,
+                    "timeout_seconds": timeout_seconds,
+                    "timeout_was_default": self._timeout_is_default_ceiling(),
+                    "partial_content": content,
+                },
             )
         except asyncio.CancelledError:
             await self._terminate_process(process)
@@ -432,10 +435,23 @@ class GjcLLMAdapter(CodexCliLLMAdapter):
                 if process.stdin is not None:
                     process.stdin.close()
 
-        if stderr_task is not None:
-            stderr_lines = await stderr_task
-        returncode = await process.wait()
-        if returncode != 0:
+        # ``agent_end`` already arrived, so the CLI should be exiting on its own.
+        # Bound both the stderr drain and the reap with the shutdown budget: a
+        # lingering child must not hang a completion that already has its answer.
+        returncode: int | None
+        try:
+            async with asyncio.timeout(self._process_shutdown_timeout_seconds):
+                if stderr_task is not None:
+                    stderr_lines = await stderr_task
+                returncode = await process.wait()
+        except TimeoutError:
+            if stderr_task is not None and not stderr_task.done():
+                stderr_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await stderr_task
+            await self._terminate_process(process)
+            returncode = None
+        if returncode is not None and returncode != 0:
             return Result.err(
                 ProviderError(
                     message=f"{self._display_name} exited with code {returncode}",

--- a/tests/unit/cli/test_plugin_command_mutating.py
+++ b/tests/unit/cli/test_plugin_command_mutating.py
@@ -5237,3 +5237,120 @@ def test_url_refresh_clone_timeout_is_reported_without_traceback(
     assert result.exit_code == 1, result.output
     assert "timed out" in result.output
     assert result.exception is None or isinstance(result.exception, SystemExit), result.exception
+
+
+# ---------------------------------------------------------------------------
+# git_noninteractive_env: inherited SSH transport preservation (review round 2)
+# ---------------------------------------------------------------------------
+
+
+def test_git_noninteractive_env_preserves_inherited_git_ssh_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """git_noninteractive_env() must preserve a caller-supplied GIT_SSH_COMMAND.
+
+    Users relying on GIT_SSH_COMMAND for a nonstandard port, identity file,
+    proxy jump, SSH config, or wrapper script must not have those settings
+    silently discarded. The function must append -oBatchMode=yes to the
+    inherited command rather than replacing it.
+
+    Regression catch for the ouroboros-agent BLOCKING finding at
+    src/ouroboros/cli/commands/plugin_cache.py:46 (HEAD 967bf3492).
+    """
+    from ouroboros.cli.commands.plugin_cache import git_noninteractive_env
+
+    custom_cmd = "ssh -i /home/deploy/.ssh/id_ed25519 -o ProxyJump=bastion.internal"
+    monkeypatch.setenv("GIT_SSH_COMMAND", custom_cmd)
+
+    env = git_noninteractive_env()
+
+    # The inherited command is preserved.
+    assert custom_cmd in env["GIT_SSH_COMMAND"], (
+        f"caller-supplied GIT_SSH_COMMAND was discarded; got {env['GIT_SSH_COMMAND']!r}"
+    )
+    # BatchMode=yes is appended.
+    assert "-oBatchMode=yes" in env["GIT_SSH_COMMAND"], (
+        f"BatchMode=yes was not appended; got {env['GIT_SSH_COMMAND']!r}"
+    )
+    # The other noninteractive variables are still set.
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+    assert env["GIT_ASKPASS"] == "true"
+    assert env["SSH_ASKPASS"] == "true"
+
+
+def test_git_noninteractive_env_defaults_when_no_inherited_ssh_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no GIT_SSH_COMMAND is inherited, the fallback is ssh -oBatchMode=yes."""
+    from ouroboros.cli.commands.plugin_cache import git_noninteractive_env
+
+    monkeypatch.delenv("GIT_SSH_COMMAND", raising=False)
+
+    env = git_noninteractive_env()
+
+    assert env["GIT_SSH_COMMAND"] == "ssh -oBatchMode=yes"
+
+
+def test_git_noninteractive_env_respects_existing_batchmode_setting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the caller already specifies BatchMode, do not append a duplicate."""
+    from ouroboros.cli.commands.plugin_cache import git_noninteractive_env
+
+    # -oBatchMode=no is a conscious caller choice (e.g. testing). Respect it.
+    custom = "ssh -oBatchMode=no -i /tmp/key"
+    monkeypatch.setenv("GIT_SSH_COMMAND", custom)
+
+    env = git_noninteractive_env()
+
+    assert env["GIT_SSH_COMMAND"] == custom, (
+        f"existing BatchMode setting was overridden; got {env['GIT_SSH_COMMAND']!r}"
+    )
+
+
+def test_git_noninteractive_env_handles_wrapper_script(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A wrapper script (common in CI) is preserved with BatchMode appended."""
+    from ouroboros.cli.commands.plugin_cache import git_noninteractive_env
+
+    wrapper = "/usr/local/bin/ssh-wrapper.sh"
+    monkeypatch.setenv("GIT_SSH_COMMAND", wrapper)
+
+    env = git_noninteractive_env()
+
+    assert env["GIT_SSH_COMMAND"] == f"{wrapper} -oBatchMode=yes"
+
+
+def test_shallow_clone_passes_inherited_ssh_command_to_git(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_shallow_clone must forward the preserved GIT_SSH_COMMAND to git.
+
+    End-to-end regression: set a custom GIT_SSH_COMMAND, call
+    _shallow_clone, and verify the subprocess.run env includes it.
+    """
+    custom_cmd = "ssh -p 2222 -i /opt/keys/deploy"
+    monkeypatch.setenv("GIT_SSH_COMMAND", custom_cmd)
+
+    calls: list[tuple[list[str], dict]] = []
+
+    def _spy(argv, *_args, **kwargs):
+        calls.append((list(argv), kwargs))
+        if argv[:2] == ["git", "clone"]:
+            Path(argv[-1]).mkdir(parents=True, exist_ok=True)
+            return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="deadbeef\n", stderr="")
+
+    monkeypatch.setattr("ouroboros.cli.commands.plugin.subprocess.run", _spy)
+
+    sha = _shallow_clone("git@github.com:Q00/ouroboros-plugins.git", tmp_path / "clone")
+
+    assert sha == "deadbeef"
+    # Both git calls must carry the preserved custom SSH command.
+    for argv, kwargs in calls:
+        git_ssh = kwargs["env"]["GIT_SSH_COMMAND"]
+        assert custom_cmd in git_ssh, (
+            f"custom GIT_SSH_COMMAND not forwarded to {argv[:2]}; got {git_ssh!r}"
+        )
+        assert "-oBatchMode=yes" in git_ssh

--- a/tests/unit/cli/test_plugin_command_mutating.py
+++ b/tests/unit/cli/test_plugin_command_mutating.py
@@ -20,8 +20,11 @@ import typer
 from typer.testing import CliRunner
 
 from ouroboros.cli.commands.plugin import (
+    _GIT_CLONE_TIMEOUT_SECONDS,
+    _GIT_REV_PARSE_TIMEOUT_SECONDS,
     _enumerate_catalog,
     _select_plugins,
+    _shallow_clone,
 )
 from ouroboros.cli.commands.plugin import (
     app as plugin_app,
@@ -5151,3 +5154,84 @@ def test_catalog_register_does_not_lose_concurrent_updates(tmp_path: Path) -> No
         f"concurrent register lost updates: missing "
         f"{expected - plugins_recorded}, got {plugins_recorded}"
     )
+
+
+def test_shallow_clone_bounds_git_and_refuses_credential_prompts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both git calls must be timed and non-interactive.
+
+    `capture_output=True` hides a credential prompt, so an untimed
+    `git clone` against an unreachable host or a private repository hangs
+    `ooo plugin add` silently and forever. Every invocation therefore carries
+    a timeout, a `DEVNULL` stdin, and an environment that makes git fail
+    instead of prompting.
+    """
+    calls: list[tuple[list[str], dict]] = []
+
+    def _spy(argv, *_args, **kwargs):
+        calls.append((list(argv), kwargs))
+        if argv[:2] == ["git", "clone"]:
+            Path(argv[-1]).mkdir(parents=True, exist_ok=True)
+            return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="cafef00d\n", stderr="")
+
+    monkeypatch.setattr("ouroboros.cli.commands.plugin.subprocess.run", _spy)
+
+    sha = _shallow_clone("https://github.com/Q00/ouroboros-plugins.git", tmp_path / "clone")
+
+    assert sha == "cafef00d"
+    assert [argv[:2] for argv, _ in calls] == [["git", "clone"], ["git", "rev-parse"]]
+    for argv, kwargs in calls:
+        assert kwargs["stdin"] is subprocess.DEVNULL, argv
+        assert kwargs["timeout"] > 0, argv
+        assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0", argv
+        assert kwargs["env"]["GIT_ASKPASS"] == "true", argv
+    clone_kwargs = calls[0][1]
+    rev_parse_kwargs = calls[1][1]
+    # Network reach gets a generous ceiling; a local object-store read does not.
+    assert clone_kwargs["timeout"] == _GIT_CLONE_TIMEOUT_SECONDS
+    assert rev_parse_kwargs["timeout"] == _GIT_REV_PARSE_TIMEOUT_SECONDS
+    assert clone_kwargs["timeout"] > rev_parse_kwargs["timeout"]
+
+
+@pytest.mark.parametrize("mode", ["add", "install"])
+def test_url_refresh_clone_timeout_is_reported_without_traceback(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
+) -> None:
+    """A timed-out clone follows the CLI error contract instead of crashing.
+
+    `subprocess.TimeoutExpired` is a `SubprocessError`, not an `OSError`, so
+    the call sites must widen their `except` clause or the new timeout turns a
+    hang into an unhandled traceback.
+    """
+    paths = _common_paths(tmp_path)
+    cache_root = tmp_path / "cache"
+    url = "https://github.com/Q00/ouroboros-plugins.git"
+
+    def _clone_timed_out(repo_url: str, dest: Path) -> str:
+        raise subprocess.TimeoutExpired(["git", "clone", "--depth", "1", repo_url], 300)
+
+    monkeypatch.setattr("ouroboros.cli.commands.plugin._shallow_clone", _clone_timed_out)
+
+    selector = (
+        ["add", url, "--plugin", "github-pr-ops"]
+        if mode == "add"
+        else ["install", "github-pr-ops", "--from", url]
+    )
+    result = runner.invoke(
+        plugin_app,
+        [
+            *selector,
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--plugin-home-root",
+            str(paths["plugin_home_root"]),
+            "--cache-root",
+            str(cache_root),
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "timed out" in result.output
+    assert result.exception is None or isinstance(result.exception, SystemExit), result.exception

--- a/tests/unit/cli/test_plugin_command_mutating.py
+++ b/tests/unit/cli/test_plugin_command_mutating.py
@@ -20,14 +20,16 @@ import typer
 from typer.testing import CliRunner
 
 from ouroboros.cli.commands.plugin import (
-    _GIT_CLONE_TIMEOUT_SECONDS,
-    _GIT_REV_PARSE_TIMEOUT_SECONDS,
     _enumerate_catalog,
     _select_plugins,
     _shallow_clone,
 )
 from ouroboros.cli.commands.plugin import (
     app as plugin_app,
+)
+from ouroboros.cli.commands.plugin_cache import (
+    GIT_CLONE_TIMEOUT_SECONDS,
+    GIT_REV_PARSE_TIMEOUT_SECONDS,
 )
 from ouroboros.plugin.lockfile import Lockfile
 from ouroboros.plugin.trust_store import TrustStore
@@ -5190,8 +5192,8 @@ def test_shallow_clone_bounds_git_and_refuses_credential_prompts(
     clone_kwargs = calls[0][1]
     rev_parse_kwargs = calls[1][1]
     # Network reach gets a generous ceiling; a local object-store read does not.
-    assert clone_kwargs["timeout"] == _GIT_CLONE_TIMEOUT_SECONDS
-    assert rev_parse_kwargs["timeout"] == _GIT_REV_PARSE_TIMEOUT_SECONDS
+    assert clone_kwargs["timeout"] == GIT_CLONE_TIMEOUT_SECONDS
+    assert rev_parse_kwargs["timeout"] == GIT_REV_PARSE_TIMEOUT_SECONDS
     assert clone_kwargs["timeout"] > rev_parse_kwargs["timeout"]
 
 

--- a/tests/unit/providers/test_codex_cli_adapter.py
+++ b/tests/unit/providers/test_codex_cli_adapter.py
@@ -1921,6 +1921,48 @@ class TestStreamDrainLifecycle:
     """Regression tests for review blockers #1 and #2 on Codex CLI adapter."""
 
     @pytest.mark.asyncio
+    async def test_prompt_drain_uses_completion_deadline(self) -> None:
+        """A child that stops reading stdin is terminated at the completion deadline."""
+
+        class _BlockedStdin(_FakeStdin):
+            async def drain(self) -> None:
+                await asyncio.Future()
+
+        class _BlockedStdinProcess(_FakeProcess):
+            def __init__(self) -> None:
+                super().__init__(wait_forever=True)
+                self.stdin = _BlockedStdin()
+
+        process = _BlockedStdinProcess()
+        adapter = CodexCliLLMAdapter(cli_path="codex", max_retries=1)
+        adapter._default_completion_timeout_seconds = 0.05
+
+        async def fake_create_subprocess_exec(
+            *command: str, **kwargs: Any
+        ) -> _BlockedStdinProcess:
+            output_index = command.index("--output-last-message") + 1
+            Path(command[output_index]).write_text("", encoding="utf-8")
+            return process
+
+        with patch(
+            "ouroboros.providers.codex_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await asyncio.wait_for(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="Block prompt delivery")],
+                    CompletionConfig(model="default"),
+                ),
+                timeout=5,
+            )
+
+        assert result.is_err
+        assert result.error.details["timed_out"] is True
+        assert result.error.details["timeout_seconds"] == pytest.approx(0.05)
+        assert result.error.details["timeout_was_default"] is True
+        assert process.terminated is True
+
+    @pytest.mark.asyncio
     async def test_streaming_exited_parent_non_eof_pipe_bounded(self) -> None:
         """Process exits but a descendant holds stdout open — must not hang.
 

--- a/tests/unit/providers/test_codex_cli_adapter.py
+++ b/tests/unit/providers/test_codex_cli_adapter.py
@@ -1937,9 +1937,7 @@ class TestStreamDrainLifecycle:
         adapter = CodexCliLLMAdapter(cli_path="codex", max_retries=1)
         adapter._default_completion_timeout_seconds = 0.05
 
-        async def fake_create_subprocess_exec(
-            *command: str, **kwargs: Any
-        ) -> _BlockedStdinProcess:
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _BlockedStdinProcess:
             output_index = command.index("--output-last-message") + 1
             Path(command[output_index]).write_text("", encoding="utf-8")
             return process

--- a/tests/unit/providers/test_codex_cli_adapter.py
+++ b/tests/unit/providers/test_codex_cli_adapter.py
@@ -1915,3 +1915,130 @@ class TestLazyImport:
 
         with pytest.raises(AttributeError, match="NonExistent"):
             _ = providers.NonExistent
+
+
+class TestStreamDrainLifecycle:
+    """Regression tests for review blockers #1 and #2 on Codex CLI adapter."""
+
+    @pytest.mark.asyncio
+    async def test_streaming_exited_parent_non_eof_pipe_bounded(self) -> None:
+        """Process exits but a descendant holds stdout open — must not hang.
+
+        Regression for review blocker #1: if the direct child exits but a
+        stream never reaches EOF, the adapter must still return within the
+        completion deadline rather than hanging indefinitely on the pipe drain.
+        """
+
+        class _NeverEOFStream:
+            """A stream whose read() hangs forever, simulating a held-open pipe."""
+
+            async def read(self, chunk_size: int = 16384) -> bytes:
+                await asyncio.Future()  # never returns
+                return b""  # unreachable
+
+        process_holder: dict[str, Any] = {}
+
+        class _ExitedButPipesOpenProcess:
+            def __init__(self) -> None:
+                self.stdin = _FakeStdin()
+                self.stdout = _NeverEOFStream()
+                self.stderr = _FakeStream("")
+                self.returncode = 0
+                self.terminated = False
+                self.killed = False
+
+            async def wait(self) -> int:
+                return 0  # process exited immediately
+
+            def terminate(self) -> None:
+                self.terminated = True
+
+            def kill(self) -> None:
+                self.killed = True
+
+        adapter = CodexCliLLMAdapter(cli_path="codex", max_retries=1)
+        adapter._default_completion_timeout_seconds = 0.05
+
+        async def fake_create_subprocess_exec(
+            *command: str, **kwargs: Any
+        ) -> _ExitedButPipesOpenProcess:
+            output_index = command.index("--output-last-message") + 1
+            Path(command[output_index]).write_text("", encoding="utf-8")
+            proc = _ExitedButPipesOpenProcess()
+            process_holder["process"] = proc
+            return proc
+
+        with patch(
+            "ouroboros.providers.codex_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await asyncio.wait_for(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="Hang on pipe")],
+                    CompletionConfig(model="default"),
+                ),
+                timeout=5,
+            )
+
+        assert result.is_err
+        assert result.error.details["timed_out"] is True
+        assert result.error.details["timeout_was_default"] is True
+
+    @pytest.mark.asyncio
+    async def test_legacy_timeout_returns_result_err_provider_error(self) -> None:
+        """Legacy communicate() timeout must be translated to Result.err(ProviderError).
+
+        Regression for review blocker #2: the legacy path must not propagate a
+        bare TimeoutError. It must terminate the child, clean temp artifacts,
+        and return a structured error with timed_out, timeout_seconds, and
+        timeout_was_default details.
+        """
+
+        class _HangingLegacyProcess:
+            """Legacy process whose communicate() hangs forever."""
+
+            def __init__(self) -> None:
+                self.stdin = _FakeStdin()
+                self.returncode = None
+                self.terminated = False
+                self.killed = False
+
+            async def communicate(self, _input: bytes | None = None) -> tuple[bytes, bytes]:
+                await asyncio.Future()  # never returns
+                return b"", b""  # unreachable
+
+            def terminate(self) -> None:
+                self.terminated = True
+                self.returncode = -15
+
+            def kill(self) -> None:
+                self.killed = True
+                self.returncode = -9
+
+        adapter = CodexCliLLMAdapter(cli_path="codex", max_retries=1)
+        adapter._default_completion_timeout_seconds = 0.05
+
+        async def fake_create_subprocess_exec(
+            *command: str, **kwargs: Any
+        ) -> _HangingLegacyProcess:
+            output_index = command.index("--output-last-message") + 1
+            Path(command[output_index]).write_text("partial output", encoding="utf-8")
+            return _HangingLegacyProcess()
+
+        with patch(
+            "ouroboros.providers.codex_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await asyncio.wait_for(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="Hang legacy")],
+                    CompletionConfig(model="default"),
+                ),
+                timeout=5,
+            )
+
+        assert result.is_err
+        assert result.error.details["timed_out"] is True
+        assert result.error.details["timeout_seconds"] == pytest.approx(0.05)
+        assert result.error.details["timeout_was_default"] is True
+        assert "timed out" in result.error.message

--- a/tests/unit/providers/test_codex_cli_adapter.py
+++ b/tests/unit/providers/test_codex_cli_adapter.py
@@ -16,7 +16,11 @@ from ouroboros.config.models import OuroborosConfig
 from ouroboros.core.errors import ProviderError
 from ouroboros.providers.base import CompletionConfig, Message, MessageRole
 from ouroboros.providers.codex_cli_adapter import CodexCliLLMAdapter
-from ouroboros.providers.codex_cli_stream import collect_stream_lines, terminate_runtime_process
+from ouroboros.providers.codex_cli_stream import (
+    DEFAULT_CLI_COMPLETION_TIMEOUT_SECONDS,
+    collect_stream_lines,
+    terminate_runtime_process,
+)
 
 
 class _FakeStream:
@@ -1374,6 +1378,45 @@ class TestCodexCliLLMAdapter:
         assert result.error.details["timed_out"] is True
         assert create_calls == 1
         assert callback_events == [("thinking", "Still working...")]
+        assert process_holder["process"].terminated or process_holder["process"].killed
+
+    @pytest.mark.asyncio
+    async def test_default_timeout_bounds_wait_when_no_timeout_configured(self) -> None:
+        """A wedged `codex` child must not block the generation forever.
+
+        ``timeout`` defaults to ``None`` and no production call site passes one,
+        so without the module-level ceiling ``await process.wait()`` is an
+        unbounded wait on the default path.
+        """
+        process_holder: dict[str, _FakeProcess] = {}
+        adapter = CodexCliLLMAdapter(cli_path="codex", max_retries=1)
+        assert adapter._timeout is None
+        assert adapter._effective_timeout_seconds() == DEFAULT_CLI_COMPLETION_TIMEOUT_SECONDS
+        adapter._default_completion_timeout_seconds = 0.01
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            output_index = command.index("--output-last-message") + 1
+            Path(command[output_index]).write_text("", encoding="utf-8")
+            process = _FakeProcess(returncode=124, wait_forever=True)
+            process_holder["process"] = process
+            return process
+
+        with patch(
+            "ouroboros.providers.codex_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await asyncio.wait_for(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="Hang")],
+                    CompletionConfig(model="default"),
+                ),
+                timeout=10,
+            )
+
+        assert result.is_err
+        assert result.error.details["timed_out"] is True
+        assert result.error.details["timeout_seconds"] == pytest.approx(0.01)
+        assert result.error.details["timeout_was_default"] is True
         assert process_holder["process"].terminated or process_holder["process"].killed
 
     def test_build_command_does_not_include_prompt_as_positional_arg(self) -> None:

--- a/tests/unit/providers/test_copilot_cli_adapter.py
+++ b/tests/unit/providers/test_copilot_cli_adapter.py
@@ -1264,3 +1264,117 @@ class TestRegressionToolEventDoesNotReplaceAssistantContent:
         assert result.error.details["session_id"] == "sess-legacy-tool-only"
         assert "cat ~/.ssh/id_rsa" not in result.error.message
         assert messages == [("tool", "shell")]
+
+    @pytest.mark.asyncio
+    async def test_streaming_exited_parent_non_eof_pipe_bounded(self) -> None:
+        """Process exits but a descendant holds stdout open — must not hang.
+
+        Regression for review blocker #1: if the direct child exits but a
+        stream never reaches EOF, the adapter must still return within the
+        completion deadline rather than hanging indefinitely on the pipe drain.
+        """
+
+        class _NeverEOFStream:
+            """A stream whose read() hangs forever, simulating a held-open pipe."""
+
+            async def read(self, chunk_size: int = 16384) -> bytes:
+                await asyncio.Future()  # never returns
+                return b""  # unreachable
+
+        class _ExitedButPipesOpenProcess:
+            def __init__(self) -> None:
+                self.stdin = _FakeStdin()
+                self.stdout = _NeverEOFStream()
+                self.stderr = _FakeStream("")
+                self.returncode = 0
+                self.terminated = False
+                self.killed = False
+
+            async def wait(self) -> int:
+                return 0  # process exited immediately
+
+            def terminate(self) -> None:
+                self.terminated = True
+
+            def kill(self) -> None:
+                self.killed = True
+
+        adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
+        adapter._default_completion_timeout_seconds = 0.05
+
+        async def fake_create_subprocess_exec(
+            *command: str, **kwargs: Any
+        ) -> _ExitedButPipesOpenProcess:
+            return _ExitedButPipesOpenProcess()
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await asyncio.wait_for(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="Hang on pipe")],
+                    CompletionConfig(model="default"),
+                ),
+                timeout=5,
+            )
+
+        assert result.is_err
+        assert result.error.details["timed_out"] is True
+        assert result.error.details["timeout_was_default"] is True
+
+    @pytest.mark.asyncio
+    async def test_legacy_timeout_returns_result_err_provider_error(self) -> None:
+        """Legacy communicate() timeout must be translated to Result.err(ProviderError).
+
+        Regression for review blocker #2: the legacy path must not propagate a
+        bare TimeoutError. It must terminate the child and return a structured
+        error with timed_out, timeout_seconds, and timeout_was_default details.
+        """
+
+        class _HangingLegacyProcess:
+            """Legacy process whose communicate() hangs forever."""
+
+            def __init__(self) -> None:
+                self.stdin = _FakeStdin()
+                self.returncode = None
+                self.terminated = False
+                self.killed = False
+
+            async def communicate(self) -> tuple[bytes, bytes]:
+                await asyncio.Future()  # never returns
+                return b"", b""  # unreachable
+
+            def terminate(self) -> None:
+                self.terminated = True
+                self.returncode = -15
+
+            def kill(self) -> None:
+                self.killed = True
+                self.returncode = -9
+
+        adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
+        adapter._default_completion_timeout_seconds = 0.05
+
+        async def fake_create_subprocess_exec(
+            *command: str, **kwargs: Any
+        ) -> _HangingLegacyProcess:
+            return _HangingLegacyProcess()
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await asyncio.wait_for(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="Hang legacy")],
+                    CompletionConfig(model="default"),
+                ),
+                timeout=5,
+            )
+
+        assert result.is_err
+        assert result.error.details["timed_out"] is True
+        assert result.error.details["timeout_seconds"] == pytest.approx(0.05)
+        assert result.error.details["timeout_was_default"] is True
+        assert "timed out" in result.error.message

--- a/tests/unit/providers/test_copilot_cli_adapter.py
+++ b/tests/unit/providers/test_copilot_cli_adapter.py
@@ -15,6 +15,7 @@ from ouroboros.config._model_defaults import DEFAULT_OPUS_MODEL
 from ouroboros.copilot.model_discovery import CopilotModel
 from ouroboros.core.errors import ProviderError
 from ouroboros.providers.base import CompletionConfig, Message, MessageRole
+from ouroboros.providers.codex_cli_stream import DEFAULT_CLI_COMPLETION_TIMEOUT_SECONDS
 from ouroboros.providers.copilot_cli_adapter import CopilotCliLLMAdapter
 
 
@@ -1101,6 +1102,41 @@ class TestComplete:
         assert result.is_err
         assert result.error.details["timed_out"] is True
         assert result.error.details["timeout_seconds"] == pytest.approx(0.05)
+        assert result.error.details["timeout_was_default"] is False
+
+    @pytest.mark.asyncio
+    async def test_default_timeout_bounds_wait_when_no_timeout_configured(self) -> None:
+        """A wedged CLI must not hang forever on the constructor default.
+
+        ``timeout`` defaults to ``None`` and no production call site sets it, so
+        the ceiling from :data:`DEFAULT_CLI_COMPLETION_TIMEOUT_SECONDS` is the
+        only thing standing between a stuck ``copilot`` process and a generation
+        that never returns.
+        """
+        adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
+        assert adapter._timeout is None
+        assert adapter._effective_timeout_seconds() == DEFAULT_CLI_COMPLETION_TIMEOUT_SECONDS
+        adapter._default_completion_timeout_seconds = 0.05
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            return _FakeProcess(wait_forever=True)
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await asyncio.wait_for(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="Hang")],
+                    CompletionConfig(model="default"),
+                ),
+                timeout=10,
+            )
+
+        assert result.is_err
+        assert result.error.details["timed_out"] is True
+        assert result.error.details["timeout_seconds"] == pytest.approx(0.05)
+        assert result.error.details["timeout_was_default"] is True
 
     @pytest.mark.asyncio
     async def test_depth_guard_returns_provider_error_without_spawning(self) -> None:

--- a/tests/unit/providers/test_gjc_llm_adapter.py
+++ b/tests/unit/providers/test_gjc_llm_adapter.py
@@ -1,5 +1,6 @@
 """Unit tests for the GJC LLM adapter."""
 
+import asyncio
 import json
 from typing import Any
 from unittest.mock import patch
@@ -7,6 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from ouroboros.providers.base import CompletionConfig, Message, MessageRole
+from ouroboros.providers.codex_cli_stream import DEFAULT_CLI_COMPLETION_TIMEOUT_SECONDS
 from ouroboros.providers.gjc_llm_adapter import GjcLLMAdapter
 
 
@@ -745,3 +747,114 @@ async def test_slash_qualified_model_id_sends_set_model() -> None:
         "provider": "openrouter",
         "modelId": "google/gemini-3-flash-preview",
     }
+
+
+class _HangingStream:
+    """Stream that never yields a byte and never reaches EOF."""
+
+    async def read(self, chunk_size: int = 16384) -> bytes:
+        await asyncio.Future()
+        raise AssertionError("unreachable")
+
+
+class _WedgedProcess(_FakeProcess):
+    """Process whose RPC stream hangs after start-up."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.stdout = _HangingStream()
+        self.stderr = _FakeStream("")
+
+    async def wait(self) -> int:
+        if self.returncode is None:
+            await asyncio.Future()
+        return self.returncode
+
+    def terminate(self) -> None:
+        super().terminate()
+        self.returncode = self._returncode
+
+    def kill(self) -> None:
+        super().kill()
+        self.returncode = self._returncode
+
+
+class _LingeringProcess(_FakeProcess):
+    """Process that answers the prompt but never exits on its own."""
+
+    async def wait(self) -> int:
+        if self.returncode is None:
+            await asyncio.Future()
+        return self.returncode
+
+    def terminate(self) -> None:
+        super().terminate()
+        self.returncode = self._returncode
+
+    def kill(self) -> None:
+        super().kill()
+        self.returncode = self._returncode
+
+
+@pytest.mark.asyncio
+async def test_default_timeout_bounds_rpc_protocol_when_no_timeout_configured() -> None:
+    """A silent `gjc --mode rpc` child must not block the generation forever.
+
+    ``timeout`` defaults to ``None`` and no production call site sets one, so
+    the module-level ceiling is the only bound on the RPC protocol wait.
+    """
+    process = _WedgedProcess()
+    factory = _ProcessFactory(process)
+    adapter = GjcLLMAdapter(cli_path="/tmp/gjc", cwd="/tmp/project")
+    assert adapter._timeout is None
+    assert adapter._effective_timeout_seconds() == DEFAULT_CLI_COMPLETION_TIMEOUT_SECONDS
+    adapter._default_completion_timeout_seconds = 0.01
+    adapter._process_shutdown_timeout_seconds = 0.01
+
+    with patch("ouroboros.providers.gjc_llm_adapter.asyncio.create_subprocess_exec", factory):
+        result = await asyncio.wait_for(
+            adapter.complete(
+                [Message(role=MessageRole.USER, content="Hang")],
+                CompletionConfig(model="default"),
+            ),
+            timeout=10,
+        )
+
+    assert result.is_err
+    assert result.error.details["timed_out"] is True
+    assert result.error.details["timeout_seconds"] == pytest.approx(0.01)
+    assert result.error.details["timeout_was_default"] is True
+    assert process.terminated
+
+
+@pytest.mark.asyncio
+async def test_lingering_child_after_agent_end_does_not_hang_completion() -> None:
+    """The post-`agent_end` reap is bounded, and the answer is still returned."""
+    process = _LingeringProcess(
+        stdout=_gjc_jsonl(
+            _ready(),
+            _ack("prompt-1"),
+            _agent_end("prompt-1", "Hello"),
+        )
+    )
+    factory = _ProcessFactory(process)
+    adapter = GjcLLMAdapter(cli_path="/tmp/gjc", cwd="/tmp/project")
+    adapter._process_shutdown_timeout_seconds = 0.01
+
+    with (
+        patch("ouroboros.providers.gjc_llm_adapter.asyncio.create_subprocess_exec", factory),
+        patch(
+            "ouroboros.providers.gjc_llm_adapter.uuid4", return_value=type("U", (), {"hex": "1"})()
+        ),
+    ):
+        result = await asyncio.wait_for(
+            adapter.complete(
+                [Message(role=MessageRole.USER, content="Say hello")],
+                CompletionConfig(model="default"),
+            ),
+            timeout=10,
+        )
+
+    assert result.is_ok
+    assert result.value.content == "Hello"
+    assert process.terminated


### PR DESCRIPTION
## Problem

### Three CLI adapters defaulted to an unbounded wait

Each had this shape, with `None` as the constructor default — so the **unbounded branch was the default path**:

```python
if self._timeout is None:
    await process.wait()          # blocks forever
else:
    await asyncio.wait_for(process.wait(), timeout=self._timeout)
```

A wedged CLI blocked the generation forever with no diagnostic.

Caller analysis: the real class names are `CopilotCliLLMAdapter`, `CodexCliLLMAdapter`, `GjcLLMAdapter`. The only construction path is `providers/factory.py` forwarding `create_llm_adapter(timeout=...)`, and **no production caller passes `timeout` at all** — not `evaluation_handlers`, `pm_handler`, `authoring_handlers`, `qa.py`, `mcp/server/adapter.py`, or `auto/adapters.py`. Only two tests pass one, both explicit positive floats. So nothing relied on unbounded behavior and a default ceiling is the correct fix.

### The plugin installer could hang on a credential prompt

`plugin.py` `_shallow_clone` ran `git clone --depth 1` and `git rev-parse HEAD` with `check=True`, no `timeout=`, and stdin not redirected. With `capture_output=True`, an unreachable host or a git credential prompt hung `ooo plugin add` silently and forever.

## Fixes

### Adapters

Added `DEFAULT_CLI_COMPLETION_TIMEOUT_SECONDS = 1800.0` plus `_effective_timeout_seconds()` / `_timeout_is_default_ceiling()` to `RuntimeStreamMixin`. **1800s** matches the `per_iteration_timeout_seconds` default the Ralph loop already enforces, so a single completion can never outlive the iteration that owns it. An explicit positive `timeout` still wins unchanged.

The idle-guard approach used by `opencode_runtime`/`codex_cli_runtime` does not apply here: `_iter_stream_lines` does not accept the chunk-timeout kwargs (that is `iter_runtime_stream_lines`, used only by the orchestrator runtimes), and these adapters hang on `process.wait()`, not on a stream read.

Sites fixed — including three not in the original report:

| Site | What was unbounded |
| :--- | :--- |
| `copilot_cli_adapter.py:803` | `_handle_streaming_process` |
| `copilot_cli_adapter.py:600` | `_collect_legacy_process_output` — same shape on `communicate()` |
| `codex_cli_adapter.py:1188` | streaming |
| `codex_cli_adapter.py:950` | legacy `communicate()` |
| `gjc_llm_adapter.py:400` | `await run_protocol()` |
| `gjc_llm_adapter.py:437` | `await stderr_task` + `await process.wait()` after `agent_end` |

The last one uses a 5s `_process_shutdown_timeout_seconds` — the established "process should be exiting now" budget. On expiry the child is terminated and the already-received answer is still returned, so a merely slow-exiting CLI is not turned into a failure.

Timeout errors now report the effective seconds plus `timeout_was_default: bool`, distinguishing an operator limit from the fallback.

### Plugin installer

`_GIT_CLONE_TIMEOUT_SECONDS = 300` (network reach) and `_GIT_REV_PARSE_TIMEOUT_SECONDS = 30` (local object-store read — it either answers immediately or is wedged), following the `timeout=30` style in `core/worktree.py`. Both calls get `stdin=subprocess.DEVNULL` and `env=_git_noninteractive_env()`, which sets `GIT_TERMINAL_PROMPT=0`, `GIT_ASKPASS`/`SSH_ASKPASS=true`, and `GIT_SSH_COMMAND="ssh -oBatchMode=yes"` — the SSH transport prompts through its own channel, which `GIT_TERMINAL_PROMPT` alone does not close.

## A latent bug the timeout would have introduced

Both git call sites caught `(subprocess.CalledProcessError, OSError)`. `subprocess.TimeoutExpired` is a `SubprocessError`, **not** an `OSError` — so adding a timeout would have converted a hang into an unhandled traceback. Widened both to `subprocess.SubprocessError` and added an explicit `TimeoutExpired` branch to `plugin_cache.url_cache_refresh_error`, which also handles `exc.cmd` being a `str` (where `" ".join` would otherwise join characters).

## Testing

- `ruff check` + `ruff format --check` on all 10 changed files — clean
- `mypy` on all 6 changed source files — clean
- `pytest tests/unit/providers` — 851 passed, 7 skipped
- `pytest tests/ -k plugin` — 1138 passed, 5 skipped
- `pytest tests/unit/cli` — 2083 passed, 7 skipped

Six regression tests: default-ceiling coverage for copilot / codex / gjc (each asserts `_timeout is None`, that the effective value is the module default, then drives a wedged process to a bounded failure with `timeout_was_default is True`), the bounded gjc reap returning its answer despite a never-exiting child, `_shallow_clone` asserting timeout + DEVNULL stdin + prompt-disabling env with clone > rev-parse, and a parametrized `TimeoutExpired` path asserting exit 1 with no traceback.

## Note for reviewers

The venv's editable install resolves `ouroboros` to the main repo's `src`, so tests launched from a worktree silently exercise the wrong tree. All results above used `PYTHONPATH` pinned to this branch's `src`, verified via `ouroboros.__file__`.