### PR TITLE
docs: add the development loop and review conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,11 @@ Bundled agents live in `src/ouroboros/agents/`. When a skill references an agent
 
 ## Shipping a change (read before you commit)
 
+**The code you edit is not the code that runs, by default.** The checked-in
+`.mcp.json` points at the published PyPI package, so edits to this working tree
+have no effect on a client until you repoint it at local source. See
+[docs/contributing/developing.md](docs/contributing/developing.md).
+
 `main` is protected: direct pushes are rejected with `GH006`, for everyone,
 including the owner. Every change lands through a squash-merged PR, so a
 release tag must be created on the merged `main` commit — not before.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,11 @@ Bundled agents live in `src/ouroboros/agents/`. When a skill references an agent
 
 ## Shipping a change (read before you commit)
 
+**The code you edit is not the code that runs, by default.** The checked-in
+`.mcp.json` points at the published PyPI package, so edits to this working tree
+have no effect on a client until you repoint it at local source. See
+[docs/contributing/developing.md](docs/contributing/developing.md).
+
 `main` is protected: direct pushes are rejected with `GH006`, for everyone,
 including the owner. Every change lands through a squash-merged PR, so a
 release tag must be created on the merged `main` commit — not before.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,9 +158,10 @@ on the paths you touched. Every gate, its local reproduction command, and its
 legitimate escape hatch are documented in
 [CI Gates and Branch Protection](./docs/contributing/ci-gates.md).
 
-Review is performed by `ouroboros-agent[bot]`, and its approval satisfies the
-required review. It grades your PR against the linked issue's requirements and
-reproduces the defects it reports. Read
+`ouroboros-agent[bot]` ties each review verdict to the commit it checked. It
+grades your PR against the linked issue's requirements and reproduces the
+defects it reports. Confirm the applicable verdict belongs to the current head,
+then read
 [Review Conventions](./docs/contributing/review-conventions.md) before your first
 push — most review rounds are lost to objections you can preempt.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,13 @@ uv run ouroboros --version   # verify
 uv run pytest tests/unit/ -q # run tests
 ```
 
+> **`uv sync` is not the whole loop.** The checked-in `.mcp.json` points at the
+> **published PyPI package**, so a clone that you edit is not the code your
+> client runs. Before your first change, read
+> [The Development Loop](./docs/contributing/developing.md) — it covers pointing
+> the tooling at your working tree, where config and state live, and the fastest
+> way to verify each kind of change.
+
 **Requirements**: Python >= 3.12, [uv](https://github.com/astral-sh/uv). LiteLLM-bearing profiles support Python 3.12-3.13.
 
 This repository's `.python-version` defaults source checkouts to **stable Python 3.14** for local development. Core and non-LiteLLM contributor environments support Python 3.12-3.14. LiteLLM-bearing environments, including `--all-extras`, support Python 3.12-3.13; examples prefer Python 3.13 without making it the minimum.
@@ -150,6 +157,12 @@ Four checks are required to merge (`Ruff Lint`, `MyPy Type Check`,
 on the paths you touched. Every gate, its local reproduction command, and its
 legitimate escape hatch are documented in
 [CI Gates and Branch Protection](./docs/contributing/ci-gates.md).
+
+Review is performed by `ouroboros-agent[bot]`, and its approval satisfies the
+required review. It grades your PR against the linked issue's requirements and
+reproduces the defects it reports. Read
+[Review Conventions](./docs/contributing/review-conventions.md) before your first
+push — most review rounds are lost to objections you can preempt.
 
 ### Release Maintenance
 
@@ -826,6 +839,8 @@ ls skills/*.yaml 2>/dev/null || echo "No skill YAML files found"
 
 - [Architecture Overview](./docs/contributing/architecture-overview.md) - How the system fits together
 - [Testing Guide](./docs/contributing/testing-guide.md) - How to write and run tests
+- [The Development Loop](./docs/contributing/developing.md) - Run your own code: local MCP, config, state, per-change verification
+- [Review Conventions](./docs/contributing/review-conventions.md) - What the review bot demands, and how to preempt a round
 - [Key Patterns](./docs/contributing/key-patterns.md) - Core patterns with code examples
 - [CI Gates and Branch Protection](./docs/contributing/ci-gates.md) - What CI enforces, how to reproduce it locally, and how releases land
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,6 +67,9 @@ replayable execution contract on your choice of runtime backend.
 ### Contributing
 
 - [Contributing Guide](../CONTRIBUTING.md) - How to set up, code, test, and submit PRs
+- [The Development Loop](./contributing/developing.md) - Run your own code, not the published package: local MCP, config, state, fastest verification per change type
+- [Review Conventions](./contributing/review-conventions.md) - What the review bot demands, with evidence from real reviews
+- [CI Gates and Branch Protection](./contributing/ci-gates.md) - Required checks, local reproduction, release order
 - [Architecture for Contributors](./contributing/architecture-overview.md) - How modules connect
 - [Source Tour](./contributing/source-tour.md) - Three core mechanisms mapped to file:line coordinates, for teardown writers and reviewers
 - [Agent OS Kernel Terminology](./contributing/agent-os-kernel-terminology.md) - Locked vocabulary for `AgentRuntimeContext`, `ControlPlane`, `ControlContract`, `Directive`, `ControlBus`, and `IOJournal`

--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -60,9 +60,12 @@ the MCP 1.x `[claude]`, `[claude-sdk]`, or `[all]` profiles to this
 environment. Re-run the command after edits because a tool install is a
 snapshot; use `uv run` below when every invocation should reflect the working tree.
 
-The `--python '>=3.12'` matters. `uvx`/`uv tool` otherwise resolve against the
-machine's default interpreter, and on a 3.11 box the MCP server dies before it
-can answer `initialize`. Any launcher you generate must carry the same floor.
+The `--python '>=3.12'` option makes the global tool install's interpreter
+request explicit. uv can discover or download compatible interpreters when
+needed, and this package declares `requires-python = ">=3.12"`. Keep the
+explicit request here for reproducibility. The project-scoped `uv run` commands
+below resolve through the checkout's Python requirement and do not need the same
+flag.
 
 ### Surface 2 — the MCP server
 

--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -13,9 +13,18 @@ The checked-in `.mcp.json` points an MCP client at the **published PyPI
 package**, not at your working tree:
 
 ```json
-{ "command": "uvx",
-  "args": ["--isolated", "--python", ">=3.12", "--from", "ouroboros-ai[mcp]",
-           "ouroboros", "mcp", "serve", "..."] }
+{
+  "mcpServers": {
+    "ouroboros": {
+      "command": "uvx",
+      "args": [
+        "--isolated", "--python", ">=3.12", "--from", "ouroboros-ai[mcp]",
+        "ouroboros", "mcp", "serve",
+        "--runtime", "claude-cli", "--llm-backend", "claude_code"
+      ]
+    }
+  }
+}
 ```
 
 So if you clone the repo, edit a handler, and open your agent client in the

--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -60,12 +60,12 @@ the MCP 1.x `[claude]`, `[claude-sdk]`, or `[all]` profiles to this
 environment. Re-run the command after edits because a tool install is a
 snapshot; use `uv run` below when every invocation should reflect the working tree.
 
-The `--python '>=3.12'` option makes the global tool install's interpreter
-request explicit. uv can discover or download compatible interpreters when
-needed, and this package declares `requires-python = ">=3.12"`. Keep the
-explicit request here for reproducibility. The project-scoped `uv run` commands
-below resolve through the checkout's Python requirement and do not need the same
-flag.
+The `--python '>=3.12'` option repeats the package's compatibility floor at
+the global tool-install boundary. uv can discover or download a compatible
+interpreter when needed, and this package declares `requires-python = ">=3.12"`.
+The range does not pin an exact Python version. The project-scoped `uv run`
+commands below resolve through the checkout's Python requirement and do not need
+the same flag.
 
 ### Surface 2 — the MCP server
 

--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -82,24 +82,28 @@ command is implemented by `serve()` in
 [`src/ouroboros/cli/commands/mcp.py`](../../src/ouroboros/cli/commands/mcp.py).
 
 
-To make a client use it, replace the `ouroboros` entry in your client's MCP
-config — `~/.claude/mcp.json` for Claude Code, or the project `.mcp.json` —
-with the local form, and **preserve every other server entry in the file**:
+To make Claude Code use it without editing the checked-in `.mcp.json`, add a
+local-scoped server with the same name. Claude Code stores local scope under the
+project entry in `~/.claude.json`, and local scope takes precedence over the
+project-scoped server:
 
-```json
-"ouroboros": {
-  "command": "uv",
-  "args": ["run", "--directory", "/path/to/your/clone", "--group", "mcp-test", "ouroboros", "mcp", "serve", "--runtime", "claude-cli", "--llm-backend", "claude_code"],
-  "timeout": 600
-}
+```bash
+claude mcp add --scope local --transport stdio ouroboros -- \
+  uv run --directory /path/to/your/clone --group mcp-test \
+  ouroboros mcp serve --runtime claude-cli --llm-backend claude_code
 ```
+
+Use `claude mcp get ouroboros` to inspect the registered command. Claude Code's
+supported scopes and storage locations are documented in
+[Connect Claude Code to tools via MCP](https://code.claude.com/docs/en/mcp).
+For another client, use that client's documented MCP registration surface
+rather than assuming Claude Code's file locations.
 
 Connection and runtime selection are separate concepts. The example above
 deliberately pins `--runtime` and `--llm-backend` so its smoke-test behavior is
 deterministic. Remove those two option/value pairs if the server should inherit
-the environment/config precedence documented below. Back up the client file
-before editing it, preserve every unrelated server, and restore it when testing
-ends so you do not silently keep running a stale branch weeks later.
+the environment/config precedence documented below. Remove the local override
+when testing ends so you do not silently keep running a stale branch weeks later.
 
 **Restart the client after changing MCP config.** Nothing hot-reloads.
 
@@ -153,7 +157,7 @@ assuming the config loader is broken.
 | What | Default or fallback | Override |
 |---|---|---|
 | Config | `~/.ouroboros/config.yaml` | No dedicated override; follows the effective home directory |
-| Event database | Generated config: `~/.ouroboros/data/ouroboros.db`; legacy fallback: `~/.ouroboros/ouroboros.db` | `persistence.database_path`, relative to the config directory unless absolute |
+| Event database | Generated config: `~/.ouroboros/data/ouroboros.db`; legacy fallback: `~/.ouroboros/ouroboros.db` | `mcp serve --db PATH` for that server process; otherwise `persistence.database_path`, relative to the config directory unless absolute |
 | Logs | `~/.ouroboros/logs/ouroboros.log` | No config-file path override; `logging.log_path` is persisted but is not consumed by the runtime logger |
 | Worktrees created by runs | `~/.ouroboros/worktrees/` | `orchestrator.worktree_root` |
 
@@ -163,8 +167,11 @@ Event-store resolution is implemented by `resolve_event_store_path()` and
 Managed worktrees resolve through `managed_worktree_root()` in
 [`src/ouroboros/core/worktree.py`](../../src/ouroboros/core/worktree.py).
 The event database and managed-worktree entries are defaults and compatibility
-fallbacks, not invariant paths; check `config.yaml` before inspecting or cleaning
-those resources. The runtime log destination is the fixed path shown above.
+fallbacks, not invariant paths. For an MCP server, inspect the active client
+launch command first: an explicit `mcp serve --db PATH` selects that process's
+EventStore instead of the config-resolved path. Otherwise check `config.yaml`
+before inspecting those resources. The runtime log destination is the fixed
+path shown above.
 
 The event database and its WAL can grow across runs. `ouroboros cleanup`
 does not checkpoint, vacuum, truncate, or remove either file; database

--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -20,9 +20,10 @@ package**, not at your working tree:
 
 So if you clone the repo, edit a handler, and open your agent client in the
 project directory, the server that answers is the last release — your change
-has no effect and nothing warns you. The distribution-qualified command
-`uvx --from ouroboros-ai ouroboros ...` likewise runs the published release on
-the command line.
+has no effect and nothing warns you. The isolated, distribution-qualified
+command `uvx --isolated --from ouroboros-ai ouroboros ...` likewise runs the
+published release on the command line instead of reusing an installed tool
+environment.
 
 Point the tooling at your working tree instead. There are two surfaces, and
 which one you need depends on what you changed.

--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -20,8 +20,9 @@ package**, not at your working tree:
 
 So if you clone the repo, edit a handler, and open your agent client in the
 project directory, the server that answers is the last release — your change
-has no effect and nothing warns you. Same for `uvx ouroboros ...` on the
-command line.
+has no effect and nothing warns you. The distribution-qualified command
+`uvx --from ouroboros-ai ouroboros ...` likewise runs the published release on
+the command line.
 
 Point the tooling at your working tree instead. There are two surfaces, and
 which one you need depends on what you changed.

--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -152,7 +152,7 @@ assuming the config loader is broken.
 
 | What | Default or fallback | Override |
 |---|---|---|
-| Config | `~/.ouroboros/config.yaml` | Ouroboros config directory |
+| Config | `~/.ouroboros/config.yaml` | No dedicated override; follows the effective home directory |
 | Event database | Generated config: `~/.ouroboros/data/ouroboros.db`; legacy fallback: `~/.ouroboros/ouroboros.db` | `persistence.database_path`, relative to the config directory unless absolute |
 | Logs | `~/.ouroboros/logs/ouroboros.log` | No config-file path override; `logging.log_path` is persisted but is not consumed by the runtime logger |
 | Worktrees created by runs | `~/.ouroboros/worktrees/` | `orchestrator.worktree_root` |

--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -166,13 +166,19 @@ The event database and managed-worktree entries are defaults and compatibility
 fallbacks, not invariant paths; check `config.yaml` before inspecting or cleaning
 those resources. The runtime log destination is the fixed path shown above.
 
-This state accumulates and it is not small — the event DB and its WAL grow
-across runs, and abandoned run worktrees are the usual cause of a full disk.
-Clean up with the built-in command, which checks locks and dirty trees:
+The event database and its WAL can grow across runs. `ouroboros cleanup`
+does not checkpoint, vacuum, truncate, or remove either file; database
+maintenance is a separate operation and has no supported cleanup command in
+this guide.
+
+The built-in command prunes managed auto-session worktrees and their merged
+branches, stale locks, and orphaned `auto_*.json` session state. It checks live
+locks and dirty worktrees before removing anything:
 
 ```bash
 uv run ouroboros cleanup --dry-run   # report only
-uv run ouroboros cleanup --force
+uv run ouroboros cleanup --force     # also remove clean, unmerged worktrees
+uv run ouroboros cleanup --state-all # include blocked/failed session state
 ```
 
 Never delete the configured worktree root by hand — a live run may hold one.

--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -50,13 +50,15 @@ client spawns the binary for you), install the local package with its isolated
 MCP 2 dependency profile:
 
 ```bash
-uv tool install --force --with mcp --from . ouroboros-ai --python '>=3.12'
+uv tool install --force --with 'mcp==2.0.0' --from . ouroboros-ai --python '>=3.12'
 ```
 
-The `--with mcp` supplies the separate MCP 2 SDK. Do not add the MCP 1.x
-`[claude]`, `[claude-sdk]`, or `[all]` profiles to this environment. Re-run
-the command after edits because a tool install is a snapshot; use `uv run`
-below when you want every invocation to reflect the current working tree.
+The exact `--with 'mcp==2.0.0'` pin supplies the separate MCP 2 SDK without
+bypassing the repository's reviewed version. Keep it synchronized with the
+`mcp` optional dependency and `mcp-test` group in `pyproject.toml`. Do not add
+the MCP 1.x `[claude]`, `[claude-sdk]`, or `[all]` profiles to this
+environment. Re-run the command after edits because a tool install is a
+snapshot; use `uv run` below when every invocation should reflect the working tree.
 
 The `--python '>=3.12'` matters. `uvx`/`uv tool` otherwise resolve against the
 machine's default interpreter, and on a 3.11 box the MCP server dies before it
@@ -152,7 +154,7 @@ assuming the config loader is broken.
 |---|---|---|
 | Config | `~/.ouroboros/config.yaml` | Ouroboros config directory |
 | Event database | Generated config: `~/.ouroboros/data/ouroboros.db`; legacy fallback: `~/.ouroboros/ouroboros.db` | `persistence.database_path`, relative to the config directory unless absolute |
-| Logs | `~/.ouroboros/logs/ouroboros.log` | `logging.log_path`, relative to the config directory unless absolute |
+| Logs | `~/.ouroboros/logs/ouroboros.log` | No config-file path override; `logging.log_path` is persisted but is not consumed by the runtime logger |
 | Worktrees created by runs | `~/.ouroboros/worktrees/` | `orchestrator.worktree_root` |
 
 Event-store resolution is implemented by `resolve_event_store_path()` and
@@ -160,8 +162,9 @@ Event-store resolution is implemented by `resolve_event_store_path()` and
 [`src/ouroboros/config/models.py`](../../src/ouroboros/config/models.py).
 Managed worktrees resolve through `managed_worktree_root()` in
 [`src/ouroboros/core/worktree.py`](../../src/ouroboros/core/worktree.py).
-Treat the table as defaults and compatibility fallbacks, not invariant paths;
-check `config.yaml` before inspecting or cleaning state.
+The event database and managed-worktree entries are defaults and compatibility
+fallbacks, not invariant paths; check `config.yaml` before inspecting or cleaning
+those resources. The runtime log destination is the fixed path shown above.
 
 This state accumulates and it is not small — the event DB and its WAL grow
 across runs, and abandoned run worktrees are the usual cause of a full disk.
@@ -181,7 +184,7 @@ Never delete the configured worktree root by hand — a live run may hold one.
 |---|---|---|
 | Pure Python (no MCP surface) | `uv run pytest tests/unit/<area>` | no |
 | CLI command or flag | `uv run ooo <command>` | no |
-| MCP tool handler | point the client at local source, then call the tool | **yes** |
+| MCP tool handler | `uv run --group mcp-test pytest tests/unit/mcp -q`, then point the client at local source and call the tool | **yes** |
 | `SKILL.md` / markdown | depends on dev-mode vs installed-plugin resolution | usually yes |
 
 Scope your test runs while iterating:
@@ -190,18 +193,20 @@ Scope your test runs while iterating:
 uv run pytest tests/unit/<area> -q
 ```
 
-The full suite runs in parallel — a large win, and not enabled by default:
+For a broad local run, keep external MCP integration and end-to-end coverage
+separate while retaining the hermetic MCP unit suite:
 
 ```bash
-uv run pytest tests/ --ignore=tests/unit/mcp --ignore=tests/integration/mcp \
+uv run --group mcp-test pytest tests/ --ignore=tests/integration/mcp \
   --ignore=tests/e2e -n auto --dist worksteal
 ```
 
-`tests/unit/mcp` is excluded there deliberately. That suite has leaked to real
-state — writing to the real event DB and creating real worktrees. CI runs it
-in a clean container, which is where it belongs; running it repeatedly against
-your own `$HOME` inside a shared checkout is how people lose work. See
-[Testing Guide](./testing-guide.md).
+`tests/conftest.py` redirects `$HOME` before collection and gives every test a
+separate home, so `tests/unit/mcp` cannot write to your real config, event DB,
+logs, or worktrees. Run that suite while changing MCP handlers; reserve the
+external integration and end-to-end suites for environments that provide their
+required services. See [Testing Guide](./testing-guide.md).
+
 
 ## Before you open the PR
 

--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -1,0 +1,172 @@
+# The Development Loop
+
+You cloned this repo to change something. This page is about the shortest path
+from an edit to seeing that edit actually run.
+
+Read it before the architecture docs. Knowing where a module lives does not
+help if the code you are running is not the code you edited — which, by
+default in this repository, it is not.
+
+## The trap: by default you are not running your own code
+
+The checked-in `.mcp.json` points an MCP client at the **published PyPI
+package**, not at your working tree:
+
+```json
+{ "command": "uvx",
+  "args": ["--isolated", "--python", ">=3.12", "--from", "ouroboros-ai[mcp]",
+           "ouroboros", "mcp", "serve", "..."] }
+```
+
+So if you clone the repo, edit a handler, and open your agent client in the
+project directory, the server that answers is the last release — your change
+has no effect and nothing warns you. Same for `uvx ouroboros ...` on the
+command line.
+
+Point the tooling at your working tree instead. There are two surfaces, and
+which one you need depends on what you changed.
+
+### Surface 1 — the CLI
+
+The package installs three console scripts (`pyproject.toml:88`):
+
+| Script | Entry point |
+|---|---|
+| `ooo` | `ouroboros.cli.main:app` |
+| `ouroboros` | `ouroboros.cli.main:app` |
+| `ozo` | `ouroboros.cli.commands.zcode:app` |
+
+Inside the repo, `uv run` already resolves to your working tree — no install
+step, no staleness:
+
+```bash
+uv run ouroboros --version
+uv run ooo status
+```
+
+To make your working tree the `ooo` on your `PATH` everywhere (useful when a
+client spawns the binary for you):
+
+```bash
+uv tool install --force --editable . --python '>=3.12'
+```
+
+The `--python '>=3.12'` matters. `uvx`/`uv tool` otherwise resolve against the
+machine's default interpreter, and on a 3.11 box the MCP server dies before it
+can answer `initialize`. Any launcher you generate must carry the same floor.
+
+### Surface 2 — the MCP server
+
+Most of this project's behavior reaches a user through MCP, so this is the
+surface you will usually need. Run the server straight from your working tree:
+
+```bash
+uv run --directory /path/to/your/clone ouroboros mcp serve
+```
+
+(`serve` is defined at `src/ouroboros/cli/commands/mcp.py:1115`.)
+
+To make a client use it, replace the `ouroboros` entry in your client's MCP
+config — `~/.claude/mcp.json` for Claude Code, or the project `.mcp.json` —
+with the local form, and **preserve every other server entry in the file**:
+
+```json
+"ouroboros": {
+  "command": "uv",
+  "args": ["run", "--directory", "/path/to/your/clone", "ouroboros", "mcp", "serve"],
+  "timeout": 600
+}
+```
+
+Keep connection settings and runtime selection separate: the MCP config
+carries `command` / `args` / `timeout` only. Which model or runtime is used is
+config, not connection — see below. Back up the file before you edit it, and
+restore it when you are done testing so you do not silently keep running a
+stale branch weeks later.
+
+**Restart the client after changing MCP config.** Nothing hot-reloads.
+
+> If the server fails to start, suspect a *different* server first. One broken
+> entry in the client's MCP config can take the whole startup down. Run the
+> serve command by hand and read the first ~40 lines of output.
+
+## Runtime selection lives in config, not in the connection
+
+Config file: `~/.ouroboros/config.yaml`.
+
+```yaml
+llm:
+  backend: claude_code      # claude_code | codex | litellm | opencode
+orchestrator:
+  runtime_backend: claude   # which agent runtime executes work
+```
+
+Resolution order (`src/ouroboros/config/loader.py:1742`):
+
+1. environment variable `OUROBOROS_LLM_BACKEND` — a per-shell override
+2. `~/.ouroboros/config.yaml`
+3. the built-in default (`claude_code`)
+
+A CLI flag on `mcp serve` can be overridden by config in some paths, so if a
+runtime selection appears to be ignored, check `config.yaml` before assuming
+the flag is broken.
+
+## Where state and output go
+
+| What | Where |
+|---|---|
+| Config | `~/.ouroboros/config.yaml` |
+| Event database | `~/.ouroboros/ouroboros.db` (`persistence/event_store.py:552`) |
+| Logs | `~/.ouroboros/logs/ouroboros.log` (`observability/logging.py:163`) |
+| Worktrees created by runs | `~/.ouroboros/worktrees/` |
+
+This state accumulates and it is not small — the event DB and its WAL grow
+across runs, and abandoned run worktrees are the usual cause of a full disk.
+Clean up with the built-in command, which checks locks and dirty trees:
+
+```bash
+uv run ouroboros cleanup --dry-run   # report only
+uv run ouroboros cleanup --force
+```
+
+Never `rm -rf ~/.ouroboros/worktrees` by hand — a live run may hold one.
+
+## Fastest verification per change type
+
+| You changed | Minimum to see it work | Client restart? |
+|---|---|---|
+| Pure Python (no MCP surface) | `uv run pytest tests/unit/<area>` | no |
+| CLI command or flag | `uv run ooo <command>` | no |
+| MCP tool handler | point the client at local source, then call the tool | **yes** |
+| `SKILL.md` / markdown | depends on dev-mode vs installed-plugin resolution | usually yes |
+
+Scope your test runs while iterating:
+
+```bash
+uv run pytest tests/unit/<area> -q
+```
+
+The full suite runs in parallel — a large win, and not enabled by default:
+
+```bash
+uv run pytest tests/ --ignore=tests/unit/mcp --ignore=tests/integration/mcp \
+  --ignore=tests/e2e -n auto --dist worksteal
+```
+
+`tests/unit/mcp` is excluded there deliberately. That suite has leaked to real
+state — writing to the real event DB and creating real worktrees. CI runs it
+in a clean container, which is where it belongs; running it repeatedly against
+your own `$HOME` inside a shared checkout is how people lose work. See
+[Testing Guide](./testing-guide.md).
+
+## Before you open the PR
+
+```bash
+uv run ruff format src/ tests/ && uv run ruff check src/ tests/ --fix
+uv run mypy src/ouroboros
+uv run pytest
+```
+
+Then read [Review Conventions](./review-conventions.md) — the reviewer is
+strict and predictable, and most rounds are lost to objections you can
+preempt. Gate details are in [CI Gates](./ci-gates.md).

--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -28,7 +28,8 @@ which one you need depends on what you changed.
 
 ### Surface 1 — the CLI
 
-The package installs three console scripts (`pyproject.toml:88`):
+The package installs three console scripts (see `[project.scripts]` in
+[`pyproject.toml`](../../pyproject.toml)):
 
 | Script | Entry point |
 |---|---|
@@ -45,11 +46,17 @@ uv run ooo status
 ```
 
 To make your working tree the `ooo` on your `PATH` everywhere (useful when a
-client spawns the binary for you):
+client spawns the binary for you), install the local package with its isolated
+MCP 2 dependency profile:
 
 ```bash
-uv tool install --force --editable . --python '>=3.12'
+uv tool install --force --with mcp --from . ouroboros-ai --python '>=3.12'
 ```
+
+The `--with mcp` supplies the separate MCP 2 SDK. Do not add the MCP 1.x
+`[claude]`, `[claude-sdk]`, or `[all]` profiles to this environment. Re-run
+the command after edits because a tool install is a snapshot; use `uv run`
+below when you want every invocation to reflect the current working tree.
 
 The `--python '>=3.12'` matters. `uvx`/`uv tool` otherwise resolve against the
 machine's default interpreter, and on a 3.11 box the MCP server dies before it
@@ -58,13 +65,20 @@ can answer `initialize`. Any launcher you generate must carry the same floor.
 ### Surface 2 — the MCP server
 
 Most of this project's behavior reaches a user through MCP, so this is the
-surface you will usually need. Run the server straight from your working tree:
+surface you will usually need. MCP 2 is intentionally a separate dependency
+profile: the default `dev` group does not install it. Select the repository's
+`mcp-test` group when running the server straight from your working tree:
 
 ```bash
-uv run --directory /path/to/your/clone ouroboros mcp serve
+uv run --directory /path/to/your/clone --group mcp-test \
+  ouroboros mcp serve --runtime claude-cli --llm-backend claude_code
 ```
 
-(`serve` is defined at `src/ouroboros/cli/commands/mcp.py:1115`.)
+This executes the local package and supplies `mcp==2.0.0`. Do not combine this
+profile with the MCP 1.x `[claude]`, `[claude-sdk]`, or `[all]` profiles. The
+command is implemented by `serve()` in
+[`src/ouroboros/cli/commands/mcp.py`](../../src/ouroboros/cli/commands/mcp.py).
+
 
 To make a client use it, replace the `ouroboros` entry in your client's MCP
 config — `~/.claude/mcp.json` for Claude Code, or the project `.mcp.json` —
@@ -73,24 +87,30 @@ with the local form, and **preserve every other server entry in the file**:
 ```json
 "ouroboros": {
   "command": "uv",
-  "args": ["run", "--directory", "/path/to/your/clone", "ouroboros", "mcp", "serve"],
+  "args": ["run", "--directory", "/path/to/your/clone", "--group", "mcp-test", "ouroboros", "mcp", "serve", "--runtime", "claude-cli", "--llm-backend", "claude_code"],
   "timeout": 600
 }
 ```
 
-Keep connection settings and runtime selection separate: the MCP config
-carries `command` / `args` / `timeout` only. Which model or runtime is used is
-config, not connection — see below. Back up the file before you edit it, and
-restore it when you are done testing so you do not silently keep running a
-stale branch weeks later.
+Connection and runtime selection are separate concepts. The example above
+deliberately pins `--runtime` and `--llm-backend` so its smoke-test behavior is
+deterministic. Remove those two option/value pairs if the server should inherit
+the environment/config precedence documented below. Back up the client file
+before editing it, preserve every unrelated server, and restore it when testing
+ends so you do not silently keep running a stale branch weeks later.
 
 **Restart the client after changing MCP config.** Nothing hot-reloads.
+
+Before restarting it, run the exact serve command by hand. A successful startup
+prints `MCP Server starting on stdio...` and `Registered ... tools` to stderr;
+press Ctrl+C after those lines appear. An immediate `MCP dependencies not
+installed` error means the launcher still omitted the MCP profile.
 
 > If the server fails to start, suspect a *different* server first. One broken
 > entry in the client's MCP config can take the whole startup down. Run the
 > serve command by hand and read the first ~40 lines of output.
 
-## Runtime selection lives in config, not in the connection
+## Runtime selection is separate from the connection
 
 Config file: `~/.ouroboros/config.yaml`.
 
@@ -101,24 +121,47 @@ orchestrator:
   runtime_backend: claude   # which agent runtime executes work
 ```
 
-Resolution order (`src/ouroboros/config/loader.py:1742`):
+The agent runtime and the LLM backend are separate selectors with separate
+precedence rules. The resolvers are `get_agent_runtime_backend()` and
+`get_llm_backend()` in
+[`src/ouroboros/config/loader.py`](../../src/ouroboros/config/loader.py).
 
-1. environment variable `OUROBOROS_LLM_BACKEND` — a per-shell override
-2. `~/.ouroboros/config.yaml`
-3. the built-in default (`claude_code`)
+Agent runtime precedence:
 
-A CLI flag on `mcp serve` can be overridden by config in some paths, so if a
-runtime selection appears to be ignored, check `config.yaml` before assuming
-the flag is broken.
+1. `OUROBOROS_AGENT_RUNTIME`
+2. `OUROBOROS_RUNTIME`
+3. `orchestrator.runtime_backend` in `config.yaml`
+4. the built-in default, `claude`
+
+LLM backend precedence:
+
+1. `OUROBOROS_LLM_BACKEND`
+2. `OUROBOROS_RUNTIME`, only when its value names a backend that implements the
+   LLM adapter contract
+3. `llm.backend` in `config.yaml`
+4. the built-in default, `claude_code`
+
+An explicit `mcp serve --runtime` or `--llm-backend` option selects that server
+process directly. Otherwise, if a selection appears to ignore YAML, inspect the
+client launcher's environment and your shell's `OUROBOROS_*` variables before
+assuming the config loader is broken.
 
 ## Where state and output go
 
-| What | Where |
-|---|---|
-| Config | `~/.ouroboros/config.yaml` |
-| Event database | `~/.ouroboros/ouroboros.db` (`persistence/event_store.py:552`) |
-| Logs | `~/.ouroboros/logs/ouroboros.log` (`observability/logging.py:163`) |
-| Worktrees created by runs | `~/.ouroboros/worktrees/` |
+| What | Default or fallback | Override |
+|---|---|---|
+| Config | `~/.ouroboros/config.yaml` | Ouroboros config directory |
+| Event database | Generated config: `~/.ouroboros/data/ouroboros.db`; legacy fallback: `~/.ouroboros/ouroboros.db` | `persistence.database_path`, relative to the config directory unless absolute |
+| Logs | `~/.ouroboros/logs/ouroboros.log` | `logging.log_path`, relative to the config directory unless absolute |
+| Worktrees created by runs | `~/.ouroboros/worktrees/` | `orchestrator.worktree_root` |
+
+Event-store resolution is implemented by `resolve_event_store_path()` and
+`event_store_path_from_config()` in
+[`src/ouroboros/config/models.py`](../../src/ouroboros/config/models.py).
+Managed worktrees resolve through `managed_worktree_root()` in
+[`src/ouroboros/core/worktree.py`](../../src/ouroboros/core/worktree.py).
+Treat the table as defaults and compatibility fallbacks, not invariant paths;
+check `config.yaml` before inspecting or cleaning state.
 
 This state accumulates and it is not small — the event DB and its WAL grow
 across runs, and abandoned run worktrees are the usual cause of a full disk.
@@ -129,7 +172,8 @@ uv run ouroboros cleanup --dry-run   # report only
 uv run ouroboros cleanup --force
 ```
 
-Never `rm -rf ~/.ouroboros/worktrees` by hand — a live run may hold one.
+Never delete the configured worktree root by hand — a live run may hold one.
+
 
 ## Fastest verification per change type
 

--- a/docs/contributing/review-conventions.md
+++ b/docs/contributing/review-conventions.md
@@ -15,8 +15,9 @@ nobody catalogued. Start with the question. The rules are what it looks like
 when the answer was no.
 
 Everything here was extracted from the bot's actual review bodies on this
-repository's PRs, not from a style guide. Some PRs take a single round; one
-took thirty and was closed unmerged.
+repository's PRs, not from a style guide. Some PRs clear review quickly; PR
+#1926 accumulated 64 `CHANGES_REQUESTED` reviews across 60 commits and was
+closed unmerged.
 
 ## What the review actually contains
 
@@ -73,16 +74,16 @@ So when a round arrives, there are two possible readings:
 
 Telling those apart early is the whole skill. What it costs to get wrong:
 
-| PR | Direction taken | Rounds | Outcome |
+| PR | Direction taken | `CHANGES_REQUESTED` reviews | Outcome |
 |---|---|---|---|
-| #1926 | "**bind** regex evidence to acceptance input" — make the check correct enough to be trusted | 30 | **closed, never merged** |
+| #1926 | "**bind** regex evidence to acceptance input" — make the check correct enough to be trusted | 64 across 60 commits | **closed, never merged** |
 | #2065 | "**refuse** unbound regex evidence as grounds to overturn an agent FAIL" — stop trusting it | 3 | merged |
 
-The same defect. Thirty rounds versus three. #2065 did not out-argue the
+The same defect. Sixty-four change-request reviews versus three. #2065 did not out-argue the
 reviewer and did not write a better check — it asked whether that component
 should have been allowed to overturn a verdict at all, and the answer was no.
 
-Nobody in #1926 was careless. Every round was answered. The question that
+Nobody in #1926 was careless. The repeated findings were answered. The question that
 would have ended it in week one was never asked.
 
 ### The signal that you should be asking it
@@ -127,7 +128,7 @@ Re-derive from the problem instead:
 Read these as worked examples of the question being skipped, not as a taxonomy
 to match your situation against.
 
-**Enumerating a surface you do not own** (#2212, 10 rounds). A hand-maintained
+**Enumerating a surface you do not own** (#2212, 10 change-request reviews). A hand-maintained
 `uv run` option grammar inside a verification path. Round after round named
 another gap — *"The hand-maintained option grammar is still incomplete for
 valid current `uv run` commands."* A table mirroring someone else's CLI can
@@ -135,7 +136,7 @@ never be complete, so the rounds could not end. It closed when the code stopped
 enumerating what was allowed and started refusing anything it had not
 positively parsed.
 
-**Two paths kept alive that must agree** (#2193, 7 rounds). A new fused path
+**Two paths kept alive that must agree** (#2193, 7 change-request reviews). A new fused path
 beside the legacy one: the legacy branch skipping completion logic, the atomic
 branch losing an answer on failure, `[decide_later]` meaning different things
 depending on which path ran. Two implementations that must stay identical will

--- a/docs/contributing/review-conventions.md
+++ b/docs/contributing/review-conventions.md
@@ -274,7 +274,8 @@ requirement that is simply unmet.
 - **Re-review is triggered by a comment.** Push your fix, then post a comment
   explaining what changed. A push alone is unreliable; empty commits and
   re-requesting a reviewer do not work. Turnaround is typically 7–15 minutes.
-- **The review pins a commit.** Check the `HEAD checked` field — a verdict may
+- **The review pins a commit.** Compare the commit associated with the submitted
+  review in the PR review metadata with the PR's current head; a verdict may
   predate your latest push.
 - **Prior findings carry forward.** Respond to each one, in the PR
   conversation, even if the answer is "not doing this, because …".

--- a/docs/contributing/review-conventions.md
+++ b/docs/contributing/review-conventions.md
@@ -1,7 +1,8 @@
 # Review Conventions
 
-Every PR is reviewed by `ouroboros-agent[bot]` ("ourobot") before it can merge.
-Its approval satisfies the required review on `main`.
+`ouroboros-agent[bot]` ("ourobot") records review verdicts against specific
+commits. Before acting on a verdict, verify that its associated commit is the
+PR's current head.
 
 The bot is strict, and it is strict in a predictable, repeatable way. Most
 review rounds are lost to objections that could have been preempted before the
@@ -117,36 +118,39 @@ Re-derive from the problem instead:
    you have the change you should have opened.
 4. Say it in the PR: the current shape cannot close, here is the one that can.
    A stated structural argument gets engaged with — the reviewer's own
-   non-blocking notes are frequently pointing at it already. In #2212 the exit
-   was sitting in a round-5 suggestion to share one authoritative parser
-   instead of maintaining parallel option tables that drift.
+   non-blocking notes are frequently pointing at it already. In #2212 a round-5
+   suggestion proposed one authoritative parser instead of parallel option
+   tables; the merged repair instead bounded the affected parser and rejected
+   unknown or malformed option forms.
 5. Be willing to close the PR and open a differently-shaped one. #2065 is not a
    failure story. It is the correct ending to #1926.
 
-### Three ways this has actually gone wrong here
+### Three ways review pressure changed the design
 
-Read these as worked examples of the question being skipped, not as a taxonomy
-to match your situation against.
+Read these as worked examples of a boundary becoming explicit, not as a
+taxonomy to match your situation against.
 
-**Enumerating a surface you do not own** (#2212, 10 change-request reviews). A hand-maintained
-`uv run` option grammar inside a verification path. Round after round named
-another gap — *"The hand-maintained option grammar is still incomplete for
-valid current `uv run` commands."* A table mirroring someone else's CLI can
-never be complete, so the rounds could not end. It closed when the code stopped
-enumerating what was allowed and started refusing anything it had not
-positively parsed.
+**Conservatively parsing a surface you do not own** (#2212, 10 change-request
+reviews). The verification path needed to recognize `uv run` without accepting
+non-executing or malformed commands as test evidence. Repeated reviews found
+missing value-taking options and unsafe command forms. The merged repair kept a
+bounded option table for that path, rejected unknown or malformed forms, and
+covered compound and non-executing modes. The current tree still has a separate
+`uv run` parser in `evaluation/detector.py`; this example is about fail-closed
+evidence validation, not eliminating every option table.
 
-**Two paths kept alive that must agree** (#2193, 7 change-request reviews). A new fused path
-beside the legacy one: the legacy branch skipping completion logic, the atomic
-branch losing an answer on failure, `[decide_later]` meaning different things
-depending on which path ran. Two implementations that must stay identical will
-diverge along a new axis every round. One of them has to stop existing.
+**Keeping compatibility paths under one contract** (#2193, 7 change-request
+reviews). The atomic PM path and legacy two-call fallback both remained. The
+repair aligned decision counting and Seed eligibility across them, then made
+the fallback boundary explicit through the atomic-turn capability flag. The
+lesson is not that one path must disappear; it is that capability differences
+must not change shared interview semantics.
 
-**Trusting a component that should not be trusted** (#1926 → #2065, above).
+**Removing authority from an unreliable component** (#1926 → #2065, above).
 
-In all three, the reviewer was not being pedantic. It was repeatedly reporting
-the same underlying fact — this shape cannot hold — in the only vocabulary it
-has: specific findings at specific lines.
+In all three, specific line findings exposed an authority, parsing, or
+compatibility boundary. The durable repair stated that boundary in code and
+tests instead of patching each observed example.
 
 ### Not an escape hatch
 
@@ -183,8 +187,10 @@ A code path that accepts a request, does nothing, and reports success is
 always a blocker:
 
 > "The public tool schema accepts `answers`, but plugin mode only examines the
-> singular `answer` variable. A request … enters the plugin branch, records no
-> rounds, and still returns a successful delegation receipt." — #2224
+> singular `answer` variable. A request such as `{"session_id": id, "answers":
+> [{"question": "Which workflow?", "answer": "Review"}]}` enters the plugin
+> branch, records no rounds, and still returns a successful delegation receipt."
+> — #2224
 
 Corollaries the bot enforces: do not truncate silently, do not drop items from
 a batch without saying so, and do not swallow an exception into a default.
@@ -234,7 +240,7 @@ the timeout must surface through the normal error contract rather than as a
 bare exception:
 
 > "Timeout from the changed legacy `communicate()` path is not translated into
-> the adapter's `Result.err(ProviderError)` contract or followed by child
+> the adapter’s `Result.err(ProviderError)` contract or followed by child
 > cleanup." — #2239
 
 Bounding the primary wait is not enough if a stream drain sits outside the

--- a/docs/contributing/review-conventions.md
+++ b/docs/contributing/review-conventions.md
@@ -11,7 +11,7 @@ first push. This page exists so you can preempt them.
 It is tempting to read a page like this as a checklist to satisfy. Do not. The
 recurring blockers catalogued below are all the same question wearing different
 clothes — *is this change structurally in the right direction?* — and a
-contributor who memorizes ten rules will lose a month to the eleventh case
+contributor who memorizes a list of rules will lose time to the next case
 nobody catalogued. Start with the question. The rules are what it looks like
 when the answer was no.
 
@@ -163,13 +163,7 @@ disagreement, and the reviewer is probably right.
 
 Ordered by how often they appear in review bodies.
 
-### 1. Fix the root cause, not the symptom
-
-The per-diff form of the question above: *if this input arrives again through a
-different path, does the bug come back?* If yes, you moved the symptom rather
-than removing it, and the next round will say so somewhere else.
-
-### 2. Validate untrusted input — never coerce it
+### 1. Validate untrusted input — never coerce it
 
 `bool(...)` on an external payload is a blocker, not a shortcut:
 
@@ -181,7 +175,7 @@ Anything crossing a trust boundary — a planner payload, an MCP argument, a
 config file, `./.env` — gets parsed and validated against a closed set of
 accepted values.
 
-### 3. No silent success
+### 2. Honor the public schema and never report silent success
 
 A code path that accepts a request, does nothing, and reports success is
 always a blocker:
@@ -195,19 +189,7 @@ always a blocker:
 Corollaries the bot enforces: do not truncate silently, do not drop items from
 a batch without saying so, and do not swallow an exception into a default.
 
-### 4. Fail closed
-
-When a check cannot prove the safe condition holds, it must refuse, not
-proceed. Recent examples that landed on exactly this principle: making
-`is_on_protected_branch` fail closed (#2236), and a gate that errors rather
-than passing when it cannot enumerate changed files.
-
-### 5. Keep the public schema and the implementation in agreement
-
-If a declared parameter is not honored on every branch, that is a defect even
-when the common path works. See #2224 above.
-
-### 6. Same semantics across every runtime
+### 3. Keep the same semantics across every runtime
 
 This project drives many backends. Behavior that changes meaning depending on
 which one is active is a blocker:
@@ -219,7 +201,7 @@ which one is active is a blocker:
 
 When you add a behavior to one adapter, check the others.
 
-### 7. Crash-safety and idempotency on the persistence path
+### 4. Preserve crash-safety and idempotency on persistence paths
 
 Commit ordering and retry behavior are reviewed explicitly:
 
@@ -233,7 +215,7 @@ Commit ordering and retry behavior are reviewed explicitly:
 
 A lock serializes; it does not make an operation idempotent.
 
-### 8. Bound every wait
+### 5. Bound every wait
 
 Any subprocess wait, network call, or stream drain needs a finite ceiling, and
 the timeout must surface through the normal error contract rather than as a
@@ -245,17 +227,6 @@ bare exception:
 
 Bounding the primary wait is not enough if a stream drain sits outside the
 deadline (#2239).
-
-### 9. Regression coverage for every new branch
-
-"Add regression coverage for the newly bounded subprocess paths" appears
-verbatim as a blocker. A new conditional without a test that exercises it will
-be flagged, and the bot names the specific case it wants covered.
-
-### 10. Do not add production contracts for test convenience
-
-Test-only environment variables and test-only public knobs are rejected. Make
-the test set up real state instead.
 
 ## Preempting a round
 

--- a/docs/contributing/review-conventions.md
+++ b/docs/contributing/review-conventions.md
@@ -20,7 +20,7 @@ The bot posts a fixed structure:
    checked. If you pushed after it started, the verdict describes the older commit.
 2. **What Improved** — what the PR does well.
 3. **Issue Requirements** — a table grading your PR against **the linked
-   issue's** requirements, each marked *Met*, *Partially met*, or unmet.
+   issue's** requirements, each marked *Met*, *Partially met*, or *Not met*.
 4. **Prior Findings Status** — every finding from earlier rounds, and whether
    you resolved it. Unaddressed findings carry forward.
 5. **Blockers** — a table of `File:Line`, severity, and the finding.

--- a/docs/contributing/review-conventions.md
+++ b/docs/contributing/review-conventions.md
@@ -7,10 +7,16 @@ The bot is strict, and it is strict in a predictable, repeatable way. Most
 review rounds are lost to objections that could have been preempted before the
 first push. This page exists so you can preempt them.
 
-The rules below were extracted from the bot's actual review bodies on merged
-PRs, not from a style guide. Some PRs take a single round; some take seven.
-The difference is almost entirely whether the change is a root-cause fix with
-proof, or a plausible-looking patch.
+It is tempting to read a page like this as a checklist to satisfy. Do not. The
+recurring blockers catalogued below are all the same question wearing different
+clothes — *is this change structurally in the right direction?* — and a
+contributor who memorizes ten rules will lose a month to the eleventh case
+nobody catalogued. Start with the question. The rules are what it looks like
+when the answer was no.
+
+Everything here was extracted from the bot's actual review bodies on this
+repository's PRs, not from a style guide. Some PRs take a single round; one
+took thirty and was closed unmerged.
 
 ## What the review actually contains
 
@@ -38,16 +44,116 @@ Two consequences worth internalizing:
   guard"* (#2224, #2239). You are not arguing with a linter. If you claim a
   path is unreachable, expect it to be tested.
 
+## Is this change structurally in the right direction?
+
+Ask this before your first push, and again every time a round lands. It is the
+only question on this page that matters, and the rest of the page exists
+because it is the one people skip.
+
+This project's whole premise is that most failure is upstream of the code —
+you solve the root problem or you spend forever on symptoms. Review applies
+that premise to your diff. A round is not an obstacle between you and merge.
+It is evidence about your direction.
+
+So when a round arrives, there are two possible readings:
+
+- **This specific thing is wrong.** Fix it, push, done. Most rounds.
+- **The reviewer found this because the shape makes it findable.** Fix the
+  specific thing and another one appears, because you are defending a position
+  that cannot be defended. No number of rounds closes this.
+
+Telling those apart early is the whole skill. What it costs to get wrong:
+
+| PR | Direction taken | Rounds | Outcome |
+|---|---|---|---|
+| #1926 | "**bind** regex evidence to acceptance input" — make the check correct enough to be trusted | 30 | **closed, never merged** |
+| #2065 | "**refuse** unbound regex evidence as grounds to overturn an agent FAIL" — stop trusting it | 3 | merged |
+
+The same defect. Thirty rounds versus three. #2065 did not out-argue the
+reviewer and did not write a better check — it asked whether that component
+should have been allowed to overturn a verdict at all, and the answer was no.
+
+Nobody in #1926 was careless. Every round was answered. The question that
+would have ended it in week one was never asked.
+
+### The signal that you should be asking it
+
+You are not obliged to introspect after every comment. These are the specific
+signs that the next round will not be the last one:
+
+- The same finding **reappears at a different line number**. You are moving the
+  failure, not removing it.
+- Each fix **adds surface** — another branch, another special case, another
+  entry in a table.
+- The blocker count is **not trending down** after three rounds.
+- You are arguing about **which inputs are legitimate** rather than about what
+  the code does.
+- You find yourself thinking *"the reviewer keeps finding edge cases"*. Edge
+  cases that keep existing are not edge cases. They are the shape.
+
+### What asking it actually looks like
+
+Not "which of the known traps is this?" — that is pattern-matching, and
+pattern-matching is how you end up with a fourth trap nobody catalogued.
+Re-derive from the problem instead:
+
+1. State, in one sentence, the property the reviewer keeps attacking.
+2. Ask what would have to be true for that property to be **unnecessary**.
+   Usually one of: the component should not hold this authority; the default
+   should be refusal rather than acceptance; the truth belongs to something
+   else that should be asked directly; the two things that must agree should be
+   one thing.
+3. Ask whether the original problem is still solved by that shape. If it is,
+   you have the change you should have opened.
+4. Say it in the PR: the current shape cannot close, here is the one that can.
+   A stated structural argument gets engaged with — the reviewer's own
+   non-blocking notes are frequently pointing at it already. In #2212 the exit
+   was sitting in a round-5 suggestion to share one authoritative parser
+   instead of maintaining parallel option tables that drift.
+5. Be willing to close the PR and open a differently-shaped one. #2065 is not a
+   failure story. It is the correct ending to #1926.
+
+### Three ways this has actually gone wrong here
+
+Read these as worked examples of the question being skipped, not as a taxonomy
+to match your situation against.
+
+**Enumerating a surface you do not own** (#2212, 10 rounds). A hand-maintained
+`uv run` option grammar inside a verification path. Round after round named
+another gap — *"The hand-maintained option grammar is still incomplete for
+valid current `uv run` commands."* A table mirroring someone else's CLI can
+never be complete, so the rounds could not end. It closed when the code stopped
+enumerating what was allowed and started refusing anything it had not
+positively parsed.
+
+**Two paths kept alive that must agree** (#2193, 7 rounds). A new fused path
+beside the legacy one: the legacy branch skipping completion logic, the atomic
+branch losing an answer on failure, `[decide_later]` meaning different things
+depending on which path ran. Two implementations that must stay identical will
+diverge along a new axis every round. One of them has to stop existing.
+
+**Trusting a component that should not be trusted** (#1926 → #2065, above).
+
+In all three, the reviewer was not being pedantic. It was repeatedly reporting
+the same underlying fact — this shape cannot hold — in the only vocabulary it
+has: specific findings at specific lines.
+
+### Not an escape hatch
+
+This is not permission to dismiss a finding you do not want to fix. "The
+structure is wrong" is a claim that has to survive step 3 above — a different
+shape that still solves the original problem. Without that, it is just a
+disagreement, and the reviewer is probably right.
+
 ## The recurring blockers
 
 Ordered by how often they appear in review bodies.
 
 ### 1. Fix the root cause, not the symptom
 
-The most expensive rounds are the ones where a patch changes *which* failure
-occurs rather than removing it. Before pushing, ask what the reviewer will ask:
-*if this input arrives again through a different path, does the bug come back?*
-If the answer is yes, you have moved the symptom.
+The per-diff form of the question above: *if this input arrives again through a
+different path, does the bug come back?* If yes, you moved the symptom rather
+than removing it, and the next round will say so somewhere else.
 
 ### 2. Validate untrusted input — never coerce it
 
@@ -139,6 +245,8 @@ the test set up real state instead.
 
 Before your first push, walk your own diff and answer:
 
+- **Is the shape right?** If this is defending a position rather than removing
+  a failure, stop here — see [the question](#is-this-change-structurally-in-the-right-direction).
 - Does this remove the cause, or relocate the symptom?
 - Every new input: validated, or coerced?
 - Every new branch: can it succeed while doing nothing?
@@ -151,104 +259,6 @@ Before your first push, walk your own diff and answer:
 Writing that reasoning into the PR description is not ceremony. The bot reads
 it, and a stated, justified scope boundary is treated differently from a
 requirement that is simply unmet.
-
-## When the review will not converge
-
-Most PRs settle in one to three rounds. Some do not, and the failure looks the
-same every time: you fix what the round asked for, push, and the next round
-returns a finding of the same *kind* somewhere else. Nothing is wrong with your
-diligence. The shape of the change is wrong, and no amount of patching will
-close it.
-
-Learn to recognize this early. The cost of not recognizing it is real:
-
-| PR | Approach | Rounds | Outcome |
-|---|---|---|---|
-| #1926 | "**bind** regex evidence to acceptance input" — make the classifier correct | 30 | **closed, never merged** |
-| #2065 | "**refuse** unbound regex evidence as grounds to overturn an agent FAIL" — remove the classifier's authority | 3 | merged |
-
-Same underlying defect, opposite shape, ten times the cost. The second PR did
-not out-argue the reviewer. It removed the thing the reviewer kept finding
-holes in.
-
-### Signature 1 — you are enumerating an unbounded surface
-
-You are hand-maintaining an allowlist, option grammar, or keyword table that
-mirrors something you do not own — another tool's CLI, a model's output format,
-a third-party schema. Each round the reviewer names a case your table misses,
-because the table can never be complete.
-
-PR #2212 ("recognize option-bearing uv test runs") spent 10 rounds here:
-
-> R2: "The new allowlist does not cover the complete supported `uv run` option grammar"
-> R3: "The hand-maintained option grammar is still incomplete for valid current `uv run` commands."
-> R5: "The enumerated option schema omits valid current `uv run` flags"
-
-**The escape:** stop enumerating what is allowed; parse, and reject anything you
-did not positively understand. #2212 converged when it became operand-aware and
-started rejecting malformed operands, non-executing modes, and compound
-commands outright — an unbounded allowlist became a bounded, fail-closed parser.
-Delegating to the authoritative source beats both; the reviewer had already
-suggested exactly that, as a non-blocking note in round 5:
-
-> "Consider sharing one authoritative `uv run` option schema/parser with
-> `src/ouroboros/evaluation/detector.py` rather than maintaining parallel
-> option tables that can drift independently."
-
-Read the non-blocking suggestions. They are often where the structural fix is.
-
-### Signature 2 — you kept two paths alive
-
-You added a new path and left the old one in place, and now both must behave
-identically. Every round finds another place they diverge. This is
-combinatorial: the reviewer will keep finding pairs.
-
-PR #2193 ("fuse scoring question and routing") spent 7 rounds here — the
-legacy branch not running completion logic, the atomic branch losing an answer
-on failure, `completion` assigned only in one branch, `[decide_later]` meaning
-different things per path, then the legacy branch still calling the old helper.
-
-**The escape:** delete one path, or funnel both through one implementation. Two
-paths that must agree are two paths that will not.
-
-### Signature 3 — the component's authority is the problem, not its accuracy
-
-The reviewer keeps defeating your check with a new input class. You narrow it;
-next round it is defeated again. The question to ask is not "how do I classify
-correctly?" but "**why is this component allowed to make this decision at
-all?**"
-
-That is #1926 versus #2065 above. Thirty rounds went into making a regex-based
-evidence classifier correct enough to overturn an agent's FAIL verdict. It was
-never going to be correct enough. The merged fix let it stop overturning
-verdicts.
-
-### How to tell you are in one
-
-- The same finding reappears at a **different line number** each round. You are
-  moving the failure, not removing it.
-- Each fix **adds surface** — another branch, another special case, another
-  entry in a table.
-- The blocker count is **not trending down** after three rounds.
-- You are arguing about which inputs are legitimate rather than about what the
-  code does.
-
-### What to do
-
-Stop pushing. Another round costs you and proves nothing.
-
-1. Write down the property the reviewer keeps attacking, in one sentence.
-2. Ask whether that property can be made unnecessary — by deleting the
-   component, by inverting the default to fail closed, or by delegating to
-   whatever actually owns the truth.
-3. Say this in the PR, explicitly: the current shape cannot close, here is the
-   shape that can. A stated structural argument gets engaged with.
-4. Be willing to close the PR and open a differently-shaped one. #2065 is not a
-   failure story — it is the correct ending to #1926.
-
-None of this is a reason to dismiss a finding you simply do not want to fix. The
-signature is a repeating *kind* of finding across rounds, not a single finding
-you disagree with.
 
 ## Mechanics
 

--- a/docs/contributing/review-conventions.md
+++ b/docs/contributing/review-conventions.md
@@ -152,6 +152,104 @@ Writing that reasoning into the PR description is not ceremony. The bot reads
 it, and a stated, justified scope boundary is treated differently from a
 requirement that is simply unmet.
 
+## When the review will not converge
+
+Most PRs settle in one to three rounds. Some do not, and the failure looks the
+same every time: you fix what the round asked for, push, and the next round
+returns a finding of the same *kind* somewhere else. Nothing is wrong with your
+diligence. The shape of the change is wrong, and no amount of patching will
+close it.
+
+Learn to recognize this early. The cost of not recognizing it is real:
+
+| PR | Approach | Rounds | Outcome |
+|---|---|---|---|
+| #1926 | "**bind** regex evidence to acceptance input" — make the classifier correct | 30 | **closed, never merged** |
+| #2065 | "**refuse** unbound regex evidence as grounds to overturn an agent FAIL" — remove the classifier's authority | 3 | merged |
+
+Same underlying defect, opposite shape, ten times the cost. The second PR did
+not out-argue the reviewer. It removed the thing the reviewer kept finding
+holes in.
+
+### Signature 1 — you are enumerating an unbounded surface
+
+You are hand-maintaining an allowlist, option grammar, or keyword table that
+mirrors something you do not own — another tool's CLI, a model's output format,
+a third-party schema. Each round the reviewer names a case your table misses,
+because the table can never be complete.
+
+PR #2212 ("recognize option-bearing uv test runs") spent 10 rounds here:
+
+> R2: "The new allowlist does not cover the complete supported `uv run` option grammar"
+> R3: "The hand-maintained option grammar is still incomplete for valid current `uv run` commands."
+> R5: "The enumerated option schema omits valid current `uv run` flags"
+
+**The escape:** stop enumerating what is allowed; parse, and reject anything you
+did not positively understand. #2212 converged when it became operand-aware and
+started rejecting malformed operands, non-executing modes, and compound
+commands outright — an unbounded allowlist became a bounded, fail-closed parser.
+Delegating to the authoritative source beats both; the reviewer had already
+suggested exactly that, as a non-blocking note in round 5:
+
+> "Consider sharing one authoritative `uv run` option schema/parser with
+> `src/ouroboros/evaluation/detector.py` rather than maintaining parallel
+> option tables that can drift independently."
+
+Read the non-blocking suggestions. They are often where the structural fix is.
+
+### Signature 2 — you kept two paths alive
+
+You added a new path and left the old one in place, and now both must behave
+identically. Every round finds another place they diverge. This is
+combinatorial: the reviewer will keep finding pairs.
+
+PR #2193 ("fuse scoring question and routing") spent 7 rounds here — the
+legacy branch not running completion logic, the atomic branch losing an answer
+on failure, `completion` assigned only in one branch, `[decide_later]` meaning
+different things per path, then the legacy branch still calling the old helper.
+
+**The escape:** delete one path, or funnel both through one implementation. Two
+paths that must agree are two paths that will not.
+
+### Signature 3 — the component's authority is the problem, not its accuracy
+
+The reviewer keeps defeating your check with a new input class. You narrow it;
+next round it is defeated again. The question to ask is not "how do I classify
+correctly?" but "**why is this component allowed to make this decision at
+all?**"
+
+That is #1926 versus #2065 above. Thirty rounds went into making a regex-based
+evidence classifier correct enough to overturn an agent's FAIL verdict. It was
+never going to be correct enough. The merged fix let it stop overturning
+verdicts.
+
+### How to tell you are in one
+
+- The same finding reappears at a **different line number** each round. You are
+  moving the failure, not removing it.
+- Each fix **adds surface** — another branch, another special case, another
+  entry in a table.
+- The blocker count is **not trending down** after three rounds.
+- You are arguing about which inputs are legitimate rather than about what the
+  code does.
+
+### What to do
+
+Stop pushing. Another round costs you and proves nothing.
+
+1. Write down the property the reviewer keeps attacking, in one sentence.
+2. Ask whether that property can be made unnecessary — by deleting the
+   component, by inverting the default to fail closed, or by delegating to
+   whatever actually owns the truth.
+3. Say this in the PR, explicitly: the current shape cannot close, here is the
+   shape that can. A stated structural argument gets engaged with.
+4. Be willing to close the PR and open a differently-shaped one. #2065 is not a
+   failure story — it is the correct ending to #1926.
+
+None of this is a reason to dismiss a finding you simply do not want to fix. The
+signature is a repeating *kind* of finding across rounds, not a single finding
+you disagree with.
+
 ## Mechanics
 
 - **Re-review is triggered by a comment.** Push your fix, then post a comment

--- a/docs/contributing/review-conventions.md
+++ b/docs/contributing/review-conventions.md
@@ -20,16 +20,25 @@ took thirty and was closed unmerged.
 
 ## What the review actually contains
 
-The bot posts a fixed structure:
+The exact headings evolve with the review contract, but every review reports
+the same stable concepts:
 
-1. **Verdict** — `APPROVE` or `REQUEST_CHANGES`, with the exact HEAD commit it
-   checked. If you pushed after it started, the verdict describes the older commit.
-2. **What Improved** — what the PR does well.
-3. **Issue Requirements** — a table grading your PR against **the linked
-   issue's** requirements, each marked *Met*, *Partially met*, or *Not met*.
-4. **Prior Findings Status** — every finding from earlier rounds, and whether
-   you resolved it. Unaddressed findings carry forward.
-5. **Blockers** — a table of `File:Line`, severity, and the finding.
+1. **Verdict and exact HEAD** — `APPROVE` or `REQUEST_CHANGES`, tied to the
+   commit the bot checked. If you pushed after it started, the verdict describes
+   the older commit.
+2. **Progress against the issue** — what improved, how each linked-issue
+   requirement grades (*Met*, *Partially met*, or *Not met*), and the status of
+   findings carried from earlier rounds.
+3. **Findings by disposition** — merge-blocking findings, follow-up warnings,
+   and non-blocking suggestions are separated rather than blended together.
+4. **Verification and design assessment** — test coverage, architectural and
+   directional notes, and the design/roadmap gate explain the evidence and the
+   shape of the change.
+5. **Merge recommendation** — the final action follows from those findings.
+
+Treat these as concepts, not an exhaustive heading template; the authoritative
+contract may add or rename sections without changing how contributors should
+interpret the review.
 
 Two consequences worth internalizing:
 

--- a/docs/contributing/review-conventions.md
+++ b/docs/contributing/review-conventions.md
@@ -1,0 +1,173 @@
+# Review Conventions
+
+Every PR is reviewed by `ouroboros-agent[bot]` ("ourobot") before it can merge.
+Its approval satisfies the required review on `main`.
+
+The bot is strict, and it is strict in a predictable, repeatable way. Most
+review rounds are lost to objections that could have been preempted before the
+first push. This page exists so you can preempt them.
+
+The rules below were extracted from the bot's actual review bodies on merged
+PRs, not from a style guide. Some PRs take a single round; some take seven.
+The difference is almost entirely whether the change is a root-cause fix with
+proof, or a plausible-looking patch.
+
+## What the review actually contains
+
+The bot posts a fixed structure:
+
+1. **Verdict** — `APPROVE` or `REQUEST_CHANGES`, with the exact HEAD commit it
+   checked. If you pushed after it started, the verdict describes the older commit.
+2. **What Improved** — what the PR does well.
+3. **Issue Requirements** — a table grading your PR against **the linked
+   issue's** requirements, each marked *Met*, *Partially met*, or unmet.
+4. **Prior Findings Status** — every finding from earlier rounds, and whether
+   you resolved it. Unaddressed findings carry forward.
+5. **Blockers** — a table of `File:Line`, severity, and the finding.
+
+Two consequences worth internalizing:
+
+- **Your PR is graded against the issue, not against your PR description.** A
+  vague issue produces a vague grade; a requirement you decided was out of
+  scope reads as *Partially met* unless you say in the PR why it is deferred.
+  This is why [issue quality](./issue-quality-policy.md) is enforced.
+- **The bot reproduces things.** Findings routinely cite a probe it ran —
+  *"a focused probe classified such a companion as `decide_later` and made it
+  skip-eligible"*, *"A focused runtime probe with `process.wait()` returning
+  immediately and both streams remaining open exceeded an outer 0.2-second
+  guard"* (#2224, #2239). You are not arguing with a linter. If you claim a
+  path is unreachable, expect it to be tested.
+
+## The recurring blockers
+
+Ordered by how often they appear in review bodies.
+
+### 1. Fix the root cause, not the symptom
+
+The most expensive rounds are the ones where a patch changes *which* failure
+occurs rather than removing it. Before pushing, ask what the reviewer will ask:
+*if this input arrives again through a different path, does the bug come back?*
+If the answer is yes, you have moved the symptom.
+
+### 2. Validate untrusted input — never coerce it
+
+`bool(...)` on an external payload is a blocker, not a shortcut:
+
+> "Companion routing fields are coerced with `bool(...)` instead of validated
+> as booleans. An untrusted planner payload such as `"decide_later": "false"`
+> is interpreted as `True`" — #2224
+
+Anything crossing a trust boundary — a planner payload, an MCP argument, a
+config file, `./.env` — gets parsed and validated against a closed set of
+accepted values.
+
+### 3. No silent success
+
+A code path that accepts a request, does nothing, and reports success is
+always a blocker:
+
+> "The public tool schema accepts `answers`, but plugin mode only examines the
+> singular `answer` variable. A request … enters the plugin branch, records no
+> rounds, and still returns a successful delegation receipt." — #2224
+
+Corollaries the bot enforces: do not truncate silently, do not drop items from
+a batch without saying so, and do not swallow an exception into a default.
+
+### 4. Fail closed
+
+When a check cannot prove the safe condition holds, it must refuse, not
+proceed. Recent examples that landed on exactly this principle: making
+`is_on_protected_branch` fail closed (#2236), and a gate that errors rather
+than passing when it cannot enumerate changed files.
+
+### 5. Keep the public schema and the implementation in agreement
+
+If a declared parameter is not honored on every branch, that is a defect even
+when the common path works. See #2224 above.
+
+### 6. Same semantics across every runtime
+
+This project drives many backends. Behavior that changes meaning depending on
+which one is active is a blocker:
+
+> "Plugin mode records every normalized pair through
+> `InterviewState.record_answer`, bypassing `record_turn_answers`, so the
+> documented per-question `[deferred]` and `[decide_later]` controls change
+> meaning by runtime." — #2224
+
+When you add a behavior to one adapter, check the others.
+
+### 7. Crash-safety and idempotency on the persistence path
+
+Commit ordering and retry behavior are reviewed explicitly:
+
+> "Batch answer persistence is not replay-safe because interview state is
+> committed before the authoritative `pending_batch` metadata is updated." — #2224
+
+> "The new answer path is not idempotent after a successful write.
+> `record_turn_answers` unconditionally appends every supplied pair, while the
+> handler lock only serializes calls and persists no turn/request identity
+> that could recognize a transport retry." — #2224
+
+A lock serializes; it does not make an operation idempotent.
+
+### 8. Bound every wait
+
+Any subprocess wait, network call, or stream drain needs a finite ceiling, and
+the timeout must surface through the normal error contract rather than as a
+bare exception:
+
+> "Timeout from the changed legacy `communicate()` path is not translated into
+> the adapter's `Result.err(ProviderError)` contract or followed by child
+> cleanup." — #2239
+
+Bounding the primary wait is not enough if a stream drain sits outside the
+deadline (#2239).
+
+### 9. Regression coverage for every new branch
+
+"Add regression coverage for the newly bounded subprocess paths" appears
+verbatim as a blocker. A new conditional without a test that exercises it will
+be flagged, and the bot names the specific case it wants covered.
+
+### 10. Do not add production contracts for test convenience
+
+Test-only environment variables and test-only public knobs are rejected. Make
+the test set up real state instead.
+
+## Preempting a round
+
+Before your first push, walk your own diff and answer:
+
+- Does this remove the cause, or relocate the symptom?
+- Every new input: validated, or coerced?
+- Every new branch: can it succeed while doing nothing?
+- Every new wait: bounded, and does the timeout surface as a typed error?
+- Every new behavior: does it mean the same thing on the other runtimes?
+- Every new conditional: is there a test that reaches it?
+- Does the linked issue list a requirement this PR does not meet? Say so
+  explicitly in the PR body, with the reason.
+
+Writing that reasoning into the PR description is not ceremony. The bot reads
+it, and a stated, justified scope boundary is treated differently from a
+requirement that is simply unmet.
+
+## Mechanics
+
+- **Re-review is triggered by a comment.** Push your fix, then post a comment
+  explaining what changed. A push alone is unreliable; empty commits and
+  re-requesting a reviewer do not work. Turnaround is typically 7–15 minutes.
+- **The review pins a commit.** Check the `HEAD checked` field — a verdict may
+  predate your latest push.
+- **Prior findings carry forward.** Respond to each one, in the PR
+  conversation, even if the answer is "not doing this, because …".
+- **Pushing back is legitimate.** The bot is wrong sometimes. Say concretely
+  why — with the code path or a reproduction — and it can reverse itself; a
+  round of explanation is cheaper than a bad change. What does not work is
+  silently ignoring a finding.
+
+## Related
+
+- [CI Gates and Branch Protection](./ci-gates.md) — the automated gates
+- [Issue Quality Policy](./issue-quality-policy.md) — why the issue text is graded
+- [Verifier Evidence Policy](./verifier-evidence-policy.md) — evidence rules in the verifier


### PR DESCRIPTION
Refs #2271 — first two pages of that issue. Deliberately scoped: the architecture-map correction, the testing-guide gaps, and the orphaned root review files are follow-ups.

## What

**`docs/contributing/developing.md`** (new) — the missing "I changed a line, how do I see it work" page. It explains that the checked-in `.mcp.json` runs the published package, then covers working-tree CLI and MCP execution, supported Claude Code local-scope registration, separate agent-runtime and LLM-backend precedence, process-level `mcp serve --db` selection, effective config and state locations, `ouroboros cleanup`, and minimum verification by change type.

**`docs/contributing/review-conventions.md`** (new) — contributor guidance derived from actual `ouroboros-agent[bot]` review bodies. It documents the stable review concepts while noting that headings evolve, five source-backed recurring blocker classes, each paired with one or more verbatim review excerpts, a pre-push checklist, and exact-head re-review mechanics based on the commit associated with each submitted review.

**Entry points wired** — `CONTRIBUTING.md` Quick Setup warns that `uv sync` is not the whole loop; *Submit PR* points at the review conventions; `CLAUDE.md` and `AGENTS.md` carry the same warning above the managed `<!-- ooo:START -->` region; `docs/README.md` indexes all three contributor pages including `ci-gates.md`.

## Why

The contributor docs previously stopped at `uv sync` and `pytest`, before the toolchain and review details that determine whether a local change actually runs and passes review.

## Verification

Docs-only; no source or workflow changes.

Claims were checked against current source and live repository metadata:

| Claim | Evidence |
|---|---|
| console scripts `ooo` / `ouroboros` / `ozo` | `[project.scripts]` in `pyproject.toml` |
| local MCP dependency and launch profile | `[project.optional-dependencies]` / `[dependency-groups]` in `pyproject.toml`; `serve()` in `src/ouroboros/cli/commands/mcp.py` |
| agent-runtime precedence | `get_agent_runtime_backend()` in `src/ouroboros/config/loader.py` |
| LLM-backend precedence | `get_llm_backend()` in `src/ouroboros/config/loader.py` |
| process-level and configured event-database paths | `mcp serve --db` in `src/ouroboros/cli/commands/mcp.py`; `resolve_event_store_path()` / `event_store_path_from_config()` in `src/ouroboros/config/models.py` |
| runtime log destination | `src/ouroboros/observability/logging.py` |
| cleanup scope and flags; event DB/WAL are excluded | `src/ouroboros/cli/commands/cleanup.py` |
| `.mcp.json` targets the published package | `.mcp.json` |

Live review metadata confirmed 64 `CHANGES_REQUESTED` reviews across 60 commits on #1926, 3 on #2065, 10 on #2212, and 7 on #2193. All six quoted review blocks were matched verbatim against live review bodies from #2224 and #2239 after normalizing Markdown line wrapping. All relative links across the six changed Markdown files resolve. The exact tree passed `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run --frozen pytest -p no:cacheprovider tests/unit/test_dependencies_configured.py tests/unit/config/test_loader.py tests/unit/cli/test_cleanup.py tests/unit/cli/test_mcp_nested_guard.py tests/unit/cli/test_mcp_startup_cleanup.py -q` with 334 tests, followed by `git diff --check`. The documented `claude mcp add --scope local --transport stdio ... -- <command>` form was also registered under an isolated home and read back with `claude mcp get ouroboros`, confirming local-scope storage in `.claude.json` and exact argument serialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gq4Aox35z3SKCU6pjWTc2Z