### PR TITLE
fix(ci): decode module-size Git source as UTF-8

### DIFF
--- a/scripts/check-module-size.py
+++ b/scripts/check-module-size.py
@@ -291,7 +291,7 @@ def _baseline_policy(ref: str) -> Policy | None:
                 cwd=REPO_ROOT,
                 check=True,
                 capture_output=True,
-                text=True,
+                encoding="utf-8",
             )
             policy = _policy_literals(completed.stdout)
         except (UnicodeError, subprocess.CalledProcessError, OSError, SyntaxError) as exc:

--- a/tests/unit/scripts/test_check_module_size.py
+++ b/tests/unit/scripts/test_check_module_size.py
@@ -69,6 +69,7 @@ def _baseline_repo(
     soft_cap: int = 2000,
     reseed_slack: int = 200,
     excluded: frozenset[str] = frozenset({"src/ouroboros/_version.py"}),
+    trailer: str = "",
 ) -> str:
     """Build a git repo whose HEAD carries a given policy, and return its ref.
 
@@ -84,6 +85,7 @@ def _baseline_repo(
         f"RESEED_SLACK = {reseed_slack}\n"
         f"GRANDFATHERED: dict[str, int] = {{\n{entries}\n}}\n"
         f"EXCLUDED = frozenset({set(excluded)!r})\n"
+        f"{trailer}"
     )
     script = root / "scripts" / "check-module-size.py"
     script.parent.mkdir(parents=True, exist_ok=True)
@@ -334,6 +336,14 @@ class TestPolicyTightening:
 
         assert module.main(["--baseline-ref", ref]) == 1
         assert "could not inspect policy candidate" in capsys.readouterr().err
+
+    def test_baseline_policy_source_is_decoded_as_utf8(self, module, monkeypatch, tmp_path):
+        ref = _baseline_repo(tmp_path, {}, trailer="# 한글 정책\n")
+        _write(tmp_path, "src/ouroboros/ok.py", 10)
+        _isolate(module, monkeypatch, tmp_path, {})
+        monkeypatch.setattr(module.subprocess, "_text_encoding", lambda: "ascii")
+
+        assert module.main(["--baseline-ref", ref]) == 0
 
     def test_no_baseline_ref_skips_the_comparison(self, module, monkeypatch, tmp_path):
         """A bare local run must not require a git repository."""


### PR DESCRIPTION
## Summary

Closes #2250.

- decode the module-size baseline policy returned by `git show` explicitly as UTF-8 instead of using the host locale
- keep strict decoding so malformed non-UTF-8 Python source still fails closed through the existing error path
- add a regression test with a Korean UTF-8 policy comment while the implicit subprocess encoding is forced to ASCII

This keeps the module-size gate reproducible on native Windows systems using Korean CP949 and other non-UTF-8 locales.

## Verification

- `uv run --frozen pytest -q tests/unit/scripts/test_check_module_size.py` — 34 passed
- `uv run --frozen ruff check scripts/check-module-size.py tests/unit/scripts/test_check_module_size.py`
- `uv run --frozen ruff format --check scripts/check-module-size.py tests/unit/scripts/test_check_module_size.py`
- `python scripts/check-module-size.py --baseline-ref origin/main`
- `git diff --check`

## Reproduction before the fix

On Windows 11 with a Korean CP949 Python locale:

```text
UnicodeDecodeError: 'cp949' codec can't decode byte 0xe2 ...
TypeError: compile() arg 1 must be a string, bytes or AST object
```