### PR TITLE
fix(orchestrator): accept PowerShell-wrapped test evidence

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -295,6 +295,11 @@ Key constraints:
 - Failures are handled by an attempt-then-bounce loop (bounded retries + evaluation feedback) rather than ever-deeper pre-execution splitting
 - Children are dependency-sorted and executed within each level
 
+Delivery receipts are matched against completed runtime tool calls. Shell transport
+wrappers are normalized conservatively, including POSIX `sh -c` and native Windows
+PowerShell `-Command` wrappers, while trailing or executable PowerShell arguments are
+rejected. Command and test claims must still match successful journal entries exactly.
+
 Values above `4` remain executable on the legacy path, but cannot authorize
 Routing D route switching or its crash-resumable parallel owner. Reducing the
 value to `4` or less opts a fresh run into that stronger durable boundary.

--- a/docs/runtime-guides/codex.md
+++ b/docs/runtime-guides/codex.md
@@ -54,6 +54,12 @@ For alternative install methods and shell completions, see the [Codex CLI README
 
 > **Windows users:** Install and run both Codex CLI and Ouroboros inside a WSL 2 environment for full compatibility. See [Platform Support](../platform-support.md) for details.
 
+The evidence verifier also recognizes the narrow `powershell.exe`/`pwsh.exe
+-Command` transport shape used by native Windows runtimes and accepts current
+`uv run`/`uvx` pytest forms, including `python -m pytest`. This compatibility does
+not change native Windows from experimental support or make executable
+PowerShell forms such as `-File` and `-EncodedCommand` trusted evidence aliases.
+
 ## Configuration
 
 To select Codex CLI as the runtime backend, set the following in your Ouroboros configuration:

--- a/src/ouroboros/orchestrator/evidence/shell_parsing.py
+++ b/src/ouroboros/orchestrator/evidence/shell_parsing.py
@@ -72,14 +72,74 @@ def _test_command_invocation_allowing_output_plumbing(command: str) -> str | Non
 
 
 def _shell_command_body(command: str) -> str | None:
-    """Return the ``-c`` body when the command starts with a shell wrapper."""
+    """Return the command body when the command starts with a shell wrapper.
+
+    Codex uses POSIX ``sh -lc`` wrappers on Unix and a native
+    ``pwsh.exe -Command`` wrapper on Windows.  Both are transport wrappers;
+    evidence may cite the exact inner command without repeating the wrapper.
+    """
     if _has_unquoted_status_masking_control(command):
         return None
     try:
         parts = shlex.split(command)
     except ValueError:
         return None
-    return _shell_command_body_from_argv(tuple(parts))
+    argv = tuple(parts)
+    return _shell_command_body_from_argv(argv) or _powershell_command_body_from_argv(argv)
+
+
+_POWERSHELL_EXECUTABLES = frozenset({"powershell", "powershell.exe", "pwsh", "pwsh.exe"})
+_POWERSHELL_FLAG_OPTIONS = frozenset(
+    {
+        "-nologo",
+        "-noprofile",
+        "-noninteractive",
+        "-noni",
+        "-sta",
+        "-mta",
+    }
+)
+_POWERSHELL_VALUE_OPTIONS = frozenset(
+    {
+        "-executionpolicy",
+        "-inputformat",
+        "-outputformat",
+        "-windowstyle",
+        "-workingdirectory",
+    }
+)
+
+
+def _powershell_command_body_from_argv(argv: tuple[str, ...]) -> str | None:
+    """Return a PowerShell ``-Command`` body from a narrow wrapper prefix.
+
+    Only non-executing host options are allowed before ``-Command`` and no
+    trailing arguments are accepted.  This keeps aliasing exact and prevents a
+    partial inner command from proving a larger PowerShell script.
+    """
+    if len(argv) < 3:
+        return None
+    executable = Path(argv[0].replace("\\", "/")).name.lower()
+    if executable not in _POWERSHELL_EXECUTABLES:
+        return None
+
+    index = 1
+    while index < len(argv):
+        option = argv[index].lower()
+        if option in {"-command", "-c"}:
+            if index + 2 != len(argv):
+                return None
+            return argv[index + 1].strip()
+        if option in _POWERSHELL_FLAG_OPTIONS:
+            index += 1
+            continue
+        if option in _POWERSHELL_VALUE_OPTIONS:
+            if index + 1 >= len(argv):
+                return None
+            index += 2
+            continue
+        return None
+    return None
 
 
 _SHELL_OPTIONS_WITH_ARGUMENT = frozenset({"-O", "+O", "-o", "+o", "--init-file", "--rcfile"})
@@ -341,6 +401,7 @@ _UV_VALUE_OPTIONS = frozenset(
         "--extra-index-url",
         "--find-links",
         "--fork-strategy",
+        "--from",
         "--group",
         "--index",
         "--index-strategy",
@@ -415,10 +476,13 @@ _UV_SHORT_FLAG_OPTIONS = frozenset({"n", "q", "U", "v"})
 
 
 def _uv_run_pytest_parts(parts: list[str]) -> list[str] | None:
-    """Parse the uv option prefix and return selected pytest plus its arguments."""
-    if len(parts) < 3 or parts[:2] != ["uv", "run"]:
+    """Parse a ``uv run``/``uvx`` prefix and return pytest plus its arguments."""
+    if len(parts) >= 3 and parts[:2] == ["uv", "run"]:
+        index = 2
+    elif len(parts) >= 2 and parts[0] == "uvx":
+        index = 1
+    else:
         return None
-    index = 2
     while index < len(parts):
         token = parts[index]
         if token == "--":
@@ -466,9 +530,17 @@ def _uv_run_pytest_parts(parts: list[str]) -> list[str] | None:
                     return None
             position = len(cluster)
         index += 1
-    if index >= len(parts) or parts[index] not in {"pytest", "py.test"}:
+    if index >= len(parts):
         return None
-    return parts[index:]
+    if parts[index] in {"pytest", "py.test"}:
+        return parts[index:]
+    if (
+        len(parts) >= index + 3
+        and _is_python_executable(parts[index])
+        and parts[index + 1 : index + 3] == ["-m", "pytest"]
+    ):
+        return parts[index:]
+    return None
 
 
 def _test_invocation_from_prefix(command: str) -> str | None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -4987,6 +4987,12 @@ async def test_unmaterializable_ac_is_judged_while_valid_sibling_completes(
             "pytest tests/test_foo.py",
             id="test-invocation-pipefail-output-plumbing",
         ),
+        pytest.param(
+            '"C:\\\\Users\\\\runner\\\\pwsh.exe" -NoProfile -Command '
+            "'uv run --isolated --with pytest pytest -q tests/test_foo.py'",
+            "uv run --isolated --with pytest pytest -q tests/test_foo.py",
+            id="windows-pwsh-command-wrapper",
+        ),
     ),
 )
 def test_command_claim_supports_runtime_command_shape(runtime_command: str, claim: str) -> None:
@@ -5079,6 +5085,24 @@ def test_command_claim_supports_runtime_command_shape(runtime_command: str, clai
             "pytest tests/unit/test_foo.py",
             {},
             id="tee-redirected-run",
+        ),
+        pytest.param(
+            "pwsh.exe -Command 'pytest tests/test_foo.py' trailing",
+            "pytest tests/test_foo.py",
+            {},
+            id="powershell-command-with-trailing-argv",
+        ),
+        pytest.param(
+            "pwsh.exe -EncodedCommand cAB5AHQAZQBzAHQA",
+            "pytest tests/test_foo.py",
+            {},
+            id="powershell-encoded-command",
+        ),
+        pytest.param(
+            "pwsh.exe -File bootstrap.ps1 -Command 'pytest tests/test_foo.py'",
+            "pytest tests/test_foo.py",
+            {},
+            id="powershell-file-before-command",
         ),
     ),
 )
@@ -10571,6 +10595,9 @@ class TestParallelACExecutor:
             "uv run -qn pytest -q",
             "uv run -p3.12 pytest -q",
             "uv run -m pytest -q",
+            "uv run --python 3.12 --with-requirements requirements.txt "
+            "--with pytest python -m pytest -q",
+            "uvx --python 3.12 --from pytest --with-requirements requirements.txt pytest -q",
         ),
     )
     def test_option_bearing_uv_pytest_is_candidate_evidence(self, command: str) -> None:
@@ -10758,8 +10785,18 @@ class TestParallelACExecutor:
     def test_uv_current_global_flags_remain_test_evidence(self, command: str) -> None:
         assert _looks_like_test_command(command) is True
 
-    def test_option_bearing_uv_command_backs_its_exact_tests_passed_claim(self) -> None:
-        command = "uv run --python 3.12 --with pytest pytest -q"
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "uv run --python 3.12 --with pytest pytest -q",
+            "uv run --python 3.12 --with-requirements requirements.txt "
+            "--with pytest python -m pytest -q",
+            "uvx --python 3.12 --from pytest --with-requirements requirements.txt pytest -q",
+        ),
+    )
+    def test_option_bearing_uv_command_backs_its_exact_tests_passed_claim(
+        self, command: str
+    ) -> None:
         message = AgentMessage(
             type="assistant",
             content=f"Calling tool: Bash: {command}",


### PR DESCRIPTION
## Summary

- Normalize the narrow powershell.exe/pwsh.exe -Command transport wrapper emitted by native Windows runtimes so an exact inner command can back a receipt.
- Recognize current uv run and uvx pytest forms, including python -m pytest and value-bearing runner options.
- Keep aliasing fail-closed: -File, -EncodedCommand, unknown options, and trailing arguments are not accepted.
- Document the evidence boundary without changing native Windows from experimental support.

## Problem

On native Windows, the runtime journal records a PowerShell transport command while a worker receipt cites the exact inner pytest command. The verifier previously normalized POSIX sh -c wrappers only, so successful Windows tests could be rejected as unsupported or fabricated evidence. In the same recovery run, uv run ... python -m pytest and uvx --from pytest ... were not classified as test evidence.

## Test plan

- [x] Windows focused evidence regressions: 36 passed
- [x] Linux related files: 578 passed; the sole failure, test_atomic_windows_capacity_rejection_does_not_dispatch, reproduces unchanged on upstream main
- [x] The one unrelated filesystem race observed in a second container run passed when rerun in isolation
- [x] uv run ruff check and uv run ruff format --check clean for changed Python files
- [x] uv run mypy clean for shell_parsing.py
- [x] git diff --check clean
- [ ] Full repository test suite was not run; validation was limited to the affected orchestrator evidence surface

## Related issues

Refs #2155 for prior native-Windows shell portability context.