### PR TITLE
docs: fix references to deleted ouroboros packages

### DIFF
--- a/project-context.md
+++ b/project-context.md
@@ -50,7 +50,7 @@ async def bad():
 
 | Component | Format | Example |
 |-----------|--------|---------|
-| Files | `snake_case.py` | `pal_router.py` |
+| Files | `snake_case.py` | `command_parser.py` |
 | Classes | `PascalCase` | `EffectiveOntology` |
 | Functions | `snake_case` | `calculate_drift` |
 | Variables | `snake_case` | `current_context` |
@@ -65,27 +65,27 @@ async def bad():
 # DO: Absolute imports only
 from ouroboros.core.seed import Seed
 from ouroboros.core.types import Result
-from ouroboros.routing.router import PALRouter
+from ouroboros.router import resolve_skill_dispatch
 
 # DON'T: Relative imports across packages
 from ..core.seed import Seed  # FORBIDDEN
-from .router import PALRouter  # Only within same package
+from .dispatch import resolve_skill_dispatch  # Only within same package
 ```
 
 **Layered Dependencies:**
 ```
 CLI Layer (cli/)
     ↓ can import
-Application Layer (execution/, bigbang/, secondary/)
+Application Layer (orchestrator/, bigbang/, pm/, auto/)
     ↓ can import
-Domain Layer (core/, routing/, evaluation/, resilience/, consensus/)
+Domain Layer (core/, router/, evaluation/, evolution/, resilience/, verification/)
     ↓ can import
 Infrastructure Layer (providers/, persistence/, observability/, config/)
 ```
 
 - Lower layers NEVER import upper layers
 - Domain phases NEVER import each other directly
-- Communication between phases via ExecutionEngine orchestrator
+- Communication between phases goes through the `orchestrator/` package
 
 ---
 

--- a/tests/test-execution-plan.md
+++ b/tests/test-execution-plan.md
@@ -231,7 +231,7 @@ Use these shortcuts during normal iteration. They are cheaper than the full repo
 
 | Change area | Minimum order |
 | --- | --- |
-| `src/ouroboros/config/**`, `src/ouroboros/core/**`, `src/ouroboros/persistence/**`, `src/ouroboros/routing/**` | Phase 0 -> Phase 1 -> relevant Phase 2 suites -> `tests/unit/orchestrator` -> `tests/unit/cli` |
+| `src/ouroboros/config/**`, `src/ouroboros/core/**`, `src/ouroboros/persistence/**`, `src/ouroboros/router/**` | Phase 0 -> Phase 1 -> relevant Phase 2 suites -> `tests/unit/orchestrator` -> `tests/unit/cli` |
 | `src/ouroboros/providers/**` | Phase 0 -> Phase 1 -> `tests/unit/providers` -> `tests/unit/bigbang` -> `tests/unit/orchestrator` |
 | `src/ouroboros/mcp/**` | Phase 0 -> Phase 1 -> `tests/unit/mcp` -> `tests/integration/mcp` |
 | `src/ouroboros/orchestrator/**` | Phase 0 -> Phase 1 -> relevant Phase 2 suites -> `tests/unit/orchestrator` -> `tests/unit/cli` -> `tests/e2e/test_full_workflow.py` |


### PR DESCRIPTION
## Problem

Five directories under `src/ouroboros/` — `routing/`, `secondary/`, `rlm/`, `openclaw/`, `integrations/` — track **zero** files in git. They are already-deleted packages whose only on-disk trace is untracked `__pycache__` bytecode. Verified per directory:

| Directory | git-tracked files | real `.py` files |
| :--- | ---: | ---: |
| `routing/` | 0 | 0 |
| `secondary/` | 0 | 0 |
| `rlm/` | 0 | 0 |
| `openclaw/` | 0 | 0 |
| `integrations/` | 0 | 0 |

An import sweep across `src/` and `tests/` for `from ouroboros.<pkg>` / `import ouroboros.<pkg>` returned zero hits for all five.

The documentation, however, still pointed at them — and `routing/` sitting next to the genuinely-live `router/` is a real navigation hazard.

## Why this PR contains no deletions

Those directories do not exist in a fresh `git worktree` checkout, because untracked files never propagate. They live only in the main working copy, and since they are untracked, **no commit can ever remove them** — that requires `rm -rf` in the working copy, which I did separately.

This PR therefore fixes only what is actually version-controlled: the docs that referenced the dead packages.

## The `PALRouter` reference was doubly dead

`project-context.md:68` documented `from ouroboros.routing.router import PALRouter`. `grep -rn 'PALRouter|PAL_ROUTER|pal_router' src/` returns **zero hits** — neither the package nor the symbol exists.

The live successor is `src/ouroboros/router/` (`__init__.py`, `command_parser.py`, `dispatch.py`, `registry.py`, `types.py`), a stateless skill-dispatch resolver whose documented public entrypoint is the function `resolve_skill_dispatch` (with `ResolveRequest` / `Resolved` / `NotHandled` / `InvalidSkill`). There is no class acting as the public API — `SkillDispatchRouter` exists but is not the entry path — so the example now maps to the real function rather than inventing a class.

## Changes

`project-context.md`
- `:68` — `from ouroboros.routing.router import PALRouter` → `from ouroboros.router import resolve_skill_dispatch`
- `:72` — relative-import example `from .router import PALRouter` → `from .dispatch import resolve_skill_dispatch` (a module that exists)
- `:53` — file-naming example `pal_router.py` → `command_parser.py` (a file that exists)
- `:79`/`:81` — the layered-dependency map listed four dead packages (`execution/`, `secondary/`, `routing/`, `consensus/`). Replaced with the live `orchestrator/`, `bigbang/`, `pm/`, `auto/` (application) and `core/`, `router/`, `evaluation/`, `evolution/`, `resilience/`, `verification/` (domain). Also dropped "via ExecutionEngine orchestrator" — `grep -rn 'ExecutionEngine' src/` returns zero hits, so that class no longer exists; now reads "through the `orchestrator/` package".

`tests/test-execution-plan.md`
- `:234` — `src/ouroboros/routing/**` → `src/ouroboros/router/**`, matching the `tests/unit/router` suite.

## Deliberately left alone

`docs/history/master-roadmap-2026-07.md:99,113` also references `routing/`, but that is the archived roadmap which *planned* this cleanup. Rewriting a historical record would falsify it.

`.gitignore:2` already has `__pycache__/`, so no rule was added.

`src/ouroboros/execution/` was left untouched — it is a separate, intentional tombstone with a tracked `__init__.py` and its own architecture guard.

## Testing

- `import ouroboros` — ok
- `tests/unit/orchestrator/test_decomposition_live_path.py` — 2 passed
- `tests/unit/router tests/unit/cli` — 2362 passed, 7 skipped


Refs #1398.
