### PR TITLE
fix(worktree): decode Git output as UTF-8

### DIFF
--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -51,6 +51,10 @@ Native Windows support is **experimental**. Known limitations:
 - **Terminal/TUI**: Requires a terminal with ANSI support (Windows Terminal recommended; `cmd.exe` is not supported).
 - **CI testing**: Native Windows is not part of the current CI matrix.
 
+Git worktree discovery decodes Git for Windows output as UTF-8, so repository
+paths containing non-ASCII characters do not depend on the active ANSI code
+page. This compatibility does not change the experimental support status.
+
 If you encounter Windows-specific issues, please [open an issue](https://github.com/Q00/ouroboros/issues) with the `platform:windows` label.
 
 ## Python Version Compatibility

--- a/src/ouroboros/core/worktree.py
+++ b/src/ouroboros/core/worktree.py
@@ -130,6 +130,11 @@ def _run_git_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[
             cwd=cwd,
             capture_output=True,
             text=True,
+            # Git for Windows emits repository paths as UTF-8. Relying on the
+            # process ANSI code page (commonly cp949 on Korean Windows) can
+            # make subprocess' reader thread fail and leave stdout as None.
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
             check=False,
         )

--- a/tests/unit/core/test_worktree.py
+++ b/tests/unit/core/test_worktree.py
@@ -15,6 +15,7 @@ from ouroboros.core.worktree import (
     WorktreeError,
     _acquire_lock,
     _branch_exists,
+    _run_git,
     _worktree_cleanup_policy,
     cleanup_task_workspace,
     maybe_prepare_task_workspace,
@@ -24,6 +25,38 @@ from ouroboros.core.worktree import (
     release_task_workspace,
     restore_task_workspace,
 )
+
+
+def test_run_git_decodes_non_ascii_paths_as_utf8(tmp_path: Path) -> None:
+    repo_path = "C:/Users/example/문서/우로보로스"
+    completed = subprocess.CompletedProcess(
+        args=["git", "rev-parse", "--show-toplevel"],
+        returncode=0,
+        stdout=f"{repo_path}\n",
+        stderr="",
+    )
+
+    with patch("ouroboros.core.worktree.subprocess.run", return_value=completed) as run:
+        assert _run_git(["rev-parse", "--show-toplevel"], tmp_path) == repo_path
+
+    assert run.call_args.kwargs["text"] is True
+    assert run.call_args.kwargs["encoding"] == "utf-8"
+    assert run.call_args.kwargs["errors"] == "replace"
+
+
+def test_run_git_round_trips_non_ascii_repository_path(tmp_path: Path) -> None:
+    repo = tmp_path / "문서" / "우로보로스"
+    repo.mkdir(parents=True)
+    subprocess.run(
+        ["git", "init", "--quiet"],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+    )
+
+    resolved = Path(_run_git(["rev-parse", "--show-toplevel"], repo)).resolve()
+
+    assert resolved == repo.resolve()
 
 
 def _workspace(path_root: Path) -> TaskWorkspace:


### PR DESCRIPTION
## Summary

- Decode textual Git worktree commands explicitly as UTF-8 with replacement fallback.
- Preserve repository-root discovery for non-ASCII paths on native Windows ANSI locales.
- Document the behavior without changing native Windows from experimental support.

## Problem

Git for Windows emits repository paths as UTF-8, while subprocess text mode otherwise inherits the active ANSI code page. On a Korean CP949 host this can fail in the reader thread, leave stdout unusable, and abort worktree discovery even though Git succeeded.

## Test plan

- [x] Native Windows worktree suite: 27 passed
- [x] Real Git repository under a Korean path round-trips to the same resolved root
- [x] Ruff check and format clean
- [x] Mypy clean for worktree.py
- [x] git diff --check clean
- [ ] Full repository suite was not run; validation was limited to worktree management

## Related issues

Closes #2246