### PR TITLE
fix(mcp): preserve typed interview reopen errors

### DIFF
--- a/src/ouroboros/mcp/telemetry_boundary.py
+++ b/src/ouroboros/mcp/telemetry_boundary.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import builtins
 from collections.abc import Awaitable, Callable
+import json
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -202,6 +203,38 @@ async def observe_adapter_tool_call[T, E](
     return result
 
 
+def _sdk_tool_error(error: object) -> Exception:
+    """Map an explicitly typed tool error onto the SDK's JSON-RPC error channel.
+
+    ``MCPToolError.error_code`` opts into the public machine-readable contract.
+    Its details cross the boundary only when they are a canonical JSON object;
+    malformed details fall back to the existing execution-error behavior without
+    rendering those details into the client-visible message. Untyped errors keep
+    the legacy ``RuntimeError(str(error))`` path and therefore remain ordinary
+    ``CallToolResult(isError=True)`` responses under the MCP SDK.
+    """
+    from mcp.shared.exceptions import MCPError as SDKMCPError
+    from mcp.types import INTERNAL_ERROR
+
+    from ouroboros.mcp.errors import MCPToolError
+
+    if not isinstance(error, MCPToolError) or not error.error_code:
+        return RuntimeError(str(error))
+
+    try:
+        details = json.loads(json.dumps(error.details, ensure_ascii=False, allow_nan=False))
+    except (TypeError, ValueError):
+        return RuntimeError(error.message)
+    if not isinstance(details, dict) or details != error.details:
+        return RuntimeError(error.message)
+
+    return SDKMCPError(
+        code=INTERNAL_ERROR,
+        message=error.message,
+        data={"error_code": error.error_code, "details": details},
+    )
+
+
 async def call_sdk_tool(
     adapter: MCPServerAdapter,
     name: str,
@@ -257,7 +290,7 @@ async def call_sdk_tool(
             )
         if result.is_err:
             error_type = _safe_error_type(result.error)
-            raise RuntimeError(str(result.error))
+            raise _sdk_tool_error(result.error)
         value = result.value
         if definition.output_schema is not None:
             Draft202012Validator(definition.output_schema).validate(value.structured_content)

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -1316,8 +1316,10 @@ class GenerateSeedHandler:
             if details["blockers"]:
                 return Result.err(
                     MCPToolError(
-                        f"Interview must be reopened before Seed generation: {details}",
+                        "Interview must be reopened before Seed generation",
                         tool_name="ouroboros_generate_seed",
+                        error_code="interview_reopen_required",
+                        details=details,
                     )
                 )
             interview_state.requirement_distillation = distillation
@@ -1475,10 +1477,21 @@ class GenerateSeedHandler:
             if seed_result.is_err:
                 error = seed_result.error
                 if isinstance(error, ValidationError):
+                    readiness_code = error.details.get("code")
                     return Result.err(
                         MCPToolError(
                             f"Validation error: {error}",
                             tool_name="ouroboros_generate_seed",
+                            error_code=(
+                                readiness_code
+                                if readiness_code == "interview_reopen_required"
+                                else None
+                            ),
+                            details=(
+                                error.details
+                                if readiness_code == "interview_reopen_required"
+                                else None
+                            ),
                         )
                     )
                 return Result.err(

--- a/tests/integration/mcp/test_server_adapter.py
+++ b/tests/integration/mcp/test_server_adapter.py
@@ -559,6 +559,139 @@ class TestMCPServerAdapterIntegration:
         assert prompt_result.messages[0].content.text == "Hello, MCP!"
 
     @pytest.mark.asyncio
+    async def test_public_v2_client_receives_typed_tool_error_data(self) -> None:
+        """Typed tool failures cross the served SDK boundary as JSON-RPC error data."""
+        from mcp import Client
+        from mcp.server import MCPServer
+        from mcp.shared.exceptions import MCPError as SDKMCPError
+
+        readiness_details = {
+            "code": "interview_reopen_required",
+            "blockers": [
+                {
+                    "candidate_id": "reference-0:contrast-required",
+                    "code": "reference_confirmation_required",
+                    "reason": "required_unknown",
+                    "section": "context",
+                    "reference_ids": ["linear"],
+                }
+            ],
+        }
+
+        class TypedErrorTool:
+            @property
+            def definition(self) -> MCPToolDefinition:
+                return MCPToolDefinition(
+                    name="typed_error",
+                    description="Return a typed readiness failure",
+                )
+
+            async def handle(self, arguments: dict[str, object]):
+                del arguments
+                return Result.err(
+                    MCPToolError(
+                        "Interview must be reopened before Seed generation",
+                        tool_name="typed_error",
+                        error_code="interview_reopen_required",
+                        details=readiness_details,
+                    )
+                )
+
+        adapter = MCPServerAdapter(name="typed-error-boundary")
+        adapter.register_tool(TypedErrorTool())
+
+        with patch.object(MCPServer, "run_stdio_async", new=AsyncMock()):
+            await adapter.serve(transport="stdio")
+
+        async with Client(adapter._mcp_server, mode="auto") as client:
+            with pytest.raises(SDKMCPError) as error_info:
+                await client.call_tool("typed_error", {})
+
+        assert error_info.value.data == {
+            "error_code": "interview_reopen_required",
+            "details": readiness_details,
+        }
+
+    @pytest.mark.asyncio
+    async def test_public_v2_boundary_keeps_untyped_errors_as_tool_results(self) -> None:
+        """Existing untyped failures remain ordinary MCP execution-error results."""
+        from mcp import Client
+        from mcp.server import MCPServer
+
+        class UntypedErrorTool:
+            @property
+            def definition(self) -> MCPToolDefinition:
+                return MCPToolDefinition(
+                    name="untyped_error",
+                    description="Return an ordinary tool failure",
+                )
+
+            async def handle(self, arguments: dict[str, object]):
+                del arguments
+                return Result.err(
+                    MCPToolError(
+                        "Ordinary tool failure",
+                        tool_name="untyped_error",
+                    )
+                )
+
+        adapter = MCPServerAdapter(name="untyped-error-boundary")
+        adapter.register_tool(UntypedErrorTool())
+
+        with patch.object(MCPServer, "run_stdio_async", new=AsyncMock()):
+            await adapter.serve(transport="stdio")
+
+        async with Client(adapter._mcp_server, mode="auto") as client:
+            result = await client.call_tool("untyped_error", {})
+
+        assert result.is_error is True
+        assert result.content[0].text == "Ordinary tool failure"
+
+    @pytest.mark.asyncio
+    async def test_public_v2_boundary_does_not_expose_non_json_tool_error_details(
+        self,
+    ) -> None:
+        """Malformed typed details fall back to the SDK's ordinary safe error result."""
+        from mcp import Client
+        from mcp.server import MCPServer
+
+        class UnsafeDetails:
+            def __repr__(self) -> str:
+                return "private-runtime-object"
+
+        class UnsafeTypedErrorTool:
+            @property
+            def definition(self) -> MCPToolDefinition:
+                return MCPToolDefinition(
+                    name="unsafe_typed_error",
+                    description="Return malformed typed details",
+                )
+
+            async def handle(self, arguments: dict[str, object]):
+                del arguments
+                return Result.err(
+                    MCPToolError(
+                        "Typed tool failure",
+                        tool_name="unsafe_typed_error",
+                        error_code="unsafe_details_probe",
+                        details={"private": UnsafeDetails()},
+                    )
+                )
+
+        adapter = MCPServerAdapter(name="unsafe-details-boundary")
+        adapter.register_tool(UnsafeTypedErrorTool())
+
+        with patch.object(MCPServer, "run_stdio_async", new=AsyncMock()):
+            await adapter.serve(transport="stdio")
+
+        async with Client(adapter._mcp_server, mode="auto") as client:
+            result = await client.call_tool("unsafe_typed_error", {})
+
+        assert result.is_error is True
+        assert result.content[0].text == "Typed tool failure"
+        assert "private-runtime-object" not in result.content[0].text
+
+    @pytest.mark.asyncio
     async def test_public_v2_boundary_preserves_canonical_schema_and_binary_resource(
         self,
     ) -> None:

--- a/tests/integration/mcp/test_server_adapter.py
+++ b/tests/integration/mcp/test_server_adapter.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from ouroboros import __version__
+from ouroboros.bigbang.interview import InterviewRound, InterviewState, InterviewStatus
 from ouroboros.config.models import (
     EvaluationConfig,
     LLMConfig,
@@ -20,9 +21,11 @@ from ouroboros.config.models import (
     RuntimeProfileConfig,
 )
 from ouroboros.core.types import Result
+from ouroboros.interview_adapters import ReferenceCue, ReferenceOrigin
 from ouroboros.mcp.errors import MCPResourceNotFoundError, MCPToolError
 from ouroboros.mcp.server.adapter import MCPServerAdapter, create_ouroboros_server
 from ouroboros.mcp.server.security import AuthConfig, AuthMethod, RateLimitConfig
+from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler
 from ouroboros.mcp.types import (
     ContentType,
     MCPContentItem,
@@ -559,57 +562,68 @@ class TestMCPServerAdapterIntegration:
         assert prompt_result.messages[0].content.text == "Hello, MCP!"
 
     @pytest.mark.asyncio
-    async def test_public_v2_client_receives_typed_tool_error_data(self) -> None:
-        """Typed tool failures cross the served SDK boundary as JSON-RPC error data."""
+    async def test_public_v2_generate_seed_preserves_typed_reopen_error(self) -> None:
+        """The public generate-seed path exposes machine-readable recovery data."""
         from mcp import Client
         from mcp.server import MCPServer
         from mcp.shared.exceptions import MCPError as SDKMCPError
 
-        readiness_details = {
-            "code": "interview_reopen_required",
-            "blockers": [
-                {
-                    "candidate_id": "reference-0:contrast-required",
-                    "code": "reference_confirmation_required",
-                    "reason": "required_unknown",
-                    "section": "context",
-                    "reference_ids": ["linear"],
-                }
+        state = InterviewState(
+            interview_id="session-unresolved-reference",
+            initial_context="Build an issue tool",
+            status=InterviewStatus.COMPLETED,
+            ambiguity_score=0.1,
+            rounds=[
+                InterviewRound(
+                    round_number=1,
+                    question="What outcome matters most?",
+                    user_response="Fast triage.",
+                )
             ],
-        }
-
-        class TypedErrorTool:
-            @property
-            def definition(self) -> MCPToolDefinition:
-                return MCPToolDefinition(
-                    name="typed_error",
-                    description="Return a typed readiness failure",
-                )
-
-            async def handle(self, arguments: dict[str, object]):
-                del arguments
-                return Result.err(
-                    MCPToolError(
-                        "Interview must be reopened before Seed generation",
-                        tool_name="typed_error",
-                        error_code="interview_reopen_required",
-                        details=readiness_details,
-                    )
-                )
-
+            reference_cues=(
+                ReferenceCue(
+                    reference_id="linear",
+                    label="Linear-like",
+                    origin=ReferenceOrigin.USER_TEXT,
+                ),
+            ),
+        )
+        handler = GenerateSeedHandler(
+            agent_runtime_backend="opencode",
+            opencode_mode="plugin",
+        )
         adapter = MCPServerAdapter(name="typed-error-boundary")
-        adapter.register_tool(TypedErrorTool())
+        adapter.register_tool(handler)
 
-        with patch.object(MCPServer, "run_stdio_async", new=AsyncMock()):
+        with (
+            patch(
+                "ouroboros.mcp.tools.authoring_handlers._plugin_load_state",
+                AsyncMock(return_value=Result.ok(state)),
+            ),
+            patch.object(MCPServer, "run_stdio_async", new=AsyncMock()),
+        ):
             await adapter.serve(transport="stdio")
-
-        async with Client(adapter._mcp_server, mode="auto") as client:
-            with pytest.raises(SDKMCPError) as error_info:
-                await client.call_tool("typed_error", {})
+            async with Client(adapter._mcp_server, mode="auto") as client:
+                with pytest.raises(SDKMCPError) as error_info:
+                    await client.call_tool(
+                        "ouroboros_generate_seed",
+                        {"session_id": state.interview_id},
+                    )
 
         assert error_info.value.data == {
             "error_code": "interview_reopen_required",
-            "details": readiness_details,
+            "details": {
+                "code": "interview_reopen_required",
+                "blockers": [
+                    {
+                        "candidate_id": "reference-0:contrast-required",
+                        "code": "reference_confirmation_required",
+                        "reason": "required_unknown",
+                        "section": "context",
+                        "reference_ids": ["linear"],
+                    }
+                ],
+            },
         }
 
     @pytest.mark.asyncio

--- a/tests/unit/mcp/tools/test_interview_reference_context.py
+++ b/tests/unit/mcp/tools/test_interview_reference_context.py
@@ -372,7 +372,12 @@ async def test_plugin_reference_seed_succeeds_for_confirmed_requirement() -> Non
 
     assert result.is_ok
     assert confirmed_requirement in result.value.content[0].text
-    confirmed = result.value.meta["requirement_distillation"]["candidates"][-1]
+    requirement_distillation = result.value.meta["requirement_distillation"]
+    assert isinstance(requirement_distillation, dict)
+    candidates = requirement_distillation["candidates"]
+    assert isinstance(candidates, list)
+    confirmed = candidates[-1]
+    assert isinstance(confirmed, dict)
     assert confirmed["content_source"] == "reference_derived"
     assert confirmed["resolution"] == "confirmed"
     assert confirmed["confirmation_authority"] == "user"

--- a/tests/unit/mcp/tools/test_interview_reference_context.py
+++ b/tests/unit/mcp/tools/test_interview_reference_context.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from ouroboros.bigbang.interview import InterviewRound, InterviewState, InterviewStatus
+from ouroboros.core.errors import ValidationError
 from ouroboros.core.requirement_candidate import (
     CandidateContentSource,
     CandidateResolution,
@@ -195,8 +196,19 @@ async def test_plugin_reference_seed_reopens_when_no_acs_are_promoted() -> None:
         result = await handler.handle({"session_id": state.interview_id})
 
     assert result.is_err
-    assert "interview_reopen_required" in str(result.error)
-    assert "no_promoted_acceptance_criteria" in str(result.error)
+    assert result.error.error_code == "interview_reopen_required"
+    assert result.error.details == {
+        "code": "interview_reopen_required",
+        "blockers": [
+            {
+                "candidate_id": "promoted-acceptance-criteria",
+                "code": "no_promoted_acceptance_criteria",
+                "reason": "no_promoted_acceptance_criteria",
+                "section": "acceptance_criterion",
+                "reference_ids": [],
+            }
+        ],
+    }
     save_state.assert_not_awaited()
     dispatch.assert_not_awaited()
 
@@ -238,5 +250,131 @@ async def test_plugin_seed_reopens_interview_for_queued_unresolved_reference() -
         result = await handler.handle({"session_id": state.interview_id})
 
     assert result.is_err
-    assert "reference_confirmation_required" in str(result.error)
+    assert result.error.error_code == "interview_reopen_required"
+    assert result.error.details == {
+        "code": "interview_reopen_required",
+        "blockers": [
+            {
+                "candidate_id": "reference-0:contrast-required",
+                "code": "reference_confirmation_required",
+                "reason": "required_unknown",
+                "section": "context",
+                "reference_ids": ["linear"],
+            }
+        ],
+    }
+    dispatch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_in_process_seed_preserves_typed_reopen_error() -> None:
+    details = {
+        "code": "interview_reopen_required",
+        "blockers": [
+            {
+                "candidate_id": "reference-0:contrast-required",
+                "code": "reference_confirmation_required",
+                "reason": "required_unknown",
+                "section": "context",
+                "reference_ids": ["linear"],
+            }
+        ],
+    }
+    state = InterviewState(
+        interview_id="session-in-process-reference",
+        initial_context="Build an issue tool",
+        status=InterviewStatus.COMPLETED,
+        ambiguity_score=0.1,
+    )
+    engine = MagicMock()
+    engine.load_state = AsyncMock(return_value=Result.ok(state))
+    generator = MagicMock()
+    generator.generate = AsyncMock(
+        return_value=Result.err(
+            ValidationError(
+                "Interview must be reopened before Seed generation",
+                field="requirement_distillation",
+                details=details,
+            )
+        )
+    )
+    handler = GenerateSeedHandler(
+        interview_engine=engine,
+        seed_generator=generator,
+        llm_adapter=MagicMock(),
+    )
+
+    result = await handler.handle({"session_id": state.interview_id})
+
+    assert result.is_err
+    assert result.error.error_code == "interview_reopen_required"
+    assert result.error.details is details
+
+
+@pytest.mark.asyncio
+async def test_plugin_reference_seed_succeeds_for_confirmed_requirement() -> None:
+    cue = ReferenceCue(
+        reference_id="linear",
+        label="Linear-like",
+        origin=ReferenceOrigin.USER_TEXT,
+    )
+    question = build_reference_contrast_question(cue)
+    confirmed_requirement = "For the Linear-like reference, keyboard-first navigation is required."
+    state = InterviewState(
+        interview_id="session-confirmed-reference",
+        initial_context="Build a Linear-like issue tool",
+        status=InterviewStatus.COMPLETED,
+        ambiguity_score=0.1,
+        rounds=[
+            InterviewRound(
+                round_number=1,
+                question="What outcome matters most?",
+                user_response="Fast triage.",
+            ),
+            InterviewRound(
+                round_number=2,
+                question=question,
+                user_response="Copy speed, not keyboard menus.",
+            ),
+            InterviewRound(
+                round_number=3,
+                question="Which reference traits are actual requirements?",
+                user_response=confirmed_requirement,
+            ),
+        ],
+        reference_cues=(cue,),
+        reference_resolutions=(
+            ReferenceContrastResolution(
+                reference_id="linear",
+                status=ReferenceResolutionStatus.RESOLVED,
+                asked_question=question,
+                answer="Copy speed, not keyboard menus.",
+            ),
+        ),
+    )
+    handler = GenerateSeedHandler(agent_runtime_backend="opencode", opencode_mode="plugin")
+
+    with (
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers._plugin_load_state",
+            AsyncMock(return_value=Result.ok(state)),
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers._plugin_save_state",
+            AsyncMock(return_value=Result.ok(MagicMock())),
+        ) as save_state,
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.dispatch_plugin_terminal",
+            AsyncMock(),
+        ) as dispatch,
+    ):
+        result = await handler.handle({"session_id": state.interview_id})
+
+    assert result.is_ok
+    assert confirmed_requirement in result.value.content[0].text
+    confirmed = result.value.meta["requirement_distillation"]["candidates"][-1]
+    assert confirmed["content_source"] == "reference_derived"
+    assert confirmed["resolution"] == "confirmed"
+    assert confirmed["confirmation_authority"] == "user"
+    save_state.assert_awaited_once()
     dispatch.assert_not_awaited()


### PR DESCRIPTION
## Why this follow-up exists

PR #2226 added the reference-aware Seed readiness gate, but its typed `MCPToolError` contract was flattened at the served SDK boundary. Public MCP v2 clients therefore could not reliably branch on `interview_reopen_required` or inspect blocker metadata.

## What improves when merged

- Sets `MCPToolError.error_code` to `interview_reopen_required` and preserves the existing readiness payload in `details` for plugin and in-process generation paths.
- Maps explicitly typed tool failures onto the MCP SDK JSON-RPC error channel so `Client.call_tool` receives machine-readable `error_code` and `details` data.
- Keeps untyped failures on the existing `CallToolResult(isError=True)` path and refuses to serialize non-canonical JSON details.
- Covers no-promoted-AC, unresolved-reference, confirmed-reference success, public MCP v2 transport, generic-error compatibility, and unsafe-detail fallback paths.

## Focused validation

- `uv run pytest -q tests/unit/mcp/server/test_adapter.py tests/integration/mcp/test_server_adapter.py tests/unit/mcp/tools/test_interview_reference_context.py` — 309 passed
- `uv run mypy src/ouroboros/mcp/telemetry_boundary.py src/ouroboros/mcp/tools/authoring_handlers.py tests/integration/mcp/test_server_adapter.py tests/unit/mcp/tools/test_interview_reference_context.py` — passed
- `uv run ruff check src/ouroboros/mcp/telemetry_boundary.py tests/integration/mcp/test_server_adapter.py tests/unit/mcp/tools/test_interview_reference_context.py` — passed
- `uv run ruff format --check src/ouroboros/mcp/telemetry_boundary.py tests/integration/mcp/test_server_adapter.py tests/unit/mcp/tools/test_interview_reference_context.py` — passed

Refs #2226