### PR TITLE
fix(codex): ignore app-managed system skill refreshes

### DIFF
--- a/docs/runtime-guides/codex.ko.md
+++ b/docs/runtime-guides/codex.ko.md
@@ -238,6 +238,8 @@ sandbox = "workspace-write"
 
 `ouroboros setup --runtime codex`를 돌리고 나면 번들 `ooo` 스킬이 `~/.codex/skills/ouroboros-*`에, 라우팅 규칙이 `~/.codex/rules/`에 설치됩니다. Ouroboros를 올린 뒤 **그 산출물만** 갱신하려면 `ouroboros codex refresh`를 쓰세요. `~/.codex/config.toml`도 `~/.ouroboros/config.yaml`도 건드리지 않습니다.
 
+런타임 식별 지문은 사용자가 관리하는 규칙과 스킬을 계속 추적합니다. 다만 Codex Desktop이 자체적으로 갱신하는 예약 경로 `~/.codex/skills/.system`은 제외하며, 같은 `skills` 디렉터리의 사용자 스킬 변경은 이전처럼 런타임 식별 지문을 무효화합니다.
+
 현재 스냅숏 기준 `resolve_packaged_codex_assets()`는 `skills/*/SKILL.md` 번들 **22개**를 해석해 설치합니다(맨 `ooo`와 `welcome` 포함). 아래 표는 그 전부와, 터미널만 쓰는 사람을 위한 CLI 대응입니다.
 
 | `ooo` 스킬 | Codex 세션 | CLI 대응 (터미널) |

--- a/docs/runtime-guides/codex.md
+++ b/docs/runtime-guides/codex.md
@@ -160,6 +160,11 @@ When `runtime_profile` is unset (the default), Ouroboros emits `codex exec` exac
 
 After running `ouroboros setup --runtime codex`, the bundled `ooo` skills are installed into `~/.codex/skills/ouroboros-*` and the routing rules into `~/.codex/rules/`. To refresh only those artifacts after upgrading Ouroboros, run `ouroboros codex refresh`; it does not modify `~/.codex/config.toml` or `~/.ouroboros/config.yaml`. `resolve_packaged_codex_assets()` currently resolves and installs 22 `skills/*/SKILL.md` bundles. The table below is a **subset** — the ones most often driven from a terminal — with their CLI equivalents. See the Korean guide for the complete 22-row table.
 
+Runtime identity fingerprints continue to cover user-managed rules and skills.
+Codex Desktop's reserved `~/.codex/skills/.system` subtree is excluded because
+the app refreshes those bundled skills in place; changes to sibling user skills
+still invalidate the runtime identity as before.
+
 | `ooo` Skill | Codex session | CLI equivalent (Terminal) |
 |-------------|---------------|--------------------------|
 | `ooo interview` | Yes | `ouroboros init start --llm-backend codex "your idea"` |

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -15,7 +15,6 @@ import os
 from pathlib import Path
 import re
 import shlex
-import stat
 import subprocess  # noqa: F401  # compatibility: tests patch this shared module
 import sys
 import tempfile
@@ -60,6 +59,9 @@ from ouroboros.orchestrator.cli_version_attestation import (
     read_cli_executable_filesystem_identity,
     read_cli_executable_resolution_chain_identity,
     require_unchanged_cli_version_attestation,
+)
+from ouroboros.orchestrator.codex_instruction_assets import (
+    update_codex_instruction_asset_fingerprint,
 )
 from ouroboros.orchestrator.frugality_runtime_attestation import (
     attested_codex_child_environment,
@@ -896,82 +898,13 @@ class CodexCliRuntime:
             digest.update(contents)
             digest.update(b"\0")
         for asset_name in ("rules", "skills"):
-            self._update_codex_instruction_asset_fingerprint(
+            update_codex_instruction_asset_fingerprint(
                 digest,
                 codex_home / asset_name,
                 relative_name=asset_name,
+                ignore_direct_system=asset_name == "skills",
             )
         return digest.hexdigest()
-
-    def _update_codex_instruction_asset_fingerprint(
-        self,
-        digest: Any,
-        path: Path,
-        *,
-        relative_name: str,
-        _seen: frozenset[Path] = frozenset(),
-    ) -> None:
-        """Hash active Codex rules/skills assets, including symlink target contents."""
-        digest.update(relative_name.encode("utf-8", errors="surrogateescape"))
-        digest.update(b"\0")
-        try:
-            stat_result = path.lstat()
-        except FileNotFoundError:
-            digest.update(b"missing\0")
-            return
-        except OSError as exc:
-            raise RuntimeError("Cannot inspect Codex instruction assets") from exc
-
-        mode = stat_result.st_mode
-        if stat.S_ISLNK(mode):
-            try:
-                link_target = os.readlink(path)
-                digest.update(b"symlink\0")
-                digest.update(link_target.encode("utf-8", errors="surrogateescape"))
-                digest.update(b"\0")
-            except OSError as exc:
-                raise RuntimeError("Cannot inspect Codex instruction assets") from exc
-            target_path = Path(link_target)
-            if not target_path.is_absolute():
-                target_path = path.parent / target_path
-            normalized_target = target_path.expanduser().absolute()
-            if normalized_target in _seen:
-                digest.update(b"symlink-cycle\0")
-                return
-            self._update_codex_instruction_asset_fingerprint(
-                digest,
-                target_path,
-                relative_name=f"{relative_name}->target",
-                _seen=_seen | {path.expanduser().absolute()},
-            )
-            return
-
-        if stat.S_ISREG(mode):
-            digest.update(b"file\0")
-            try:
-                digest.update(path.read_bytes())
-            except OSError as exc:
-                raise RuntimeError("Cannot read Codex instruction assets") from exc
-            digest.update(b"\0")
-            return
-
-        if stat.S_ISDIR(mode):
-            digest.update(b"directory\0")
-            try:
-                children = sorted(path.iterdir(), key=lambda child: child.name)
-            except OSError as exc:
-                raise RuntimeError("Cannot inspect Codex instruction assets") from exc
-            for child in children:
-                self._update_codex_instruction_asset_fingerprint(
-                    digest,
-                    child,
-                    relative_name=f"{relative_name}/{child.name}",
-                    _seen=_seen | {path.expanduser().absolute()},
-                )
-            digest.update(b"end-directory\0")
-            return
-
-        digest.update(f"non-file:{mode}\0".encode("ascii"))
 
     @staticmethod
     def _stable_codex_profile_config_bytes(contents: bytes) -> bytes:

--- a/src/ouroboros/orchestrator/codex_instruction_assets.py
+++ b/src/ouroboros/orchestrator/codex_instruction_assets.py
@@ -1,0 +1,83 @@
+"""Fingerprint Codex instruction assets across directory and symlink layouts."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import stat
+from typing import Any
+
+
+def update_codex_instruction_asset_fingerprint(
+    digest: Any,
+    path: Path,
+    *,
+    relative_name: str,
+    ignore_direct_system: bool = False,
+    _seen: frozenset[Path] = frozenset(),
+) -> None:
+    """Hash active rules/skills, preserving logical roots through symlinks."""
+    digest.update(relative_name.encode("utf-8", errors="surrogateescape"))
+    digest.update(b"\0")
+    try:
+        stat_result = path.lstat()
+    except FileNotFoundError:
+        digest.update(b"missing\0")
+        return
+    except OSError as exc:
+        raise RuntimeError("Cannot inspect Codex instruction assets") from exc
+
+    mode = stat_result.st_mode
+    if stat.S_ISLNK(mode):
+        try:
+            link_target = os.readlink(path)
+            digest.update(b"symlink\0")
+            digest.update(link_target.encode("utf-8", errors="surrogateescape"))
+            digest.update(b"\0")
+        except OSError as exc:
+            raise RuntimeError("Cannot inspect Codex instruction assets") from exc
+        target_path = Path(link_target)
+        if not target_path.is_absolute():
+            target_path = path.parent / target_path
+        normalized_target = target_path.expanduser().absolute()
+        if normalized_target in _seen:
+            digest.update(b"symlink-cycle\0")
+            return
+        update_codex_instruction_asset_fingerprint(
+            digest,
+            target_path,
+            relative_name=f"{relative_name}->target",
+            ignore_direct_system=ignore_direct_system,
+            _seen=_seen | {path.expanduser().absolute()},
+        )
+        return
+
+    if stat.S_ISREG(mode):
+        digest.update(b"file\0")
+        try:
+            digest.update(path.read_bytes())
+        except OSError as exc:
+            raise RuntimeError("Cannot read Codex instruction assets") from exc
+        digest.update(b"\0")
+        return
+
+    if stat.S_ISDIR(mode):
+        digest.update(b"directory\0")
+        try:
+            children = sorted(path.iterdir(), key=lambda child: child.name)
+        except OSError as exc:
+            raise RuntimeError("Cannot inspect Codex instruction assets") from exc
+        if ignore_direct_system:
+            digest.update(b"app-managed-system-skills\0")
+            children = [child for child in children if child.name != ".system"]
+        for child in children:
+            update_codex_instruction_asset_fingerprint(
+                digest,
+                child,
+                relative_name=f"{relative_name}/{child.name}",
+                _seen=_seen | {path.expanduser().absolute()},
+            )
+        digest.update(b"end-directory\0")
+        return
+
+    digest.update(f"non-file:{mode}\0".encode("ascii"))

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -212,6 +212,65 @@ def test_codex_config_fingerprint_tracks_active_rules_and_skills(
         runtime._assert_codex_config_files_unchanged()
 
 
+def test_codex_config_fingerprint_ignores_only_app_managed_system_skills(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Desktop refreshes of .system must not hide changes to user skills."""
+    codex_home = tmp_path / "codex-home"
+    system_skill = codex_home / "skills" / ".system" / "bundled" / "SKILL.md"
+    user_skill = codex_home / "skills" / "my-skill" / "SKILL.md"
+    system_skill.parent.mkdir(parents=True)
+    user_skill.parent.mkdir(parents=True)
+    system_skill.write_text("system before\n", encoding="utf-8")
+    user_skill.write_text("user before\n", encoding="utf-8")
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    runtime = CodexCliRuntime(cli_path="codex", cwd="/tmp/project")
+
+    original = runtime.execution_identity_contract()["codex_config_fingerprint"]
+    system_skill.write_text("system during refresh\n", encoding="utf-8")
+    (system_skill.parent / "NEW.md").write_text("new bundled file\n", encoding="utf-8")
+
+    assert runtime._fingerprint_codex_config_files() == original
+
+    user_skill.write_text("user after\n", encoding="utf-8")
+
+    assert runtime._fingerprint_codex_config_files() != original
+    with pytest.raises(RuntimeError, match="Codex configuration changed"):
+        runtime._assert_codex_config_files_unchanged()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="directory symlinks require Windows privileges")
+def test_codex_config_fingerprint_ignores_system_skills_through_root_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The logical skills root keeps its ownership boundary through a symlink."""
+    codex_home = tmp_path / "codex-home"
+    skill_target = tmp_path / "skill-target"
+    system_skill = skill_target / ".system" / "bundled" / "SKILL.md"
+    user_skill = skill_target / "my-skill" / "SKILL.md"
+    system_skill.parent.mkdir(parents=True)
+    user_skill.parent.mkdir(parents=True)
+    system_skill.write_text("system before\n", encoding="utf-8")
+    user_skill.write_text("user before\n", encoding="utf-8")
+    codex_home.mkdir()
+    (codex_home / "skills").symlink_to(skill_target, target_is_directory=True)
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    runtime = CodexCliRuntime(cli_path="codex", cwd="/tmp/project")
+
+    original = runtime.execution_identity_contract()["codex_config_fingerprint"]
+    system_skill.write_text("system during refresh\n", encoding="utf-8")
+
+    assert runtime._fingerprint_codex_config_files() == original
+
+    user_skill.write_text("user after\n", encoding="utf-8")
+
+    assert runtime._fingerprint_codex_config_files() != original
+    with pytest.raises(RuntimeError, match="Codex configuration changed"):
+        runtime._assert_codex_config_files_unchanged()
+
+
 def test_codex_config_fingerprint_tracks_instruction_asset_symlink_targets(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- Exclude Codex Desktop's reserved `skills/.system` subtree from the runtime instruction fingerprint.
- Preserve that logical ownership boundary when `CODEX_HOME/skills` is a symlink.
- Keep user-managed rules, sibling skills, and nested user-skill contents covered by the existing fail-closed fingerprint.
- Document the boundary in both English and Korean runtime guides.

## Problem

Codex Desktop refreshes bundled `.system` skills in place. A background run can observe a transient mixed directory and later abort with `Codex configuration changed` even though no user-owned instruction asset changed.

## Safety boundary

Only the direct logical `CODEX_HOME/skills/.system` subtree is excluded. The logical root designation survives a symlinked `skills` directory, while sibling user skills and all user rules continue to invalidate runtime identity when modified.

## Review resolution

The previous review found that the first implementation keyed the exception to the mutable traversal label `relative_name == "skills"`. The fingerprint walker now lives in a focused module and carries `ignore_direct_system` through root symlink traversal, clearing it before descending into ordinary children. A Linux regression test proves `.system` changes remain ignored through a symlinked root while a sibling user-skill change is still rejected.

## Test plan

- [x] Native Windows non-symlink fingerprint selection: 22 passed
- [x] Linux symlink-root regression included in the successful full Python 3.12 CI suite
- [x] Full Python 3.12 CI suite passed
- [x] Ruff check and format passed
- [x] Mypy passed for both changed source modules
- [x] Module-size ratchet passed after extracting the walker
- [x] `git diff --check` passed

## Related issues

Closes #2247