### PR TITLE
fix(retry): precise transient matching, default jitter, retry logging

### DIFF
--- a/src/ouroboros/core/retry.py
+++ b/src/ouroboros/core/retry.py
@@ -1,15 +1,41 @@
-"""Retry helpers and shared transient-error classification."""
+"""Retry helpers and shared transient-error classification.
+
+``is_transient_error`` is shared by every provider adapter and the execution
+adapter, so its precision is a cross-cutting concern: a false positive burns the
+whole retry budget on a deterministic failure and delays the real error.
+
+Matching is therefore *per pattern*, not uniformly substring-based:
+
+* Patterns with no realistic false positive ("timeout", "overloaded", ...) stay
+  plain substrings — narrowing them would drop genuine variants such as
+  ``ReadTimeout`` or ``TimeoutException``.
+* ``"rate"`` is matched on alphabetic boundaries, so ``rate limit`` /
+  ``rate_limit`` / ``RateLimitError`` still match while ``generate``,
+  ``iterate`` and ``accurate`` no longer do.
+* HTTP status codes are matched only in a status-code *position* — after a
+  status-ish token, at the start of a line, or in front of their reason phrase —
+  so a token count like ``15000 tokens`` is no longer read as a ``500``.
+
+``extra_patterns`` supplied by a caller keep substring semantics unless the
+pattern has a precise rule in :data:`_PRECISE_PATTERN_REGEXES`, so adapter-local
+vocabularies ("quota exceeded", "exit code 1", ...) behave exactly as before.
+"""
 
 from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
-from functools import wraps
+from functools import lru_cache, wraps
 import random
+import re
 from typing import Any, ParamSpec, TypeVar
+
+import structlog
 
 P = ParamSpec("P")
 T = TypeVar("T")
+
+log = structlog.get_logger()
 
 BASE_TRANSIENT_PATTERNS: tuple[str, ...] = (
     "concurrency",  # parallel-request contention inside an active session
@@ -27,6 +53,61 @@ BASE_TRANSIENT_PATTERNS: tuple[str, ...] = (
     "connection",  # connection reset / aborted / error
 )
 
+# Tokens that put a bare number in a status-code position ("HTTP 503",
+# "error: 502", "upstream returned 500").
+_HTTP_STATUS_CONTEXT = (
+    r"(?:https?(?:/[\d.]+)?|status(?:[ _-]?code)?|code|errors?|err|response|responded"
+    r"|returns?|returned|got|received|failed with|upstream)"
+)
+
+# Reason phrases let a leading code be recognised mid-sentence, e.g.
+# "Reconnecting... 1/5 (502 Bad Gateway)".
+_HTTP_STATUS_REASONS: dict[str, str] = {
+    "429": r"too\W{0,2}many\W{0,2}requests",
+    "500": r"internal\W{0,2}server\W{0,2}error",
+    "502": r"bad\W{0,2}gateway",
+    "503": r"(?:service\W{0,2})?(?:temporarily\W{0,2})?unavailable",
+    "504": r"gateway\W{0,2}time\W{0,2}out",
+}
+
+
+def _http_status_regex(code: str) -> str:
+    """Build a regex that matches *code* only where a status code can appear."""
+    alternatives = [
+        # "HTTP 503 ...", "error: 502", "upstream returned 500"
+        rf"{_HTTP_STATUS_CONTEXT}\W{{0,4}}{code}(?![\d.])",
+        # "429 from https://api.openai.com/v1/responses" (start of message/line)
+        rf"^\W*{code}(?![\d.])",
+    ]
+    reason = _HTTP_STATUS_REASONS.get(code)
+    if reason:
+        alternatives.append(rf"(?<![\d.]){code}\W{{0,3}}{reason}")
+    return "|".join(alternatives)
+
+
+_ALPHA_LEFT = r"(?<![a-z])"
+_ALPHA_RIGHT = r"(?![a-z])"
+
+# Patterns whose plain-substring form produced false positives. Everything not
+# listed here is matched as a substring (see module docstring).
+_PRECISE_PATTERN_REGEXES: dict[str, str] = {
+    # "rate limit" / "rate-limited" / "rate_limit" / "RateLimitError" yes;
+    # "generate" / "iterate" / "accurate" / "corporate" no.
+    "rate": rf"{_ALPHA_LEFT}rate(?:[ _-]?limit\w*|{_ALPHA_RIGHT})",
+    "429": _http_status_regex("429"),
+    "500": _http_status_regex("500"),
+    "502": _http_status_regex("502"),
+    "503": _http_status_regex("503"),
+    "504": _http_status_regex("504"),
+}
+
+
+@lru_cache(maxsize=512)
+def _pattern_matcher(pattern: str) -> re.Pattern[str]:
+    """Compile *pattern* into its matcher (precise rule, else literal substring)."""
+    source = _PRECISE_PATTERN_REGEXES.get(pattern.lower(), re.escape(pattern.lower()))
+    return re.compile(source, re.MULTILINE)
+
 
 def is_transient_error(
     message: str,
@@ -35,9 +116,31 @@ def is_transient_error(
 ) -> bool:
     """Return whether *message* looks like a transient, retry-worthy failure."""
     lowered = message.lower()
-    if any(pattern in lowered for pattern in BASE_TRANSIENT_PATTERNS):
-        return True
-    return any(pattern in lowered for pattern in extra_patterns)
+    for pattern in (*BASE_TRANSIENT_PATTERNS, *extra_patterns):
+        if _pattern_matcher(pattern).search(lowered):
+            return True
+    return False
+
+
+# Backoff waits are jittered by default so concurrent generations that were
+# rate-limited together do not retry in lockstep against the same provider.
+DEFAULT_JITTER_RATIO = 0.5
+# A retry must always yield the event loop for a measurable moment.
+MIN_WAIT_SECONDS = 0.001
+
+
+def _jittered_wait(base: float, wait_jitter: float | None) -> float:
+    """Return the actual sleep for a retry — always > 0."""
+    base = max(base, 0.0)
+    if wait_jitter is None:
+        # Equal jitter: half the wait is fixed, half is random.
+        fixed = base * (1.0 - DEFAULT_JITTER_RATIO)
+        sleep_for = fixed + random.uniform(0.0, base * DEFAULT_JITTER_RATIO)
+    elif wait_jitter > 0:
+        sleep_for = base + random.uniform(0.0, wait_jitter)
+    else:
+        sleep_for = base
+    return max(sleep_for, MIN_WAIT_SECONDS)
 
 
 def retry_async(
@@ -46,12 +149,25 @@ def retry_async(
     attempts: int,
     wait_initial: float,
     wait_max: float,
-    wait_jitter: float = 0.0,
+    wait_jitter: float | None = None,
 ) -> Callable[[Callable[P, Any]], Callable[P, Any]]:
-    """Retry an async callable with exponential backoff."""
+    """Retry an async callable with exponential backoff and jittered waits.
+
+    Args:
+        on: Exception types that are worth retrying.
+        attempts: Total attempts, including the first one. Must be > 0.
+        wait_initial: First backoff wait, in seconds.
+        wait_max: Ceiling for the exponential backoff wait, in seconds.
+        wait_jitter: ``None`` (default) applies equal jitter proportional to the
+            current wait. A positive value adds ``uniform(0, wait_jitter)``
+            seconds on top of the wait. ``0.0`` opts out of jitter entirely.
+    """
 
     if attempts <= 0:
         msg = "attempts must be > 0"
+        raise ValueError(msg)
+    if wait_jitter is not None and wait_jitter < 0:
+        msg = "wait_jitter must be >= 0 or None"
         raise ValueError(msg)
 
     def decorator(func: Callable[P, Any]) -> Callable[P, Any]:
@@ -61,13 +177,20 @@ def retry_async(
             for attempt in range(1, attempts + 1):
                 try:
                     return await func(*args, **kwargs)
-                except on:
+                except on as exc:
                     if attempt >= attempts:
                         raise
 
-                    sleep_for = min(delay, wait_max)
-                    if wait_jitter > 0:
-                        sleep_for += random.uniform(0.0, wait_jitter)
+                    sleep_for = _jittered_wait(min(delay, wait_max), wait_jitter)
+                    log.warning(
+                        "retry_async.retry",
+                        target=getattr(func, "__qualname__", repr(func)),
+                        attempt=attempt,
+                        attempts=attempts,
+                        delay=round(sleep_for, 3),
+                        error=str(exc),
+                        error_type=type(exc).__name__,
+                    )
                     await asyncio.sleep(sleep_for)
                     delay = min(max(delay * 2, wait_initial), wait_max)
 
@@ -79,4 +202,10 @@ def retry_async(
     return decorator
 
 
-__all__ = ["BASE_TRANSIENT_PATTERNS", "is_transient_error", "retry_async"]
+__all__ = [
+    "BASE_TRANSIENT_PATTERNS",
+    "DEFAULT_JITTER_RATIO",
+    "MIN_WAIT_SECONDS",
+    "is_transient_error",
+    "retry_async",
+]

--- a/tests/unit/core/test_retry.py
+++ b/tests/unit/core/test_retry.py
@@ -6,7 +6,13 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from ouroboros.core.retry import retry_async
+from ouroboros.core import retry as retry_module
+from ouroboros.core.retry import (
+    DEFAULT_JITTER_RATIO,
+    MIN_WAIT_SECONDS,
+    _jittered_wait,
+    retry_async,
+)
 
 
 @pytest.mark.asyncio
@@ -45,3 +51,68 @@ async def test_retry_async_raises_after_exhaustion() -> None:
 
     assert attempts == 2
     assert sleep_mock.await_count == 1
+
+
+class TestJitteredWait:
+    """Waits are jittered by default so co-scheduled retries do not stampede."""
+
+    def test_default_jitter_spreads_waits_and_stays_positive(self) -> None:
+        waits = {_jittered_wait(4.0, None) for _ in range(200)}
+
+        assert len(waits) > 1  # a fixed wait would collapse to one value
+        assert all(0.0 < w <= 4.0 for w in waits)
+        # Equal jitter: never less than half the nominal wait.
+        assert min(waits) >= 4.0 * (1.0 - DEFAULT_JITTER_RATIO) - 1e-9
+        assert max(waits) > 4.0 * (1.0 - DEFAULT_JITTER_RATIO)
+
+    def test_explicit_jitter_keeps_additive_semantics(self) -> None:
+        waits = [_jittered_wait(2.0, 1.0) for _ in range(200)]
+
+        assert all(2.0 <= w <= 3.0 for w in waits)
+        assert len(set(waits)) > 1
+
+    def test_zero_jitter_opts_out_but_never_sleeps_zero(self) -> None:
+        assert _jittered_wait(2.0, 0.0) == 2.0
+        assert _jittered_wait(0.0, 0.0) == MIN_WAIT_SECONDS
+        assert _jittered_wait(-5.0, None) == MIN_WAIT_SECONDS
+
+    def test_negative_jitter_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="wait_jitter"):
+            retry_async(
+                on=(ValueError,), attempts=2, wait_initial=1.0, wait_max=2.0, wait_jitter=-1.0
+            )
+
+    @pytest.mark.asyncio
+    async def test_decorator_jitters_by_default(self) -> None:
+        @retry_async(on=(ValueError,), attempts=2, wait_initial=4.0, wait_max=4.0)
+        async def always_fail() -> None:
+            raise ValueError("boom")
+
+        with patch("asyncio.sleep", new=AsyncMock()) as sleep_mock:
+            with pytest.raises(ValueError, match="boom"):
+                await always_fail()
+
+        slept = sleep_mock.await_args.args[0]
+        assert 2.0 <= slept <= 4.0
+
+
+@pytest.mark.asyncio
+async def test_retry_async_logs_each_retry() -> None:
+    """Operators need a structlog signal during a retry storm."""
+
+    @retry_async(on=(ValueError,), attempts=3, wait_initial=0.1, wait_max=1.0)
+    async def always_fail() -> None:
+        raise ValueError("transient boom")
+
+    with patch("asyncio.sleep", new=AsyncMock()), patch.object(retry_module.log, "warning") as warn:
+        with pytest.raises(ValueError, match="transient boom"):
+            await always_fail()
+
+    assert warn.call_count == 2  # one per retry, none after exhaustion
+    event, kwargs = warn.call_args_list[0].args[0], warn.call_args_list[0].kwargs
+    assert event == "retry_async.retry"
+    assert kwargs["attempt"] == 1
+    assert kwargs["error_type"] == "ValueError"
+    assert kwargs["error"] == "transient boom"
+    assert kwargs["delay"] > 0
+    assert warn.call_args_list[1].kwargs["attempt"] == 2

--- a/tests/unit/providers/test_retry.py
+++ b/tests/unit/providers/test_retry.py
@@ -49,6 +49,62 @@ class TestIsTransientError:
         assert is_transient_error("custom cli still in startup", extra_patterns=("startup",))
 
 
+class TestNoFalsePositives:
+    """Plain-substring matching used to retry deterministic failures forever.
+
+    ``"rate"`` fired inside ``generate``/``iterate``/``accurate`` and the HTTP
+    status codes fired inside any digit run (a token count, a price), so a
+    non-retryable error burned the whole retry budget before surfacing.
+    """
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "prompt uses 15000 tokens, over the limit",
+            "token count 15000 tokens exceeded limit",
+            "failed to generate the response",
+            "could not generate an accurate estimate",
+            "iterate over the plan failed: schema invalid",
+            "corporate policy forbids this model",
+            "billing: cost was 0.500 usd",
+            "prompt exceeds 5000 chars",
+            "invalid api key: 401 unauthorized",
+        ],
+    )
+    def test_digit_runs_and_word_fragments_are_not_transient(self, message: str) -> None:
+        assert not is_transient_error(message)
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            # Status codes in a real status-code position.
+            "http 500",
+            "APIStatusError: 500 Internal Server Error",
+            "upstream returned 500",
+            "GitHub API error: 502",
+            "Reconnecting... 1/5 (502 Bad Gateway)",
+            "502 Bad Gateway final",
+            "429 from https://api.openai.com/v1/responses",
+            "504 Gateway Timeout",
+            # Rate-limit spellings that must survive the boundary tightening.
+            "rate limit exceeded",
+            "rate-limited, retry in 30s",
+            "rate_limit_exceeded",
+            "RateLimitError: slow down",
+            # Substring patterns deliberately left broad.
+            "requests.exceptions.ReadTimeout",
+            "TimeoutException: deadline exceeded",
+            "service temporarily unavailable",
+        ],
+    )
+    def test_genuine_transient_messages_still_match(self, message: str) -> None:
+        assert is_transient_error(message)
+
+    def test_status_code_matches_on_a_later_line(self) -> None:
+        # Multi-line stderr must not hide a leading status code.
+        assert is_transient_error("Reconnecting...\n429 slow down")
+
+
 class TestNoDriftAcrossAdapters:
     """Each adopting adapter must be a superset of the shared core (no removals)."""
 


### PR DESCRIPTION
## Problem

### 1. Substring matching produced false positives (MEDIUM)

`is_transient_error` matched every pattern as a plain substring, so:

| Pattern | Also matched |
| :--- | :--- |
| `"rate"` | generate, iterate, accurate, corporate, separate |
| `"500"` | `15000 tokens`, `0.500 usd`, `200000` |

A deterministic, non-retryable error whose message contained "generate" was retried to exhaustion — burning the whole retry budget and delaying the real failure.

### 2. `retry_async` emitted no signal on retry (LOW)

The hand-rolled adapter loops log each retry; `retry_async` did not, so operators could not see a retry storm in progress on the three paths that use it.

### 3. Jitter (corrected — see below)

## Correction to the reported issue

**The claim that no caller sets `wait_jitter` is wrong.** All three consumers already pass it:

- `providers/litellm_adapter.py:1336` — `wait_jitter=1.0`
- `mcp/client/adapter.py:139` — `wait_jitter=1.0`
- `orchestrator/mcp_tools.py:2155` — `wait_jitter=0.5`

So there was no live thundering-herd problem. The real defect is narrower: the **default** of `0.0` means any *future* caller silently gets lockstep retries. Fixed by changing the default, not by touching the existing callers.

## Consumer map

`is_transient_error` has 7 call sites, all funnelling through the one classifier — `claude_code_adapter:339`, `codex_cli_adapter:943` (inherited by `goose_cli_adapter`, parity locked by its tests), `copilot_cli_adapter:572`, `gemini_cli_adapter:676`, `opencode_adapter:359`, `hermes_cli_adapter:125`, and `orchestrator/adapter:1270`. Several add their own `extra_patterns`.

`BASE_TRANSIENT_PATTERNS` is re-exported as `providers/retry.TRANSIENT_ERROR_PATTERNS` and `orchestrator/adapter.TRANSIENT_ERROR_PATTERNS`, but those tuples are only concatenated and asserted on — **no consumer runs its own substring loop over them**. So the tuple is left byte-identical and only the classifier's interpretation of each entry changed. Existing assertions like `"rate" in TRANSIENT_ERROR_PATTERNS` still hold.

## Per-pattern decisions

**Made precise** (both had demonstrated false positives):

- `"rate"` → `(?<![a-z])rate(?:[ _-]?limit\w*|(?![a-z]))`. Still matches `rate limit`, `rate-limited`, `rate_limit`, `RateLimitError`, `x-ratelimit-*`.
- `"429" "500" "502" "503" "504"` → status-code **position** only: after a status-ish token within ≤4 non-word chars (`http/1.1`, `status`, `status_code`, `code`, `error`, `response`, `returned`, `got`, `failed with`, `upstream`, …); at start of message **or line** (`re.MULTILINE`, for `"429 from https://api.openai.com/…"` and multi-line stderr); or immediately before the code's reason phrase (for `"Reconnecting… 1/5 (502 Bad Gateway)"`). Digit and dot lookarounds kill the numeric false positives.

**Deliberately left as substrings**: `concurrency`, `timeout`, `timed out`, `overloaded`, `temporarily`, `try again`, `connection`. No common English word contains them, and boundaries would *lose* genuine signal — `(?<![a-z])timeout` drops `ReadTimeout`, `timeout(?![a-z])` drops `TimeoutException`. For `connection`, boundaries change nothing in practice (every substring hit is inside a connection word such as `disconnection`), and narrowing to a phrase list would drop real variants like "failed to establish a new connection".

`extra_patterns` keep substring semantics unless a string has a precise rule, so every adapter-local vocabulary (`exit code 1`, `quota`, `startup`, …) behaves exactly as before.

## Jitter

`wait_jitter: float | None = None`, where `None` means **equal jitter**: half the capped backoff fixed, half random (`DEFAULT_JITTER_RATIO = 0.5`), so the wait stays proportional and bounded by `wait_max`. An explicit positive value keeps the old additive `uniform(0, wait_jitter)` semantics, so the three existing callers are unaffected. `0.0` explicitly opts out, negatives raise `ValueError`, and every wait is floored at `MIN_WAIT_SECONDS = 0.001`.

## Logging

`log.warning("retry_async.retry", target=…, attempt=…, attempts=…, delay=…, error=str(exc), error_type=…)`. The `attempt`/`error` field names match `opencode_adapter.retry` and `parallel_executor.event_write.retry` so existing dashboards stay consistent. Nothing is logged after exhaustion — the exception propagates.

## No test encoded the bug

Every pre-existing message assertion still classifies as transient (`"Error 429 Too Many Requests"`, `"HTTP 503 Service Unavailable"`, `"GitHub API error: 502"`, `"502 Bad Gateway final"`, `"429 from https://api.openai.com/…"`), and the vocabulary assertions hold because the tuple is unchanged. No test file needed correcting.

## Testing

- `tests/unit/core` + `tests/unit/providers` — 1642 passed, 7 skipped
- `tests/unit/mcp` — 2159 passed, 1 skipped
- `tests/unit/orchestrator` — 5430 passed, 7 failed, all pre-existing environment failures (`bash: python: command not found`; this box has only `python3`) in `test_runtime_evidence.py` and one obfuscated-shell case in `test_parallel_executor.py`
- `ruff check` + `ruff format --check` clean; `mypy` clean

Added `TestNoFalsePositives` (9 must-not-match strings including `"15000 tokens"`, `"failed to generate"`, `"accurate"`; 15 must-still-match; multi-line status code) and `TestJitteredWait` + `test_retry_async_logs_each_retry` (spread, bounds, non-zero floor, negative rejection, additive-mode parity, log fields).