### PR TITLE
fix(retry): bound transient classifier contexts

### DIFF
--- a/src/ouroboros/core/retry.py
+++ b/src/ouroboros/core/retry.py
@@ -9,12 +9,12 @@ Matching is therefore *per pattern*, not uniformly substring-based:
 * Patterns with no realistic false positive ("timeout", "overloaded", ...) stay
   plain substrings — narrowing them would drop genuine variants such as
   ``ReadTimeout`` or ``TimeoutException``.
-* ``"rate"`` is matched on alphabetic boundaries, so ``rate limit`` /
-  ``rate_limit`` / ``RateLimitError`` still match while ``generate``,
-  ``iterate`` and ``accurate`` no longer do.
+* Rate-limit spellings (``rate limit``, ``rate_limit``, ``RateLimitError``)
+  are recognised, while a bare ``rate`` and word fragments such as ``generate``
+  are not.
 * HTTP status codes are matched only in a status-code *position* — after a
-  status-ish token, at the start of a line, or in front of their reason phrase —
-  so a token count like ``15000 tokens`` is no longer read as a ``500``.
+  bounded status-ish token, at the start of a line, or in front of their reason
+  phrase — so fields such as ``zipcode: 500`` are not treated as HTTP failures.
 
 ``extra_patterns`` supplied by a caller keep substring semantics unless the
 pattern has a precise rule in :data:`_PRECISE_PATTERN_REGEXES`, so adapter-local
@@ -53,11 +53,12 @@ BASE_TRANSIENT_PATTERNS: tuple[str, ...] = (
     "connection",  # connection reset / aborted / error
 )
 
-# Tokens that put a bare number in a status-code position ("HTTP 503",
-# "error: 502", "upstream returned 500").
+# Bounded tokens that put a bare number in a status-code position ("HTTP 503",
+# "error: 502", "upstream returned 500").  Alphabetic boundaries prevent a
+# suffix such as the "code" in "zipcode" from supplying status context.
 _HTTP_STATUS_CONTEXT = (
-    r"(?:https?(?:/[\d.]+)?|status(?:[ _-]?code)?|code|errors?|err|response|responded"
-    r"|returns?|returned|got|received|failed with|upstream)"
+    r"(?<![a-z])(?:https?(?:/[\d.]+)?|status(?:[ _-]?code)?|code|errors?|err|response"
+    r"|responded|returns?|returned|got|received|failed with|upstream)(?![a-z])"
 )
 
 # Reason phrases let a leading code be recognised mid-sentence, e.g.
@@ -74,8 +75,8 @@ _HTTP_STATUS_REASONS: dict[str, str] = {
 def _http_status_regex(code: str) -> str:
     """Build a regex that matches *code* only where a status code can appear."""
     alternatives = [
-        # "HTTP 503 ...", "error: 502", "upstream returned 500"
-        rf"{_HTTP_STATUS_CONTEXT}\W{{0,4}}{code}(?![\d.])",
+        # "HTTP 503 ...", "error: 502", "received a 503 from upstream"
+        rf"{_HTTP_STATUS_CONTEXT}\W{{0,4}}(?:(?:an?|the)\W+)?{code}(?![\d.])",
         # "429 from https://api.openai.com/v1/responses" (start of message/line)
         rf"^\W*{code}(?![\d.])",
     ]
@@ -86,14 +87,13 @@ def _http_status_regex(code: str) -> str:
 
 
 _ALPHA_LEFT = r"(?<![a-z])"
-_ALPHA_RIGHT = r"(?![a-z])"
 
 # Patterns whose plain-substring form produced false positives. Everything not
 # listed here is matched as a substring (see module docstring).
 _PRECISE_PATTERN_REGEXES: dict[str, str] = {
-    # "rate limit" / "rate-limited" / "rate_limit" / "RateLimitError" yes;
-    # "generate" / "iterate" / "accurate" / "corporate" no.
-    "rate": rf"{_ALPHA_LEFT}rate(?:[ _-]?limit\w*|{_ALPHA_RIGHT})",
+    # Require a rate-limit spelling; a standalone "rate" describes many
+    # deterministic validation failures (sample rate, tax rate, and so on).
+    "rate": rf"{_ALPHA_LEFT}rate[ _-]?limit\w*",
     "429": _http_status_regex("429"),
     "500": _http_status_regex("500"),
     "502": _http_status_regex("502"),

--- a/src/ouroboros/core/retry.py
+++ b/src/ouroboros/core/retry.py
@@ -53,12 +53,13 @@ BASE_TRANSIENT_PATTERNS: tuple[str, ...] = (
     "connection",  # connection reset / aborted / error
 )
 
-# Bounded tokens that put a bare number in a status-code position ("HTTP 503",
-# "error: 502", "upstream returned 500").  Alphabetic boundaries prevent a
-# suffix such as the "code" in "zipcode" from supplying status context.
+# Explicit HTTP/status tokens that put a bare number in a status-code position.
+# Generic words such as "code", "got", and "returned" are deliberately absent:
+# they also describe deterministic application values, counts, and validation
+# errors.  Compound forms such as "APIStatusError" remain supported.
 _HTTP_STATUS_CONTEXT = (
-    r"(?<![a-z])(?:https?(?:/[\d.]+)?|status(?:[ _-]?code)?|code|errors?|err|response"
-    r"|responded|returns?|returned|got|received|failed with|upstream)(?![a-z])"
+    r"(?<![a-z])(?:https?(?:/[\d.]+)?|status(?:[ _-]?code)?|response[ _-]?status"
+    r"|api[ _-]?(?:status[ _-]?)?error)(?![a-z])"
 )
 
 # Reason phrases let a leading code be recognised mid-sentence, e.g.
@@ -75,14 +76,21 @@ _HTTP_STATUS_REASONS: dict[str, str] = {
 def _http_status_regex(code: str) -> str:
     """Build a regex that matches *code* only where a status code can appear."""
     alternatives = [
-        # "HTTP 503 ...", "error: 502", "received a 503 from upstream"
-        rf"{_HTTP_STATUS_CONTEXT}\W{{0,4}}(?:(?:an?|the)\W+)?{code}(?![\d.])",
+        # "HTTP 503 ...", "status code: 502", "APIStatusError: 500"
+        rf"{_HTTP_STATUS_CONTEXT}\W{{0,4}}{code}(?![\d.])",
+        # Natural upstream reports are specific enough to distinguish a status
+        # from counts such as "received 500 tokens" or "returned 500 chars".
+        rf"(?<![a-z])upstream\W+returned\W{{0,4}}{code}(?![\d.])",
+        rf"(?<![a-z])received\W+(?:a\W+)?{code}\W+from\W+upstream(?![a-z])",
         # "429 from https://api.openai.com/v1/responses" (start of message/line)
         rf"^\W*{code}(?![\d.])",
     ]
     reason = _HTTP_STATUS_REASONS.get(code)
     if reason:
-        alternatives.append(rf"(?<![\d.]){code}\W{{0,3}}{reason}")
+        # requests/urllib3 render "503 Server Error: Service Unavailable".
+        alternatives.append(
+            rf"(?<![\d.]){code}\W{{0,3}}(?:(?:client|server)\W+error\W{{0,3}})?{reason}"
+        )
     return "|".join(alternatives)
 
 

--- a/tests/unit/providers/test_retry.py
+++ b/tests/unit/providers/test_retry.py
@@ -48,6 +48,12 @@ class TestIsTransientError:
         assert not is_transient_error("custom cli still in startup")
         assert is_transient_error("custom cli still in startup", extra_patterns=("startup",))
 
+    def test_extra_patterns_keep_literal_substring_semantics(self) -> None:
+        assert is_transient_error(
+            "custom cli startupsequence failed",
+            extra_patterns=("startup",),
+        )
+
 
 class TestNoFalsePositives:
     """Plain-substring matching used to retry deterministic failures forever.
@@ -69,6 +75,10 @@ class TestNoFalsePositives:
             "billing: cost was 0.500 usd",
             "prompt exceeds 5000 chars",
             "invalid api key: 401 unauthorized",
+            "zipcode: 500 is invalid",
+            "sample rate: 44100 is unsupported",
+            "rate",
+            "request rate exceeded",
         ],
     )
     def test_digit_runs_and_word_fragments_are_not_transient(self, message: str) -> None:
@@ -85,6 +95,7 @@ class TestNoFalsePositives:
             "Reconnecting... 1/5 (502 Bad Gateway)",
             "502 Bad Gateway final",
             "429 from https://api.openai.com/v1/responses",
+            "received a 503 from upstream",
             "504 Gateway Timeout",
             # Rate-limit spellings that must survive the boundary tightening.
             "rate limit exceeded",

--- a/tests/unit/providers/test_retry.py
+++ b/tests/unit/providers/test_retry.py
@@ -79,6 +79,10 @@ class TestNoFalsePositives:
             "sample rate: 44100 is unsupported",
             "rate",
             "request rate exceeded",
+            "received 500 tokens but the model limit is 200",
+            "model returned 500 characters",
+            "got 429 schema violations",
+            "code: 500 is not a supported application value",
         ],
     )
     def test_digit_runs_and_word_fragments_are_not_transient(self, message: str) -> None:
@@ -97,6 +101,9 @@ class TestNoFalsePositives:
             "429 from https://api.openai.com/v1/responses",
             "received a 503 from upstream",
             "504 Gateway Timeout",
+            "requests.exceptions.HTTPError: 503 Server Error: Service Unavailable for url",
+            "429 Client Error Too Many Requests",
+            "500 Server Error Internal Server Error",
             # Rate-limit spellings that must survive the boundary tightening.
             "rate limit exceeded",
             "rate-limited, retry in 30s",


### PR DESCRIPTION
## Why this follow-up exists

PR #2240 consolidated retry classification, but its shared boundaries still treated bare `rate` and generic words such as `received`, `returned`, `got`, and `code` as sufficient transient signals. This focused follow-up removes those deterministic false retries without altering the approved PR's jitter or logging behavior.

## What improves when merged

- Requires an explicit rate-limit spelling while retaining `rate limit`, `rate-limited`, `rate_limit`, and `RateLimitError`.
- Requires explicit HTTP/status evidence or bounded upstream phrasing, so token/character counts, schema violation counts, and application values remain terminal.
- Preserves standard requests-style `429 Client Error` / `500 Server Error` / `503 Server Error` messages as transient.
- Locks in adapter-local `extra_patterns` literal substring behavior.

## Focused validation

- `uv run pytest tests/unit/core/test_retry.py tests/unit/providers/test_retry.py` — 59 passed
- `uv run ruff check src/ouroboros/core/retry.py tests/unit/providers/test_retry.py tests/unit/core/test_retry.py` — passed

Refs #2240