### PR TITLE
fix(install): tolerate piped execution and older schemas

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -314,7 +314,7 @@ PH_API_KEY="${OUROBOROS_POSTHOG_API_KEY:-phc_mSoetD4ExLDDCi3vNua635NhwRTgHfRaCG9
 PH_HOST="${OUROBOROS_POSTHOG_HOST:-https://us.i.posthog.com}"
 
 _telemetry_config_allows() {
-  local f="$HOME/.ouroboros/config.yaml" script_dir source_root=""
+  local f="$HOME/.ouroboros/config.yaml" script_path script_dir source_root=""
   local python_candidate ouroboros_cmd shebang status
   # `-e` is false for a dangling symlink. That is invalid persisted state,
   # not a genuinely absent config, so keep it on the fail-closed path.
@@ -328,7 +328,13 @@ _telemetry_config_allows() {
   # requires a Python environment with Ouroboros' real schema available;
   # otherwise collection fails closed. A genuinely absent config retains the
   # documented default-on behavior after the notice below.
-  script_dir=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd) || true
+  # `curl | bash` has no sourced file path; nounset must not break this
+  # optional local-source optimization.
+  script_path="${BASH_SOURCE[0]-}"
+  script_dir=""
+  if [ -n "$script_path" ]; then
+    script_dir=$(CDPATH='' cd -- "$(dirname -- "$script_path")" 2>/dev/null && pwd) || true
+  fi
   if [ -n "$script_dir" ] && [ -f "$script_dir/../src/ouroboros/config/models.py" ]; then
     source_root=$(CDPATH='' cd -- "$script_dir/../src" 2>/dev/null && pwd) || true
   fi
@@ -355,7 +361,10 @@ try:
 except Exception:
     raise SystemExit(1)
 
-raise SystemExit(0 if config.telemetry.enabled is True else 1)
+# Older installed schemas may validate without a telemetry field. Fail closed
+# instead of dereferencing an attribute the schema does not have.
+enabled = getattr(getattr(config, "telemetry", None), "enabled", False)
+raise SystemExit(0 if enabled is True else 1)
 PY
   }
 

--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -111,6 +111,7 @@ def _run_installer(
     *,
     include_uv: bool = True,
     local_repo: bool = True,
+    piped: bool = False,
     env: dict[str, str] | None = None,
     drop_env: tuple[str, ...] = (),
     fake_commands: dict[str, str] | None = None,
@@ -181,10 +182,12 @@ exit 0
     for key in drop_env:
         run_env.pop(key, None)
 
+    command = ["bash"] if piped else ["bash", str(install_sh)]
     return subprocess.run(
-        ["bash", str(install_sh)],
+        command,
         cwd=cwd,
         env=run_env,
+        input=install_sh.read_text(encoding="utf-8") if piped else None,
         text=True,
         capture_output=True,
         check=False,
@@ -311,6 +314,62 @@ def test_installer_does_not_relabel_existing_first_command_surface_hint(
 
     assert result.returncode == 0, result.stderr
     assert hint.read_text(encoding="utf-8") == "readme_quickstart\n"
+
+
+def test_piped_installer_does_not_require_bash_source(tmp_path: Path) -> None:
+    config = tmp_path / "home" / ".ouroboros" / "config.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("telemetry:\n  enabled: true\n", encoding="utf-8")
+
+    result = _run_installer(
+        tmp_path,
+        local_repo=False,
+        piped=True,
+        env={"OUROBOROS_TELEMETRY": ""},
+        fake_commands=_telemetry_fake_commands(),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "BASH_SOURCE" not in result.stderr
+
+
+def test_installer_old_schema_without_telemetry_fails_closed(tmp_path: Path) -> None:
+    config = tmp_path / "home" / ".ouroboros" / "config.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("telemetry:\n  enabled: true\n", encoding="utf-8")
+
+    old_package = tmp_path / "old-package" / "ouroboros" / "config"
+    old_package.mkdir(parents=True)
+    (old_package.parent / "__init__.py").write_text("", encoding="utf-8")
+    (old_package / "__init__.py").write_text("", encoding="utf-8")
+    (old_package / "models.py").write_text(
+        "class OuroborosConfig:\n"
+        "    @classmethod\n"
+        "    def model_validate(cls, raw):\n"
+        "        return cls()\n",
+        encoding="utf-8",
+    )
+    python_wrapper = (
+        "#!/bin/sh\n"
+        "shift\n"
+        f"PYTHONPATH={shlex.quote(str(old_package.parents[1]))} "
+        f'exec {shlex.quote(sys.executable)} "$@"\n'
+    )
+
+    result = _run_installer(
+        tmp_path,
+        local_repo=False,
+        env={"OUROBOROS_TELEMETRY": ""},
+        fake_commands={
+            "curl": _telemetry_probe_curl(),
+            "python3": python_wrapper,
+            "python": python_wrapper,
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "AttributeError" not in result.stderr
+    assert not (tmp_path / "telemetry.log").exists()
 
 
 def test_copied_installer_dangling_config_symlink_fails_closed(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- prevent `curl | bash` installs from failing under `set -u` when `BASH_SOURCE` is unset
- keep telemetry validation fail-closed when an older installed config schema has no `telemetry` field

## Changes

- guard the optional local-source path lookup before reading `BASH_SOURCE[0]`
- read `telemetry.enabled` through a compatibility-safe fallback
- add regressions for piped execution and pre-telemetry schemas

## Verification

- `pytest -q tests/unit/scripts/test_install_runtime_selection.py` — 122 passed
- `bash -n scripts/install.sh`
- `ruff check tests/unit/scripts/test_install_runtime_selection.py`