### PR TITLE
fix(core): preserve directory close exception precedence

### DIFF
--- a/src/ouroboros/core/file_lock.py
+++ b/src/ouroboros/core/file_lock.py
@@ -219,12 +219,14 @@ def _lock_parent_authority(
         directory_fd = os.open(lock_path.parent, flags)
     else:
         directory_fd = os.dup(parent_fd)
+    outer_body_failed = True
 
     try:
         _validate_lock_parent_binding(directory_fd, lock_path.parent)
         if not stable:
             yield directory_fd
             _validate_lock_parent_binding(directory_fd, lock_path.parent)
+            outer_body_failed = False
             return
 
         opened = os.fstat(directory_fd)
@@ -247,6 +249,7 @@ def _lock_parent_authority(
                 )
             yield directory_fd
             _validate_lock_parent_binding(directory_fd, lock_path.parent)
+            outer_body_failed = False
             return
 
         _acquire_posix_lock(
@@ -287,8 +290,12 @@ def _lock_parent_authority(
                 lambda: _reset_stable_parent_authority(token),
                 suppress_errors=body_failed,
             )
+        outer_body_failed = False
     finally:
-        os.close(directory_fd)
+        _run_release_steps(
+            lambda: os.close(directory_fd),
+            suppress_errors=outer_body_failed,
+        )
 
 
 def _validate_active_lockfile(

--- a/tests/unit/core/test_file_lock.py
+++ b/tests/unit/core/test_file_lock.py
@@ -121,6 +121,40 @@ def _enter_in_copied_context(manager: object) -> None:
     copy_context().run(manager.__enter__)  # type: ignore[attr-defined]
 
 
+def _fail_next_parent_authority_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[int]:
+    """Raise after closing the next stable-parent authority descriptor."""
+    authority_fd: list[int] = []
+    failed_closes: list[int] = []
+    original_acquire = file_lock_module._acquire_posix_lock
+    original_close = file_lock_module.os.close
+
+    def record_acquire(
+        file_descriptor: int,
+        *,
+        exclusive: bool,
+        blocking: bool,
+    ) -> None:
+        if not authority_fd:
+            authority_fd.append(file_descriptor)
+        original_acquire(
+            file_descriptor,
+            exclusive=exclusive,
+            blocking=blocking,
+        )
+
+    def fail_close(file_descriptor: int) -> None:
+        original_close(file_descriptor)
+        if authority_fd == [file_descriptor] and not failed_closes:
+            failed_closes.append(file_descriptor)
+            raise OSError(errno.EIO, "directory close failed")
+
+    monkeypatch.setattr(file_lock_module, "_acquire_posix_lock", record_acquire)
+    monkeypatch.setattr(file_lock_module.os, "close", fail_close)
+    return failed_closes
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX stable-parent authority only")
 def test_cross_context_exit_releases_authority_without_raising(
     monkeypatch: pytest.MonkeyPatch,
@@ -177,6 +211,43 @@ def test_cross_context_exit_leaves_authority_reacquirable(tmp_path: Path) -> Non
     _enter_in_copied_context(manager)
     manager.__exit__(None, None, None)
 
+    with file_lock(contender, blocking=False, stable_parent_authority=True):
+        pass
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX stable-parent authority only")
+def test_parent_directory_close_failure_does_not_mask_body_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "state.json"
+    contender = tmp_path / "contender.json"
+    failed_closes = _fail_next_parent_authority_close(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="the caller's real failure"):
+        with file_lock(target, stable_parent_authority=True):
+            raise RuntimeError("the caller's real failure")
+
+    assert len(failed_closes) == 1
+    with file_lock(contender, blocking=False, stable_parent_authority=True):
+        pass
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX stable-parent authority only")
+def test_parent_directory_close_failure_surfaces_after_clean_body(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "state.json"
+    contender = tmp_path / "contender.json"
+    failed_closes = _fail_next_parent_authority_close(monkeypatch)
+
+    with pytest.raises(OSError, match="directory close failed") as raised:
+        with file_lock(target, stable_parent_authority=True):
+            pass
+
+    assert raised.value.errno == errno.EIO
+    assert len(failed_closes) == 1
     with file_lock(contender, blocking=False, stable_parent_authority=True):
         pass
 


### PR DESCRIPTION
## Why this follow-up exists

PR #2235 correctly made stable-parent lock release and ContextVar cleanup independent, but its approved review identified one remaining cleanup edge: the outer `os.close(directory_fd)` could still replace an exception already propagating from the protected body.

## What improves when merged

- Routes the parent-directory descriptor close through the existing exception-preserving cleanup policy.
- Preserves the protected-body exception when close also fails.
- Keeps a close failure observable after a clean body.
- Verifies that the parent authority lock remains released and immediately reacquirable in both cases.

## Focused validation

- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run python -m pytest tests/unit/core/test_file_lock.py -q` — 20 passed
- `uv run ruff check src/ouroboros/core/file_lock.py tests/unit/core/test_file_lock.py` — passed
- `uv run ruff format --check src/ouroboros/core/file_lock.py tests/unit/core/test_file_lock.py` — passed
- `uv run mypy src/ouroboros/core/file_lock.py` — passed

Refs #2235