### PR TITLE
feat(interview): persist reusable fanout provenance

### DIFF
--- a/src/ouroboros/mcp/tools/fanout.py
+++ b/src/ouroboros/mcp/tools/fanout.py
@@ -412,17 +412,16 @@ def _advisory_synthesizer_input(
     *,
     tool_name: str | None,
     roster_repo_ids: list[str] | None,
+    phase: str | None,
 ) -> dict[str, Any]:
-    """Return the request-side state one advisory fan-out persists.
-
-    Additive by omission: a key absent means "the default", which keeps an
-    interview record identical to what it was before a second tool existed.
-    """
+    """Return the request-side state one advisory fan-out persists."""
     data: dict[str, Any] = {"lane_ids": list(expected_keys)}
     if tool_name and tool_name != "ouroboros_interview":
         data["tool_name"] = tool_name
     if roster_repo_ids is not None:
         data["roster_repo_ids"] = list(roster_repo_ids)
+    if phase:
+        data["phase"] = phase
     return data
 
 
@@ -435,6 +434,7 @@ def register_question_advisory_fanout(
     fanout_id: str | None = None,
     tool_name: str | None = None,
     roster_repo_ids: list[str] | None = None,
+    phase: str | None = None,
 ) -> str | None:
     """Register an interview question-advisory fan-out for later result re-entry.
 
@@ -504,7 +504,10 @@ def register_question_advisory_fanout(
         expected_keys=expected_keys,
         question_identity=question_identity,
         synthesizer_input=_advisory_synthesizer_input(
-            expected_keys, tool_name=tool_name, roster_repo_ids=roster_repo_ids
+            expected_keys,
+            tool_name=tool_name,
+            roster_repo_ids=roster_repo_ids,
+            phase=phase,
         ),
         fanout_id=fanout_id,
         required_keys=required_keys,
@@ -519,6 +522,7 @@ def stamp_question_advisory_fanout(
     payloads: list[SubagentPayload],
     tool_name: str | None = None,
     roster_repo_ids: list[str] | None = None,
+    phase: str | None = None,
 ) -> None:
     """Register the advisory fan-out and stamp its id, if there is one to stamp.
 
@@ -536,6 +540,7 @@ def stamp_question_advisory_fanout(
         payloads=payloads,
         tool_name=tool_name,
         roster_repo_ids=roster_repo_ids,
+        phase=phase,
     )
     if fanout_id is not None:
         meta["question_advisory_fanout_id"] = fanout_id
@@ -979,9 +984,8 @@ def synthesize_fanout_results(prepared: PreparedFanoutSynthesis) -> dict[str, An
         }
 
     if record.kind == FANOUT_KIND_QUESTION_ADVISORY:
-        # Advisory lanes are independent advice with no gating synthesizer, so
-        # aggregate the correlated outputs deterministically in dispatch (lane)
-        # order and hand them back for the host to synthesize.
+        # Request provenance lets later interview turns identify the same-session
+        # start snapshot without trusting a child's free-form output to assert it.
         lane_ids = record.synthesizer_input.get("lane_ids") or list(record.expected_keys)
         aggregated = [
             {"lane_id": lane_id, "output": provided[lane_id]}
@@ -994,6 +998,11 @@ def synthesize_fanout_results(prepared: PreparedFanoutSynthesis) -> dict[str, An
             "fanout_id": fanout_id,
             "kind": record.kind,
             "correlation_key": record.correlation_key,
+            "provenance": {
+                "session_id": record.session_id,
+                "phase": str(record.synthesizer_input.get("phase") or ""),
+                "question_identity": record.question_identity,
+            },
             "result": outcome,
             **completion_report,
         }

--- a/src/ouroboros/mcp/tools/recent_findings.py
+++ b/src/ouroboros/mcp/tools/recent_findings.py
@@ -91,6 +91,66 @@ _ELIGIBLE_LANE_IDS = frozenset({"code_context", "data_context"})
 #: An id costs the same whatever the finding says, so counting them is counting
 #: characters.
 _RECENT_FINDINGS_MAX_ENTRIES = 20
+_INTERVIEW_BASELINE_LANE_IDS = frozenset({"code_context", "web_context"})
+
+
+def interview_baseline_by_lane(
+    findings_store: ArtifactStore | None,
+    *,
+    session_id: str,
+    now: datetime | None = None,
+) -> dict[str, dict]:
+    """Return this interview's newest fresh start-turn factual snapshot.
+
+    The server-authored synthesis provenance supplies session and phase identity;
+    child prose never grants reuse authority. A missing, stale, malformed, or
+    incomplete artifact simply falls back to normal factual fan-out.
+    """
+    if findings_store is None or not session_id:
+        return {}
+    effective_now = now or datetime.now(UTC)
+    try:
+        published = findings_store.published_contracts(
+            since=effective_now - RECENT_FINDINGS_WINDOW,
+            until=effective_now,
+            kind=_ELIGIBLE_FANOUT_KIND,
+        )
+    except (ArtifactStoreError, OSError):
+        return {}
+    for candidate in published:
+        try:
+            fetched = findings_store.fetch(candidate.contract_id)
+        except Exception:
+            continue
+        body = fetched.body
+        if not isinstance(body, dict):
+            continue
+        provenance = body.get("provenance")
+        if not isinstance(provenance, dict):
+            continue
+        if provenance.get("session_id") != session_id or provenance.get("phase") != "start":
+            continue
+        result = body.get("result")
+        outputs = result.get("aggregated_outputs") if isinstance(result, dict) else None
+        if not isinstance(outputs, list):
+            continue
+        carried = {
+            entry["lane_id"]
+            for entry in outputs
+            if isinstance(entry, dict) and entry.get("lane_id") in _INTERVIEW_BASELINE_LANE_IDS
+        }
+        lanes = carried & _INTERVIEW_BASELINE_LANE_IDS
+        if not lanes:
+            continue
+        return {
+            lane_id: {
+                "contract_id": candidate.contract_id,
+                "lane_id": lane_id,
+                "published_at": candidate.published_at.isoformat(),
+            }
+            for lane_id in sorted(lanes)
+        }
+    return {}
 
 
 def _eligible_lane_ids(body: Any) -> set[str]:
@@ -210,5 +270,6 @@ def recent_findings_by_lane(
 
 __all__ = [
     "RECENT_FINDINGS_WINDOW",
+    "interview_baseline_by_lane",
     "recent_findings_by_lane",
 ]

--- a/tests/unit/mcp/tools/test_interview_baseline_foundation.py
+++ b/tests/unit/mcp/tools/test_interview_baseline_foundation.py
@@ -1,0 +1,110 @@
+"""Foundational provenance and lookup for reusable interview artifacts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ouroboros.mcp.tools.evaluation_handlers import SubmitFanoutResultsHandler
+from ouroboros.mcp.tools.fanout import FanoutRegistry, register_question_advisory_fanout
+from ouroboros.mcp.tools.recent_findings import interview_baseline_by_lane
+from ouroboros.mcp.tools.subagent import build_subagent_payload
+from ouroboros.orchestrator.disposable_memory import DisposableMemory
+from ouroboros.persistence.artifact_store import ArtifactStore
+
+
+def _payload(lane_id: str, *, question_identity: str):
+    return build_subagent_payload(
+        tool_name="ouroboros_interview",
+        title=f"baseline:{lane_id}",
+        prompt="inspect",
+        agent="researcher",
+        context={
+            "lane_id": lane_id,
+            "question_identity": question_identity,
+            "required": False,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_fanout_publishes_server_provenance_and_is_reusable(tmp_path: Any) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = ArtifactStore.for_project(workspace)
+    store.initialize()
+    registry = FanoutRegistry(tmp_path / "fanout")
+    memory = DisposableMemory(artifact_store=store)
+    submit = SubmitFanoutResultsHandler(fanout_registry=registry, disposable_memory=memory)
+    session_id = "interview-foundation"
+    question_identity = "interview-question:0123456789abcdef"
+    payloads = [
+        _payload("code_context", question_identity=question_identity),
+        _payload("web_context", question_identity=question_identity),
+    ]
+    fanout_id = register_question_advisory_fanout(
+        registry,
+        session_id=session_id,
+        payloads=payloads,
+        phase="start",
+    )
+    assert fanout_id is not None
+
+    result = await submit.handle(
+        {
+            "session_id": session_id,
+            "fanout_id": fanout_id,
+            "correlation_key": "context.lane_id",
+            "results": [
+                {"key": "code_context", "content": {"claim": "local fact"}},
+                {"key": "web_context", "content": {"claim": "external fact"}},
+            ],
+        }
+    )
+
+    assert result.is_ok, result
+    contract_id = result.unwrap().meta["contract_id"]
+    body = store.fetch(contract_id).body
+    assert body["provenance"] == {
+        "session_id": session_id,
+        "phase": "start",
+        "question_identity": question_identity,
+    }
+    baseline = interview_baseline_by_lane(store, session_id=session_id)
+    assert set(baseline) == {"code_context", "web_context"}
+    assert {entry["contract_id"] for entry in baseline.values()} == {contract_id}
+    assert interview_baseline_by_lane(store, session_id="another-session") == {}
+
+
+@pytest.mark.asyncio
+async def test_non_start_fanout_is_not_reusable_baseline(tmp_path: Any) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = ArtifactStore.for_project(workspace)
+    store.initialize()
+    registry = FanoutRegistry(tmp_path / "fanout")
+    memory = DisposableMemory(artifact_store=store)
+    submit = SubmitFanoutResultsHandler(fanout_registry=registry, disposable_memory=memory)
+    session_id = "interview-foundation"
+    question_identity = "interview-question:fedcba9876543210"
+    payloads = [_payload("code_context", question_identity=question_identity)]
+    fanout_id = register_question_advisory_fanout(
+        registry,
+        session_id=session_id,
+        payloads=payloads,
+        phase="answer",
+    )
+    assert fanout_id is not None
+
+    result = await submit.handle(
+        {
+            "session_id": session_id,
+            "fanout_id": fanout_id,
+            "correlation_key": "context.lane_id",
+            "results": [{"key": "code_context", "content": {"claim": "later fact"}}],
+        }
+    )
+
+    assert result.is_ok, result
+    assert interview_baseline_by_lane(store, session_id=session_id) == {}


### PR DESCRIPTION
## Stack: interview factual research (1/2)

> Foundation layer. Merge this PR before #2261.

| Order | PR | Layer |
|---|---|---|
| 👉 1 | #2260 | Artifact provenance and same-session baseline lookup |
| 2 | #2261 | Factual 2→0 behavior and source-backed web references |

## Summary

- Persist server-authored `session_id`, `phase`, and `question_identity` provenance on question-advisory synthesis artifacts.
- Add a bounded lookup for fresh, same-session `phase=start` artifacts by lane.
- Keep existing interview dispatch behavior unchanged; this PR only supplies the reusable artifact substrate.

## Test plan

- [x] Foundation/fanout/recent-findings suite — 75 passed
- [x] Ruff checks clean
- [x] mypy checks clean

## Review guide

1. `fanout.py`: request phase propagation and server-authored synthesis provenance.
2. `recent_findings.py`: same-session start-artifact lookup and malformed/stale fail-safe behavior.
3. `test_interview_baseline_foundation.py`: publication and non-start rejection contracts.

## Merge order

1. This PR (#2260)
2. #2261