### PR TITLE
test(orchestrator): guard against fabricated message drift

### DIFF
--- a/tests/e2e/test_session_persistence.py
+++ b/tests/e2e/test_session_persistence.py
@@ -171,13 +171,17 @@ class TestSessionEventTracking:
         result = await runner.execute_seed(sample_seed)
         assert result.is_ok
 
-        # Check for session events
-        events = await event_store.replay("session", result.value.session_id)
-        event_types = [e.type for e in events]
+        # Check that both session- and execution-scoped progress remain observable.
+        session_events = await event_store.replay("session", result.value.session_id)
+        session_event_types = [event.type for event in session_events]
+        execution_events = await event_store.replay("execution", result.value.execution_id)
+        execution_event_types = [event.type for event in execution_events]
 
-        # Should have session lifecycle events
-        assert "orchestrator.session.started" in event_types
-        assert "orchestrator.session.completed" in event_types
+        assert "orchestrator.session.started" in session_event_types
+        assert "orchestrator.progress.updated" in session_event_types
+        assert "orchestrator.session.completed" in session_event_types
+        assert "workflow.progress.updated" in execution_event_types
+        assert "observability.drift.measured" not in execution_event_types
 
     async def test_tool_called_events_emitted(
         self,


### PR DESCRIPTION
## Why this follow-up exists

PR #2233 removes placeholder-based per-message drift measurements, but its multi-message persistence path did not lock that absence into a regression test.

## What improves when merged

- Asserts ordinary session and workflow progress events remain persisted during a multi-message execution.
- Asserts `observability.drift.measured` is absent from the execution event stream, preventing fabricated drift telemetry from being reintroduced.

## Focused validation

- `uv run pytest tests/e2e/test_session_persistence.py::TestSessionEventTracking::test_progress_events_emitted -q` — 1 passed

Refs #2233