### PR TITLE
fix(telemetry): reduce PostHog collection to core metrics

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -100,6 +100,9 @@ Notes:
   identity and daily `service_active` rows; no extra lifecycle-state property is sent.
 - A logical tool result with `is_error=true` is recorded as `status=blocked`.
   This makes seed blocks and other validation stops distinct from exceptions.
+- Registered non-product MCP tools are folded to `extension_tool` regardless of
+  their textual prefix. Their successful requests contribute only to service
+  activity; failures and logical blocks retain the fixed command token.
 - `error_type` is only an audited exception class name, never a message or
   traceback. `failure_reason_code` is one of `config`, `auth`, `timeout`,
   `model`, `tool`, `validation`, `cancelled`, or `unknown`.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,45 +1,46 @@
 # Telemetry
 
-Ouroboros collects **anonymous usage data** to understand how the tool is used
-(install funnel, interview → seed → run → evolve conversion, success rates per
-runtime backend) and to decide what to improve next.
+Ouroboros collects a deliberately small anonymous dataset for install adoption,
+daily activity, runtime adoption, and actionable failures.
 
 **We never collect:** code, prompts, seed content, file contents, file paths,
-tool arguments, environment variables, or anything that could identify you or
-your project.
+tool arguments, environment variables, account data, or project identifiers.
 
 ## How the data is used
 
-Both uses are declared here up front — there are no undisclosed uses:
+1. **Product improvement** — failed or blocked lifecycle commands and terminal
+   workflow failures decide what gets fixed next.
+2. **Aggregate adoption** — installs, active users, versions, operating systems,
+   countries, and runtime backends may be reported only as aggregates. Cells
+   covering fewer than 10 users are withheld.
 
-1. **Product improvement** — funnel drop-offs and per-backend failure rates
-   decide what gets fixed next.
-2. **Public aggregate stats** — adoption numbers (e.g. weekly active users)
-   may be published and used to promote the project. Only aggregates are ever
-   published, never per-user data, and any aggregate cell covering fewer than
-   10 users is withheld.
+**Counting rules:**
 
-**Counting rule (fixed):** one "active user" = one distinct anonymous ID with
-at least one `workflow_outcome` where `command=evaluate`, `verified=true`, and
-`ci!=true` that week. Submission receipts, installs, reinstalls, retries, and
-CI runs are not users. Published numbers follow this rule, verbatim. An
-`ouroboros_evaluate` completion that OpenCode's plugin mode delegates out
-(`delegated_to_plugin`) finishes outside the Ouroboros process and cannot be
-observed by it, so it is never counted toward a verified outcome or the
-active-user rule — that's an undercount, never an overcount.
+- install count = `install_completed` event count;
+- command DAU = distinct anonymous IDs with `command_run` and `ci!=true` that day;
+- service DAU = distinct anonymous IDs with `service_active` and `ci!=true` that day;
+- verified weekly active = distinct anonymous IDs with `workflow_outcome`,
+  `command=evaluate`, `verified=true`, and `ci!=true` that week.
 
-**Identity honesty:** the ID in `~/.ouroboros/telemetry.json` is a random UUID
-— pseudonymous, stable across sessions so retention can be measured, derived
-from nothing about you or your machine. Delete the file to reset it; opt out
-to stop it being used at all.
+`command_run` and `service_active` carry deterministic daily `$insert_id` values.
+PostHog therefore stores at most one row per anonymous user/day/dimension tuple
+for activity metrics, even when a host repeats a command or starts multiple MCP processes.
 
-**Change policy:** this document is append-only — collection scope or use
-changes are recorded in the changelog below, ship in a new minor/major version
-with a fresh first-run notice, and any *new* data category defaults to off.
+**Identity honesty:** the ID in `~/.ouroboros/telemetry.json` is a random UUID,
+stable across sessions for lifecycle analysis and derived from nothing about the
+machine or user. Delete the file to reset it; opt out to stop collection.
+
+**Change policy:** scope expansions are recorded below, ship in a new
+minor/major version with a fresh notice, and default off. Scope reductions do
+not require users to acknowledge a new notice.
 
 ### Changelog
 
-- v1 (2026-08): initial contract — events listed below, uses (1) and (2).
+- v1 (2026-08): initial contract.
+- v2 (2026-08): removed install starts, polling/helper successes, request
+  durations, tool names, provider details, Python version, frontdoor/onboarding
+  attribution, recovery actions, and subagent dispatch data; added daily
+  deduplication for retained command and service activity.
 
 ## How to opt out
 
@@ -76,111 +77,36 @@ before its first notice or event.
 ## What is sent
 
 Identity is a random UUID (`~/.ouroboros/telemetry.json`) generated on first
-use — it is not derived from your machine, account, or network.
-
-Each row below is the *exact* property set that event can carry — not "these
-plus whatever base/context happens to be set". `src/ouroboros/telemetry.py`
-enforces this per event (and, for `command_run`, per `source`) at
-serialization time; a property not listed for a row is dropped before the
-event is queued, even if some other event's row does carry it. The table and
-the code's allowlist constants are one contract in two places — edited
-together, always.
+use. Each row below is the exact property set accepted by the serializer.
 
 | Event | When | Properties (exact set) |
 |---|---|---|
-| `install_started` | `install.sh` begins | source, os, arch, version, is_local, pre, ref |
-| `install_completed` | `install.sh` finishes | source, os, arch, method (uv/pipx/pip), runtime, detected_runtimes (count), version, ref |
-| `command_run` (source=mcp) | An `ouroboros_*` MCP tool is invoked from any host CLI (Claude Code, Codex, OpenCode, …) | command (interview/seed/run/evolve/auto/evaluate/qa/…), tool, source, is_funnel, phase (`submission` or `completion`), accepted (submission only), ok (completion only), duration_ms, error_type, sample_rate (polling tools only), runtime_backend, execute_runtime_backend, interview_llm_backend, evaluate_llm_backend, frontdoor, first_command_surface, app_version, os, python_version, ci |
-| `command_run` (source=cli) | A direct `ooo <subcommand>` invocation in a terminal | command, source, is_funnel, app_version, os, python_version, frontdoor, ci — no tool, phase, duration/outcome fields, or backend context: those are mcp-only |
-| `workflow_outcome` | Two producers (never both for the same evaluation — see Notes): a background MCP job reaches a durable terminal event, **or** a direct (non-job) `ouroboros_evaluate` / `ouroboros_checklist_verify` completion | command, phase (`terminal`), terminal_status, ok, verified, final_approved, failure_reason_code (failed/cancelled/interrupted outcomes only), recovery_action (failed/cancelled/interrupted outcomes only), `$insert_id` (job-derived variant only — one-way event deduplication digest), runtime_backend, execute_runtime_backend, interview_llm_backend, evaluate_llm_backend, app_version, os, python_version, frontdoor, ci |
-| `mcp_serve_started` | A host CLI attaches the Ouroboros MCP server for a session | transport, tool_count, frontdoor, first_command_surface, app_version, os, ci — no python_version, no backend/provider context |
-| `subagent_dispatch` | A structured fan-out contract is emitted (`phase=emitted`) or correlated child results return through `ouroboros_submit_fanout_results` (`phase=submitted`) | phase, fanout_kind, payload_count, invocation_surface, dispatch_authority, host_family, host_identity_status, host_capability, capability_source, delivery_mode, execution_preference, fallback_strategy, configured_worker_backend, host_worker_mismatch, decision_reason, contract_version, fanout_reentry_available, submission_status, expected_count, received_count, undispatched_count, frontdoor, first_command_surface, app_version, os, python_version, ci |
+| `install_completed` | `install.sh` finishes successfully | os, runtime, version, ref |
+| `service_active` | An MCP service starts | service (`mcp`), runtime_backend, app_version, os, ci, `$insert_id` |
+| `command_run` (service=mcp) | A retained lifecycle MCP command succeeds/is accepted, or any MCP command fails/is blocked | command, service, status (`succeeded`, `accepted`, `failed`, `rejected`, `blocked`), error_type (exception failures only), runtime_backend, app_version, os, ci, `$insert_id` |
+| `command_run` (service=cli) | A direct non-internal `ooo <command>` is invoked | command, service (`cli`), status (`invoked`), app_version, os, ci, `$insert_id` |
+| `workflow_outcome` | A background workflow or direct evaluation reaches a terminal result | command, terminal_status, verified, failure_reason_code (non-success only), runtime_backend, app_version, os, ci, `$insert_id` |
 
 Notes:
 
-- `ref` on the install events is a short opaque channel token (`hellogithub`,
-  `readme`, `guide-zh`, …) that a docs page or listing prepends to the install
-  command as `OUROBOROS_INSTALL_REF=<channel>`. It says which of OUR surfaces
-  the command was copied from; it is chosen by us, never derived from the
-  machine, defaults to `direct`, and is discarded unless it matches
-  `[A-Za-z0-9._-]{1,32}`.
-- `first_command_surface` is a fixed enum (`readme_quickstart`,
-  `getting_started`, `setup_complete`, or `unknown`) carried only on MCP
-  session/command events. README and Getting Started installers persist the
-  enum locally before setup; the hint remains preferred after setup so the
-  first-command cohort still represents the page that brought the user in.
-  A missing hint with an existing `~/.ouroboros/config.yaml` is attributed to
-  `setup_complete`. It contains no URL, prompt, path, or user identifier.
-
-- `source` separates the two entry surfaces cleanly: `cli` means the user typed
-  the command in a terminal; `mcp` means it arrived from inside an AI agent
-  session (`ooo …` keyword in Claude Code / Codex / any MCP host). Internal
-  machinery (in-process servers, detached job workers, `ouroboros mcp serve`
-  boots, `job`/`dispatch` plumbing) is either not captured or captured as its
-  own event, so the cli-vs-agent ratio is not inflated by automation.
-- High-frequency polling tools (`ouroboros_job_status`, `ouroboros_session_status`,
-  HUD/projection queries, …) are sampled at 1/50 via an independent random
-  draw on every call — not a per-process counter — so the probability stays
-  1/50 regardless of how long a given process lives; sampled events carry a
-  `sample_rate` property so counts can be re-weighted. Everything else is
-  captured 1:1.
-- `tool`/`command` on an MCP `command_run` event only ever carry a name from
-  the audited, static list of built-in Ouroboros tools: an unrecognized
-  lookup appears as `ouroboros_unknown_tool`, and a registered third-party
-  or custom tool (extensions can register arbitrary names) appears as
-  `ouroboros_extension_tool` — the identifying name itself is never sent.
-  `command` on a job-derived `workflow_outcome` is the same contract for
-  background-job types: only the five funnel stages and Ouroboros' own
-  internal diagnostic job types are ever forwarded; anything else (a
-  third-party job type registered against the same job manager) appears as
-  the fixed `extension_job` value. `command` on a `command_run` (source=cli)
-  event is the same contract again for direct `ooo <subcommand>` runs:
-  built-in subcommands are forwarded verbatim, and a dynamically installed
-  plugin command (`ooo <plugin-name> ...`) appears as the fixed
-  `extension_command` value.
-- `error_type` is only the Python exception class name (e.g. `TimeoutError`),
-  never a message or traceback.
-- `failure_reason_code` and `recovery_action` are fixed enums emitted only for
-  non-success terminal outcomes. The classifier reads terminal status and
-  structured machine metadata only; it never reads exception messages, result
-  text, prompts, paths, or identifiers. Current reason codes are `config`,
-  `auth`, `timeout`, `model`, `tool`, `validation`, `cancelled`, and `unknown`.
-  Current recovery actions are `retry`, `setup`, `login`, `update`,
-  `inspect_logs`, and `none`. An unclassified failure is always `unknown` with
-  `inspect_logs`, so the failure denominator remains measurable.
-- `subagent_dispatch` uses closed enums only. Raw MCP `clientInfo.name`, client
-  versions, custom backend names, `fanout_id`, session ids, correlation values,
-  prompts, problem context, child outputs, repository paths, and file paths are
-  never sent. Recognized client identities are folded to `claude_code`, `codex`,
-  or `opencode`; every other non-empty identity becomes `other_known`, and an
-  absent identity becomes `unknown`. Custom worker backends become `other`.
-  Counts are bounded to 0–64. The submitted event reports only aggregate lane
-  counts and never infers whether execution was parallel from elapsed time.
-- Start-tool `command_run` events are submission receipts. They intentionally
-  have `accepted`, not `ok`; queue acceptance is never a completed or verified
-  run. `workflow_outcome` is the durable/direct terminal boundary described
-  below. Only a completed formal evaluation with explicit `final_approved=true`
-  sets `verified=true`.
-- `workflow_outcome` has two producers, and exactly one fires per evaluation:
-  the durable job-terminal boundary (`JobTelemetryBoundary`, stamping
-  `$insert_id` so a retried/redelivered terminal event dedupes) covers
-  `ouroboros_start_evaluate`'s background job; the direct-evaluation boundary
-  (`record_direct_evaluation_outcome`, no `$insert_id` — each invocation is
-  its own outcome, there is no durable job row to replay against) covers
-  `ouroboros_evaluate` and `ouroboros_checklist_verify`, both of which never
-  create a job. When a direct evaluation runs *inside* a background job (the
-  `ouroboros_start_evaluate` path reuses the same handler internally), the
-  direct boundary is explicitly suppressed for that call so the job-derived
-  event is the only one emitted — one evaluation, one `workflow_outcome`.
-- Events are sent to PostHog via a fire-and-forget background thread using a
-  **public, write-only** project API key. Telemetry never blocks a command,
-  never raises, and silently drops events when offline. The worker is a
-  daemon thread, so process exit never waits on it either — events queued or
-  in flight when a process terminates are dropped, not delivered, with one
-  exception: the detached background-job worker explicitly flushes (bounded,
-  5s) before it exits, so the durable-job `workflow_outcome` that the
-  counting rule above depends on survives even though that worker is a
-  short-lived process with no interactive command left to keep responsive.
+- `ref` is a short install-channel token such as `readme` or `hellogithub`.
+  Invalid or absent values become `direct`.
+- Successful polling and internal helper tools are not collected. Failures are
+  retained so broken status, artifact, fan-out, and control paths remain visible.
+- A logical tool result with `is_error=true` is recorded as `status=blocked`.
+  This makes seed blocks and other validation stops distinct from exceptions.
+- `error_type` is only an audited exception class name, never a message or
+  traceback. `failure_reason_code` is one of `config`, `auth`, `timeout`,
+  `model`, `tool`, `validation`, `cancelled`, or `unknown`.
+- `command` values come only from static built-in command/tool/job registries.
+- `$insert_id` on `command_run` and `service_active` is a SHA-256 digest of the
+  anonymous ID, UTC day, event, and retained dimensions. Job-derived
+  `workflow_outcome` uses a one-way job digest; direct evaluations are not deduplicated.
+- PostHog may derive coarse country from the request IP for the country
+  aggregate. Ouroboros does not include the IP address in event properties.
+- Events use a public write-only project key and a fire-and-forget worker.
+  Telemetry never blocks a command and silently drops events when offline.
+  Detached job workers flush their terminal `workflow_outcome` before exit.
 
 ## Where the code lives
 
@@ -206,4 +132,4 @@ Collection is triggered only at these audited call sites:
   `EvaluateHandler.handle()` (direct `ouroboros_evaluate`) and
   `ChecklistVerifyHandler`'s nested multi-AC delegation; suppresses it when
   the same handler runs behind the job-backed `ouroboros_start_evaluate` path;
-- [`scripts/install.sh`](scripts/install.sh) — disclosed install start/completion.
+- [`scripts/install.sh`](scripts/install.sh) — successful install completion.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -20,7 +20,8 @@ tool arguments, environment variables, account data, or project identifiers.
 - command DAU = distinct anonymous IDs with `command_run` and `ci!=true` that day;
 - service DAU = distinct anonymous IDs with `service_active` and `ci!=true` that day;
 - verified weekly active = distinct anonymous IDs with `workflow_outcome`,
-  `command=evaluate`, `verified=true`, and `ci!=true` that week.
+  `command=evaluate`, `verified=true`, and `ci!=true` that week. Evaluations
+  delegated to an external plugin bridge are excluded because no terminal evidence is available.
 
 `command_run` and `service_active` carry deterministic daily `$insert_id` values.
 PostHog therefore stores at most one row per anonymous user/day/dimension tuple
@@ -82,17 +83,21 @@ use. Each row below is the exact property set accepted by the serializer.
 | Event | When | Properties (exact set) |
 |---|---|---|
 | `install_completed` | `install.sh` finishes successfully | os, runtime, version, ref |
-| `service_active` | An MCP service starts | service (`mcp`), runtime_backend, app_version, os, ci, `$insert_id` |
+| `service_active` | The running MCP service receives its first tool request that day | service (`mcp`), runtime_backend, app_version, os, ci, `$insert_id` |
 | `command_run` (service=mcp) | A retained lifecycle MCP command succeeds/is accepted, or any MCP command fails/is blocked | command, service, status (`succeeded`, `accepted`, `failed`, `rejected`, `blocked`), error_type (exception failures only), runtime_backend, app_version, os, ci, `$insert_id` |
 | `command_run` (service=cli) | A direct non-internal `ooo <command>` is invoked | command, service (`cli`), status (`invoked`), app_version, os, ci, `$insert_id` |
-| `workflow_outcome` | A background workflow or direct evaluation reaches a terminal result | command, terminal_status, verified, failure_reason_code (non-success only), runtime_backend, app_version, os, ci, `$insert_id` |
+| `workflow_outcome` | A background workflow or direct evaluation reaches a terminal result inside Ouroboros | command, terminal_status, verified, failure_reason_code (non-success only), runtime_backend, app_version, os, ci, `$insert_id` |
 
 Notes:
-
-- `ref` is a short install-channel token such as `readme` or `hellogithub`.
-  Invalid or absent values become `direct`.
+- `ref` is one of `direct`, `readme`, `readme-hero`, `readme-ko`,
+  `readme-hero-ko`, `readme-zh`, `readme-hero-zh`, or `docs-getting-started`.
+  Every other value folds to `direct` before serialization.
 - Successful polling and internal helper tools are not collected. Failures are
   retained so broken status, artifact, fan-out, and control paths remain visible.
+- `service_active` is emitted from the tool-request boundary, not process startup.
+  A bind, SDK startup, or PID-file failure therefore cannot count as service DAU.
+- User lifecycle is derived by PostHog's lifecycle query over the stable random
+  identity and daily `service_active` rows; no extra lifecycle-state property is sent.
 - A logical tool result with `is_error=true` is recorded as `status=blocked`.
   This makes seed blocks and other validation stops distinct from exceptions.
 - `error_type` is only an audited exception class name, never a message or

--- a/docs/first-command-activation/architecture.md
+++ b/docs/first-command-activation/architecture.md
@@ -3,6 +3,9 @@
 > Generated: 2026-08-13
 > Approach: install hint plus setup fallback
 
+> Historical note: the v2 lean telemetry contract stopped collecting this
+> attribution. This document is retained only as implementation history.
+
 ## Overview
 
 The installer translates a documented `OUROBOROS_INSTALL_REF` token into a

--- a/docs/first-command-activation/implementation.md
+++ b/docs/first-command-activation/implementation.md
@@ -3,6 +3,9 @@
 > Completed: 2026-08-13
 > Branch: `main` worktree
 
+> Historical note: the v2 lean telemetry contract removed the PostHog
+> onboarding-surface dimension and its installer hint.
+
 ## Summary
 
 Added privacy-safe onboarding-surface attribution and clarified the first-run

--- a/docs/first-command-activation/requirements.md
+++ b/docs/first-command-activation/requirements.md
@@ -3,6 +3,9 @@
 > Generated: 2026-08-13
 > Status: Implemented, awaiting post-release measurement
 
+> Historical note: this measurement program ended when v2 telemetry reduced
+> collection to installs, daily activity, adoption dimensions, and failures.
+
 ## Original requirement
 
 Reduce the PostHog drop-off between MCP server startup and the user's first

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -871,14 +871,14 @@ if [ "$IS_LOCAL" = false ] && command -v curl &>/dev/null; then
   fi
 fi
 
-# Optional install-channel attribution. A docs page or listing can prepend
-# OUROBOROS_INSTALL_REF=<channel> to the install command so install_started /
-# install_completed carry which surface the install came from. Same privacy
-# contract as every other property here: a short opaque token chosen by us,
-# never derived from the machine. Token-constrained like os/arch above so a
-# hostile value cannot ride into the payload; anything else becomes "direct".
-INSTALL_REF="${OUROBOROS_INSTALL_REF:-direct}"
-[[ "$INSTALL_REF" =~ ^[A-Za-z0-9._-]{1,32}$ ]] || INSTALL_REF="direct"
+# Closed install-channel vocabulary. Unknown values may contain private slugs,
+# customer names, or account identifiers, so they always fold to `direct`.
+case "${OUROBOROS_INSTALL_REF:-direct}" in
+  direct|readme|readme-hero|readme-ko|readme-hero-ko|readme-zh|readme-hero-zh|docs-getting-started)
+    INSTALL_REF="${OUROBOROS_INSTALL_REF:-direct}"
+    ;;
+  *) INSTALL_REF="direct" ;;
+esac
 
 _banner
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -754,20 +754,12 @@ with open(sys.argv[2], "w", encoding="utf-8") as fh:
 # _telemetry_ping <event> [key=value ...] — fire-and-forget, never fails.
 _telemetry_ping() {
   _telemetry_enabled || return 0
-  local event="$1" id os arch py body kv k v props api_key_safe event_safe id_safe
+  local event="$1" id os py body kv k v props api_key_safe event_safe id_safe
   shift
   id=$(_telemetry_distinct_id) || return 0
 
-  # Token-constrain os/arch at the source: a hostile executable earlier on
-  # PATH (or a nonstandard uname) can emit anything, including embedded
-  # quotes that would otherwise mutate the JSON structure below -- neither
-  # os nor arch legitimately needs more than this charset (darwin, linux,
-  # arm64, x86_64, ...), so anything that doesn't fullmatch is discarded
-  # outright rather than partially trusted.
   os=$(uname -s | tr '[:upper:]' '[:lower:]')
   [[ "$os" =~ ^[A-Za-z0-9._-]{1,32}$ ]] || os="unknown"
-  arch=$(uname -m)
-  [[ "$arch" =~ ^[A-Za-z0-9._-]{1,32}$ ]] || arch="unknown"
 
   py=$(command -v python3 2>/dev/null || true)
   body=""
@@ -784,10 +776,11 @@ _telemetry_ping() {
     body=$("$py" -c '
 import json, re, sys
 
-event, distinct_id, api_key, os_name, arch = sys.argv[1:6]
-props = {"source": "install_sh", "os": os_name, "arch": arch}
 key_re = re.compile(r"^[A-Za-z0-9_]+$")
-for kv in sys.argv[6:]:
+
+event, distinct_id, api_key, os_name = sys.argv[1:5]
+props = {"os": os_name}
+for kv in sys.argv[5:]:
     key, sep, value = kv.partition("=")
     if sep and key_re.match(key):
         props[key] = value
@@ -800,7 +793,7 @@ print(json.dumps(
     },
     separators=(",", ":"),
 ))
-' "$event" "$id" "$PH_API_KEY" "$os" "$arch" "$@" 2>/dev/null)
+' "$event" "$id" "$PH_API_KEY" "$os" "$@" 2>/dev/null)
   fi
 
   if [ -z "$body" ]; then
@@ -813,7 +806,7 @@ print(json.dumps(
     # doesn't is stripped down to it (then length-capped) or falls back to
     # `unknown` -- best-effort, consistent with the identity/notice
     # readers' own NO_PYTHON3 fallback posture elsewhere in this file.
-    props='"source":"install_sh","os":"'"$os"'","arch":"'"$arch"'"'
+    props='"os":"'"$os"'"'
     for kv in "$@"; do
       k=$(printf '%s' "${kv%%=*}" | tr -cd 'A-Za-z0-9_')
       [ -n "$k" ] || continue
@@ -887,32 +880,9 @@ fi
 INSTALL_REF="${OUROBOROS_INSTALL_REF:-direct}"
 [[ "$INSTALL_REF" =~ ^[A-Za-z0-9._-]{1,32}$ ]] || INSTALL_REF="direct"
 
-# Preserve a coarse onboarding hint for the first MCP session. This is not a
-# user identifier and is never sent as an install property; telemetry reads
-# only the fixed enum after install, until setup creates config.yaml. Existing
-# setup or an existing hint wins, so re-running the installer cannot
-# relabel a user's first documented install surface.
-_persist_first_command_surface_hint() {
-  local surface=""
-  case "$INSTALL_REF" in
-    readme|readme-*) surface="readme_quickstart" ;;
-    getting-started|getting_started|getting-started-*|docs-getting-started) surface="getting_started" ;;
-    *) return 0 ;;
-  esac
-  local dir="$HOME/.ouroboros" tmp="$HOME/.ouroboros/first_command_surface.$$"
-  [ -f "$dir/config.yaml" ] && return 0
-  [ -s "$dir/first_command_surface" ] && return 0
-  if mkdir -p "$dir" 2>/dev/null; then
-    (umask 077; printf '%s\n' "$surface" > "$tmp" && mv -f "$tmp" "$dir/first_command_surface") \
-      2>/dev/null || rm -f "$tmp" 2>/dev/null || true
-  fi
-}
-_persist_first_command_surface_hint
-
 _banner
 
 _telemetry_notice
-_telemetry_ping install_started "is_local=$IS_LOCAL" "pre=${PRE_FLAG:-no}" "version=${LATEST:-unknown}" "ref=$INSTALL_REF"
 
 # 1. Detect installer: uv > pipx > pip (determines Python requirement)
 HAS_UV=false
@@ -1465,8 +1435,8 @@ if command -v claude &>/dev/null; then
   fi
 fi
 
-_telemetry_ping install_completed "method=${INSTALL_METHOD:-unknown}" "runtime=${RUNTIME:-none}" \
-  "detected_runtimes=${RUNTIME_COUNT:-0}" "version=${LATEST:-unknown}" "ref=$INSTALL_REF"
+_telemetry_ping install_completed "runtime=${RUNTIME:-none}" \
+  "version=${LATEST:-unknown}" "ref=$INSTALL_REF"
 
 _blank
 _say "${GREEN}${BOLD}Done! Ouroboros is ready.${RESET}"

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -23,7 +23,6 @@ from rich.text import Text
 import structlog
 import typer
 
-from ouroboros import telemetry as usage_telemetry
 from ouroboros.backends import resolve_runtime_backend_name
 from ouroboros.cli.commands.mcp_doctor import register_doctor_command
 from ouroboros.cli.formatters.panels import print_info, print_success
@@ -754,11 +753,7 @@ async def _run_mcp_server(
         from ouroboros.mcp.update_notice import maybe_schedule_cache_refresh
 
         maybe_schedule_cache_refresh()
-
         tool_count = len(server.info.tools)
-
-        # Deduplicated server-side by user/day/backend for service DAU.
-        usage_telemetry.capture_service_active()
 
         # Detect Codex seatbelt sandbox and warn about network restrictions.
         _sandbox_network_disabled = os.environ.get("CODEX_SANDBOX_NETWORK_DISABLED") == "1"

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -757,11 +757,8 @@ async def _run_mcp_server(
 
         tool_count = len(server.info.tools)
 
-        # One event per host session attach (Claude/Codex spawn `mcp serve`
-        # per session) — the denominator for agent-side usage ratios.
-        usage_telemetry.capture(
-            "mcp_serve_started", {"transport": transport, "tool_count": tool_count}
-        )
+        # Deduplicated server-side by user/day/backend for service DAU.
+        usage_telemetry.capture_service_active()
 
         # Detect Codex seatbelt sandbox and warn about network restrictions.
         _sandbox_network_disabled = os.environ.get("CODEX_SANDBOX_NETWORK_DISABLED") == "1"

--- a/src/ouroboros/mcp/telemetry_boundary.py
+++ b/src/ouroboros/mcp/telemetry_boundary.py
@@ -191,6 +191,7 @@ async def observe_adapter_tool_call[T, E](
             ok=False,
             duration_ms=_duration_ms(started_at),
             error_type=_safe_error_type(exc),
+            registered=registered,
         )
         raise
     logical_error = result.is_ok and _is_logical_error(result.value)
@@ -200,6 +201,7 @@ async def observe_adapter_tool_call[T, E](
         duration_ms=_duration_ms(started_at),
         error_type=_safe_error_type(result.error) if result.is_err else None,
         blocked=logical_error,
+        registered=registered,
     )
     return result
 
@@ -261,9 +263,7 @@ async def call_sdk_tool(
 
     started_at = time.monotonic()
     error_type: str | None = None
-    # Unregistered until a matching definition is found below; never
-    # overwritten with the caller-controlled ``name`` before that (see
-    # _UNKNOWN_TOOL_NAME).
+    registered = False
     safe_name = _UNKNOWN_TOOL_NAME
     try:
         definition = next(
@@ -272,6 +272,7 @@ async def call_sdk_tool(
         )
         if definition is None:
             raise RuntimeError(f"Tool not found: {name}")
+        registered = True
         safe_name = name
         if set(arguments) == {"kwargs"} and isinstance(arguments.get("kwargs"), dict):
             arguments = arguments["kwargs"]
@@ -302,6 +303,7 @@ async def call_sdk_tool(
             ok=False,
             duration_ms=_duration_ms(started_at),
             error_type=error_type or _safe_error_type(exc),
+            registered=registered,
         )
         raise
     logical_error = _is_logical_error(value)
@@ -310,6 +312,7 @@ async def call_sdk_tool(
         ok=not logical_error,
         duration_ms=_duration_ms(started_at),
         blocked=logical_error,
+        registered=registered,
     )
     return response
 

--- a/src/ouroboros/mcp/telemetry_boundary.py
+++ b/src/ouroboros/mcp/telemetry_boundary.py
@@ -199,6 +199,7 @@ async def observe_adapter_tool_call[T, E](
         ok=result.is_ok and not logical_error,
         duration_ms=_duration_ms(started_at),
         error_type=_safe_error_type(result.error) if result.is_err else None,
+        blocked=logical_error,
     )
     return result
 
@@ -305,7 +306,10 @@ async def call_sdk_tool(
         raise
     logical_error = _is_logical_error(value)
     usage_telemetry.capture_tool_call(
-        safe_name, ok=not logical_error, duration_ms=_duration_ms(started_at)
+        safe_name,
+        ok=not logical_error,
+        duration_ms=_duration_ms(started_at),
+        blocked=logical_error,
     )
     return response
 
@@ -334,19 +338,11 @@ def record_direct_evaluation_outcome(
         )
         properties: dict[str, Any] = {
             "command": "evaluate",
-            "phase": "terminal",
             "terminal_status": status,
-            "ok": not failed,
             "verified": (not failed) and final_approved is True,
-            "final_approved": final_approved if isinstance(final_approved, bool) else None,
         }
         if resolution is not None:
-            properties.update(
-                {
-                    "failure_reason_code": resolution.reason_code.value,
-                    "recovery_action": resolution.recovery_action.value,
-                }
-            )
+            properties["failure_reason_code"] = resolution.reason_code.value
         usage_telemetry.capture(
             "workflow_outcome",
             properties,
@@ -445,18 +441,9 @@ def stamp_backend_context(
     interview_llm_backend: str | None,
     evaluate_llm_backend: str | None,
 ) -> None:
-    """Stamp resolved provider backends onto every subsequent telemetry event.
-
-    Lives here rather than in the (grandfathered, size-capped) adapter module:
-    the adapter's composition root only supplies the resolved values, and the
-    context keys stay next to the other telemetry-boundary vocabulary.
-    """
-    usage_telemetry.set_context(
-        runtime_backend=runtime_backend,
-        execute_runtime_backend=execute_runtime_backend,
-        interview_llm_backend=interview_llm_backend,
-        evaluate_llm_backend=evaluate_llm_backend,
-    )
+    """Stamp only the retained runtime-backend dimension."""
+    del execute_runtime_backend, interview_llm_backend, evaluate_llm_backend
+    usage_telemetry.set_context(runtime_backend=runtime_backend)
 
 
 class JobTelemetryBoundary:

--- a/src/ouroboros/telemetry.py
+++ b/src/ouroboros/telemetry.py
@@ -3,8 +3,9 @@
 Privacy contract — see TELEMETRY.md at the repository root:
 
 - Never collects code, prompts, seed content, file paths, or arguments.
-  Only event names and coarse properties (command, backend, version, os,
-  duration, success) are sent.
+  Only closed command/status dimensions, runtime backend, version, OS, and
+  failure reason codes are sent. Daily activity uses deterministic insert IDs.
+  Country is derived by PostHog from the request, not sent by Ouroboros.
 - Identity is a random UUID stored in ``~/.ouroboros/telemetry.json``.
   No PII, no machine fingerprinting.
 - Opt out any time: ``DO_NOT_TRACK=1``, ``OUROBOROS_TELEMETRY=0``, or
@@ -299,6 +300,7 @@ _queue: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=_QUEUE_MAX)
 _worker: threading.Thread | None = None
 _context: dict[str, Any] = {}
 _state_cache: dict[str, Any] | None = None
+_activity_cache: set[str] = set()
 
 
 def _api_key() -> str:
@@ -878,14 +880,21 @@ def capture(event: str, properties: dict[str, Any] | None = None) -> None:
         if event in {"command_run", "service_active"} and "$insert_id" not in props:
             props["$insert_id"] = _daily_insert_id(event, resolved_id, props)
         props = _sanitize_properties(props, allowed_keys)
-        _queue.put_nowait(
-            {
-                "event": event,
-                "distinct_id": resolved_id,
-                "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-                "properties": props,
-            }
-        )
+        event_payload = {
+            "event": event,
+            "distinct_id": resolved_id,
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "properties": props,
+        }
+        if event == "service_active":
+            insert_id = str(props["$insert_id"])
+            with _lock:
+                if insert_id in _activity_cache:
+                    return
+                _queue.put_nowait(event_payload)
+                _activity_cache.add(insert_id)
+        else:
+            _queue.put_nowait(event_payload)
         _ensure_worker()
     except Exception:
         pass
@@ -909,6 +918,7 @@ def capture_tool_call(
         elif name != _UNKNOWN_TOOL_NAME and name not in _CANONICAL_TOOL_NAMES:
             name = _EXTENSION_TOOL_NAME
         command = _TOOL_FUNNEL.get(name)
+        capture_service_active()
         if ok and not blocked and command is None:
             return
         if blocked:
@@ -965,10 +975,6 @@ def capture_job_outcome(
         normalized_status = terminal_status.strip().lower()
         meta = result_meta if isinstance(result_meta, dict) else {}
         final_approved = meta.get("final_approved")
-        # Compares the RAW job_type, never the folded/audited `command`
-        # below: an extension job must not earn verified=true just because
-        # its job_type happens not to be "evaluate" either way. Folding
-        # only ever affects the `command` property, never this check.
         verified = (
             normalized_status == "completed" and job_type == "evaluate" and final_approved is True
         )
@@ -986,10 +992,7 @@ def capture_job_outcome(
         }
         if resolution is not None:
             properties["failure_reason_code"] = resolution.reason_code.value
-        capture(
-            "workflow_outcome",
-            properties,
-        )
+        capture("workflow_outcome", properties)
     except Exception:
         pass
 
@@ -1135,6 +1138,7 @@ def _reset_for_tests() -> None:
     with _lock:
         _state_cache = None
         _context.clear()
+        _activity_cache.clear()
 
 
 __all__ = [

--- a/src/ouroboros/telemetry.py
+++ b/src/ouroboros/telemetry.py
@@ -140,11 +140,6 @@ _ASYNC_SUBMISSION_TOOLS = frozenset(
         "ouroboros_start_ralph",
     }
 )
-
-# Backstop for capture_tool_call: shipped tool names are lowercase snake-case
-# after the `ouroboros_` prefix. Unknown or extension names are folded to fixed
-# literals before the command dimension is emitted.
-_TOOL_NAME_PATTERN = re.compile(r"^ouroboros_[a-z0-9_]{1,64}$")
 _UNKNOWN_TOOL_NAME = "ouroboros_unknown_tool"
 
 # The audited privacy contract for `tool`/`command`: every SHIPPED built-in
@@ -907,15 +902,14 @@ def capture_tool_call(
     duration_ms: float | None = None,
     error_type: str | None = None,
     blocked: bool = False,
+    registered: bool = True,
 ) -> None:
-    """Capture retained lifecycle commands and every failed MCP call."""
+    """Capture service activity plus retained lifecycle/failure commands."""
     del duration_ms
     try:
-        if not name.startswith("ouroboros_"):
-            return
-        if not _TOOL_NAME_PATTERN.fullmatch(name):
+        if not registered:
             name = _UNKNOWN_TOOL_NAME
-        elif name != _UNKNOWN_TOOL_NAME and name not in _CANONICAL_TOOL_NAMES:
+        elif name not in _CANONICAL_TOOL_NAMES:
             name = _EXTENSION_TOOL_NAME
         command = _TOOL_FUNNEL.get(name)
         capture_service_active()

--- a/src/ouroboros/telemetry.py
+++ b/src/ouroboros/telemetry.py
@@ -24,7 +24,6 @@ import os
 from pathlib import Path
 import platform
 import queue
-import random
 import re
 import ssl
 import threading
@@ -48,39 +47,8 @@ _QUEUE_MAX = 256
 _BATCH_MAX = 25
 _HTTP_TIMEOUT_SECONDS = 4.0
 
-# Tools that skills poll in loops (job status, HUDs, projections). Captured
-# at 1/_POLL_SAMPLE_RATE via an independent per-call random draw (not a
-# per-process counter) with a ``sample_rate`` property so absolute counts
-# can be re-weighted in PostHog without flooding ingestion. A per-process
-# counter would always capture call #1, so short-lived processes (a fresh
-# MCP session that polls once or twice before exiting) would be captured at
-# ~1:1 instead of 1/50 -- an up-to-50x over-count skewed toward exactly the
-# processes least representative of steady-state usage. A per-call draw
-# keeps the probability 1/50 regardless of how long the process lives.
-_POLLING_TOOLS = frozenset(
-    {
-        "ouroboros_job_status",
-        "ouroboros_job_wait",
-        "ouroboros_job_result",
-        "ouroboros_session_status",
-        "ouroboros_query_events",
-        "ouroboros_query_projection",
-        "ouroboros_ac_dashboard",
-        "ouroboros_ac_tree_hud",
-        "ouroboros_session_signal_targets",
-        "ouroboros_lineage_status",
-        "ouroboros_project_status",
-    }
-)
-_POLL_SAMPLE_RATE = 50
-# Module-level so a test can seed it for a deterministic capture/skip
-# pattern (telemetry._poll_rng.seed(...)); a fresh Random() per call would
-# make sampling untestable, and reusing threading._lock's RNG would couple
-# unrelated concerns. random.Random() is not cryptographically secure, which
-# is fine here -- this is a sampling coin flip, not a security boundary.
-_poll_rng = random.Random()
 
-# Funnel step per MCP tool. Everything else is still captured (tool property)
+# Funnel step per retained MCP lifecycle command.
 # but these get a stable ``command`` value so the interview -> seed -> run ->
 # evaluate -> evolve funnel can be built without knowing tool names.
 _TOOL_FUNNEL: dict[str, str] = {
@@ -102,10 +70,8 @@ _TOOL_FUNNEL: dict[str, str] = {
     "ouroboros_lateral_think": "unstuck",
 }
 
-# CLI subcommand -> funnel command normalization; None means "do not capture".
-# "mcp" is excluded because hosts (Claude Code, Codex) spawn `ouroboros mcp
-# serve` automatically per session — counting it as a terminal command would
-# inflate direct-CLI usage. Serve boots emit `mcp_serve_started` instead.
+# Internal CLI plumbing is excluded. MCP service activity is emitted separately
+# as a daily-deduplicated `service_active` event.
 _CLI_SKIP = frozenset({"dispatch", "job", "mcp"})
 _CLI_FUNNEL = {"init": "interview"}
 
@@ -174,18 +140,9 @@ _ASYNC_SUBMISSION_TOOLS = frozenset(
     }
 )
 
-# Backstop for capture_tool_call: every registered MCP tool name is
-# lowercase snake-case after the "ouroboros_" prefix (verified against
-# _TOOL_FUNNEL/_POLLING_TOOLS/_ASYNC_SUBMISSION_TOOLS above), so a `name`
-# that fails this fullmatch cannot be a real tool -- it's caller-controlled
-# input (the "ouroboros_" startswith gate alone lets anything after that
-# prefix through unchanged). The property allowlist constrains which keys
-# reach a batch, not the string semantics of a value that IS an allowed key
-# (`tool`/`command` are plain caller strings), so this is the backstop that
-# constrains the one caller-controlled value that becomes a property --
-# a path, an identifier, or anything else must never ride through `tool`
-# or `command`, even if the real boundary (the MCP tool registry lookup)
-# has a bug.
+# Backstop for capture_tool_call: shipped tool names are lowercase snake-case
+# after the `ouroboros_` prefix. Unknown or extension names are folded to fixed
+# literals before the command dimension is emitted.
 _TOOL_NAME_PATTERN = re.compile(r"^ouroboros_[a-z0-9_]{1,64}$")
 _UNKNOWN_TOOL_NAME = "ouroboros_unknown_tool"
 
@@ -207,8 +164,7 @@ _UNKNOWN_TOOL_NAME = "ouroboros_unknown_tool"
 #    composition path (used for a different runtime mode) that additionally
 #    registers `ouroboros_checklist_verify`, a genuine top-level tool absent
 #    from (1)'s default composition.
-# _TOOL_FUNNEL/_POLLING_TOOLS/_ASYNC_SUBMISSION_TOOLS keys are all subsets
-# of this set (test_telemetry.py asserts it, so the sets can't drift apart).
+# _TOOL_FUNNEL and _ASYNC_SUBMISSION_TOOLS must remain subsets of this set.
 _CANONICAL_TOOL_NAMES = frozenset(
     {
         "ouroboros_ac_dashboard",
@@ -285,169 +241,54 @@ _INTERNAL_SHIPPED_JOB_TYPES = frozenset({"detached_probe", "detached_nested_prob
 _CANONICAL_JOB_TYPES = frozenset(_JOB_FUNNEL) | _INTERNAL_SHIPPED_JOB_TYPES
 _EXTENSION_JOB_COMMAND = "extension_job"
 
-# Executable form of the TELEMETRY.md event table. Auditing call sites for
-# compliance is not the same as enforcing it: capture() and set_context()
-# below drop anything outside these sets before it reaches the queue, so a
-# call site cannot accidentally (or maliciously) smuggle an unlisted event
-# name or property -- e.g. prompt text or a file path -- into an outgoing
-# batch, even if a future edit passes one in.
-#
-# TELEMETRY.md's "What is sent" table and the sets below are one contract in
-# two places (SSOT pairing) -- edit both together, or the doc lies. Sets are
-# literal per (event, variant), not composed from a shared base + context
-# pool: variants deliberately differ in what they carry (e.g.
-# mcp_serve_started omits python_version; the cli command_run variant omits
-# every backend/provider context key entirely), so a generic union would
-# either under- or over-grant for at least one variant.
-_CONTEXT_ALLOWLIST = frozenset(
-    {
-        "runtime_backend",
-        "execute_runtime_backend",
-        "interview_llm_backend",
-        "evaluate_llm_backend",
-    }
-)
+# Exact minimal contract paired with TELEMETRY.md. Anything else is dropped.
+_CONTEXT_ALLOWLIST = frozenset({"runtime_backend"})
 _COMMAND_RUN_MCP_KEYS = frozenset(
     {
         "command",
-        "tool",
-        "source",
-        "is_funnel",
-        "phase",
-        "accepted",
-        "ok",
-        "duration_ms",
+        "service",
+        "status",
         "error_type",
-        "sample_rate",
+        "$insert_id",
         "runtime_backend",
-        "execute_runtime_backend",
-        "interview_llm_backend",
-        "evaluate_llm_backend",
-        "frontdoor",
-        "first_command_surface",
         "app_version",
         "os",
-        "python_version",
         "ci",
     }
 )
 _COMMAND_RUN_CLI_KEYS = frozenset(
     {
         "command",
-        "source",
-        "is_funnel",
+        "service",
+        "status",
+        "$insert_id",
         "app_version",
         "os",
-        "python_version",
-        "frontdoor",
         "ci",
     }
 )
 _WORKFLOW_OUTCOME_KEYS = frozenset(
     {
         "command",
-        "phase",
         "terminal_status",
-        "ok",
         "verified",
-        "final_approved",
         "failure_reason_code",
-        "recovery_action",
         "$insert_id",
         "runtime_backend",
-        "execute_runtime_backend",
-        "interview_llm_backend",
-        "evaluate_llm_backend",
         "app_version",
         "os",
-        "python_version",
-        "frontdoor",
         "ci",
     }
 )
-_MCP_SERVE_STARTED_KEYS = frozenset(
+_SERVICE_ACTIVE_KEYS = frozenset(
     {
-        "transport",
-        "tool_count",
-        "frontdoor",
-        "first_command_surface",
+        "service",
+        "$insert_id",
+        "runtime_backend",
         "app_version",
         "os",
         "ci",
     }
-)
-_SUBAGENT_DISPATCH_KEYS = frozenset(
-    {
-        "phase",
-        "fanout_kind",
-        "payload_count",
-        "invocation_surface",
-        "dispatch_authority",
-        "host_family",
-        "host_identity_status",
-        "host_capability",
-        "capability_source",
-        "delivery_mode",
-        "execution_preference",
-        "fallback_strategy",
-        "configured_worker_backend",
-        "host_worker_mismatch",
-        "decision_reason",
-        "contract_version",
-        "fanout_reentry_available",
-        "submission_status",
-        "expected_count",
-        "received_count",
-        "undispatched_count",
-        "frontdoor",
-        "first_command_surface",
-        "app_version",
-        "os",
-        "python_version",
-        "ci",
-    }
-)
-
-_SUBAGENT_DISPATCH_ENUMS: dict[str, frozenset[str]] = {
-    "phase": frozenset({"emitted", "submitted"}),
-    "fanout_kind": frozenset(
-        {"lateral_persona_panel", "question_advisory", "code_investigation", "unknown"}
-    ),
-    "invocation_surface": frozenset({"mcp_host", "internal_runtime"}),
-    "dispatch_authority": frozenset({"mcp_host", "internal_runtime", "passive_bridge"}),
-    "host_family": frozenset({"claude_code", "codex", "opencode", "other_known", "unknown"}),
-    "host_identity_status": frozenset({"known", "unknown"}),
-    "host_capability": frozenset({"parallel", "sequential", "unavailable", "undeclared"}),
-    "capability_source": frozenset(
-        {"mcp_extension", "trusted_server_option", "passive_bridge", "none"}
-    ),
-    "delivery_mode": frozenset({"passive_bridge", "inline_host", "inline_runtime"}),
-    "execution_preference": frozenset({"parallel", "sequential"}),
-    "fallback_strategy": frozenset({"sequential", "none"}),
-    "decision_reason": frozenset(
-        {
-            "passive_bridge_detected",
-            "declared_parallel",
-            "declared_sequential",
-            "host_capability_undeclared",
-            "configured_internal_runtime",
-        }
-    ),
-    "contract_version": frozenset({"v2"}),
-    "submission_status": frozenset(
-        {
-            "complete",
-            "partial",
-            "invalid_result_entry",
-            "unknown_fanout_id",
-            "correlation_mismatch",
-            "unknown_kind",
-            "publication_failed",
-        }
-    ),
-}
-_FIRST_COMMAND_SURFACES = frozenset(
-    {"setup_complete", "readme_quickstart", "getting_started", "unknown"}
 )
 # Bound on any single string property. Dropped, not truncated -- a truncated
 # value could still leak the start of a prompt or path.
@@ -884,69 +725,18 @@ def _sanitize_properties(props: dict[str, Any], allowed_keys: frozenset[str]) ->
 
 
 def set_context(**props: Any) -> None:
-    """Merge properties (e.g. runtime_backend) into every subsequent event.
-
-    Only keys in _CONTEXT_ALLOWLIST are accepted: this is a global sink read
-    by _base_properties() on every capture() call, so an unvetted key here
-    would leak into every event, not just one call site's.
-    """
+    """Merge allowlisted runtime context into subsequent events."""
     with _lock:
         for key, value in props.items():
             if key in _CONTEXT_ALLOWLIST and _is_allowed_scalar(value):
                 _context[key] = value
 
 
-def _detect_frontdoor() -> str | None:
-    """Best-effort detection of the host CLI that spawned this process."""
-    env = os.environ
-    if env.get("CLAUDECODE"):
-        return "claude"
-    if env.get("CODEX_THREAD_ID") or env.get("CODEX_SANDBOX_NETWORK_DISABLED"):
-        return "codex"
-    return None
-
-
-def _detect_first_command_surface() -> str:
-    """Return the privacy-safe onboarding surface attribution.
-
-    The value is deliberately a fixed enum. A trusted setup/config file wins
-    only when no install-time hint exists. The hint identifies the surface
-    that brought the user to installation, so it must survive the subsequent
-    setup step; otherwise every README cohort would be relabeled
-    ``setup_complete`` before its first command. ``setup_complete`` is the
-    fallback for users who configured Ouroboros without a known install
-    surface.
-    """
-    candidate = os.environ.get("OUROBOROS_FIRST_COMMAND_SURFACE", "").strip().lower()
-    if candidate in _FIRST_COMMAND_SURFACES:
-        return candidate
-
-    hint_path = Path.home() / ".ouroboros" / "first_command_surface"
-    try:
-        candidate = hint_path.read_text(encoding="utf-8").strip().lower()
-    except Exception:
-        candidate = ""
-    if candidate in _FIRST_COMMAND_SURFACES:
-        return candidate
-
-    config_path = Path.home() / ".ouroboros" / "config.yaml"
-    if config_path.is_file():
-        return "setup_complete"
-    return "unknown"
-
-
 def _base_properties() -> dict[str, Any]:
     props: dict[str, Any] = {
         "app_version": __version__,
         "os": platform.system().lower(),
-        "python_version": platform.python_version(),
     }
-    frontdoor = _detect_frontdoor()
-    if frontdoor:
-        props["frontdoor"] = frontdoor
-    props["first_command_surface"] = _detect_first_command_surface()
-    # CI runs are excluded from the published counting rule (TELEMETRY.md);
-    # stamping them lets every insight filter ci != true.
     if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"):
         props["ci"] = True
     with _lock:
@@ -1031,24 +821,32 @@ def flush(timeout: float = 1.5) -> None:
 
 
 def _resolve_allowed_keys(event: str, properties: dict[str, Any] | None) -> frozenset[str] | None:
-    """Look up the exact per-event(-variant) property set for `event`.
-
-    None means the event is not on the disclosed table at all -- capture()
-    drops it. `command_run` has two variants selected by the
-    caller-provided `source` property (`"cli"` vs. everything else,
-    including absent, which is `"mcp"`); every other event's set is fixed
-    by its name alone.
-    """
     if event == "command_run":
-        source = (properties or {}).get("source")
-        return _COMMAND_RUN_CLI_KEYS if source == "cli" else _COMMAND_RUN_MCP_KEYS
+        service = (properties or {}).get("service")
+        return _COMMAND_RUN_CLI_KEYS if service == "cli" else _COMMAND_RUN_MCP_KEYS
     if event == "workflow_outcome":
         return _WORKFLOW_OUTCOME_KEYS
-    if event == "mcp_serve_started":
-        return _MCP_SERVE_STARTED_KEYS
-    if event == "subagent_dispatch":
-        return _SUBAGENT_DISPATCH_KEYS
+    if event == "service_active":
+        return _SERVICE_ACTIVE_KEYS
     return None
+
+
+def _daily_insert_id(
+    event: str,
+    distinct_id_value: str,
+    properties: dict[str, Any],
+) -> str:
+    """Deduplicate DAU rows to one user/day/dimension tuple."""
+    day = time.strftime("%Y-%m-%d", time.gmtime())
+    dimensions = (
+        properties.get("service"),
+        properties.get("command"),
+        properties.get("status"),
+        properties.get("error_type"),
+        properties.get("runtime_backend"),
+    )
+    material = "\0".join(str(value or "") for value in (distinct_id_value, day, event, *dimensions))
+    return hashlib.sha256(material.encode()).hexdigest()
 
 
 def capture(event: str, properties: dict[str, Any] | None = None) -> None:
@@ -1077,6 +875,8 @@ def capture(event: str, properties: dict[str, Any] | None = None) -> None:
         props = _base_properties()
         if properties:
             props.update({k: v for k, v in properties.items() if v is not None})
+        if event in {"command_run", "service_active"} and "$insert_id" not in props:
+            props["$insert_id"] = _daily_insert_id(event, resolved_id, props)
         props = _sanitize_properties(props, allowed_keys)
         _queue.put_nowait(
             {
@@ -1097,96 +897,47 @@ def capture_tool_call(
     ok: bool,
     duration_ms: float | None = None,
     error_type: str | None = None,
+    blocked: bool = False,
 ) -> None:
-    """Capture one MCP tool invocation (the single funnel chokepoint).
-
-    `name` is caller-controlled and only loosely gated by the
-    "ouroboros_" prefix check below -- see _TOOL_NAME_PATTERN for the
-    strict charset backstop, and _CANONICAL_TOOL_NAMES for the audited
-    allowlist that follows it: a name that doesn't look like a real tool,
-    or looks right but isn't one this project ships, is replaced with a
-    fixed literal before it can become the `tool`/`command` property
-    values, rather than dropped or forwarded verbatim.
-    """
+    """Capture retained lifecycle commands and every failed MCP call."""
+    del duration_ms
     try:
         if not name.startswith("ouroboros_"):
             return
         if not _TOOL_NAME_PATTERN.fullmatch(name):
-            # Defense in depth: the real boundary (an MCP tool registry
-            # lookup) belongs upstream of this function and should already
-            # normalize unknown names, but this call site must not depend
-            # on that holding forever. Replace, don't drop -- unknown-tool
-            # failures are deliberately counted, just never under a caller
-            # string that could be a path, an identifier, or anything else.
             name = _UNKNOWN_TOOL_NAME
         elif name != _UNKNOWN_TOOL_NAME and name not in _CANONICAL_TOOL_NAMES:
-            # Charset-valid but not an audited built-in name: a real
-            # registered extension/custom tool (register_tool() accepts
-            # anything), not a lookup failure -- keep the two literals
-            # distinct rather than collapsing both into "unknown". Still
-            # counted, never under the caller's identifying name.
             name = _EXTENSION_TOOL_NAME
-        sample_rate = 1
-        if name in _POLLING_TOOLS:
-            if _poll_rng.random() >= 1.0 / _POLL_SAMPLE_RATE:
-                return  # independent per-call draw -- see _POLLING_TOOLS comment
-            sample_rate = _POLL_SAMPLE_RATE
-        funnel = _TOOL_FUNNEL.get(name)
-        properties: dict[str, Any] = {
-            "command": funnel or name.removeprefix("ouroboros_"),
-            "tool": name,
-            "source": "mcp",
-            "is_funnel": funnel is not None,
-            "phase": "submission" if name in _ASYNC_SUBMISSION_TOOLS else "completion",
-            "duration_ms": round(duration_ms, 1) if duration_ms is not None else None,
-            "error_type": error_type,
-            "sample_rate": sample_rate if sample_rate > 1 else None,
-        }
-        if name in _ASYNC_SUBMISSION_TOOLS:
-            properties["accepted"] = ok
+        command = _TOOL_FUNNEL.get(name)
+        if ok and not blocked and command is None:
+            return
+        if blocked:
+            status = "blocked"
+        elif name in _ASYNC_SUBMISSION_TOOLS:
+            status = "accepted" if ok else "rejected"
         else:
-            properties["ok"] = ok
-        capture("command_run", properties)
+            status = "succeeded" if ok else "failed"
+        capture(
+            "command_run",
+            {
+                "command": command or name.removeprefix("ouroboros_"),
+                "service": "mcp",
+                "status": status,
+                "error_type": error_type,
+            },
+        )
     except Exception:
         pass
+
+
+def capture_service_active() -> None:
+    """Record at most one service-active row per user/day/backend."""
+    capture("service_active", {"service": "mcp"})
 
 
 def capture_subagent_dispatch(properties: dict[str, Any]) -> None:
-    """Capture one privacy-safe fan-out contract or re-entry boundary.
-
-    Values are closed enums and bounded counts. Unknown/custom strings are
-    folded before ``capture`` so raw client names, backend names, identifiers,
-    prompts, and outputs can never reach PostHog through this event.
-    """
-    try:
-        safe: dict[str, Any] = {}
-        for key, value in properties.items():
-            allowed = _SUBAGENT_DISPATCH_ENUMS.get(key)
-            if allowed is not None:
-                if isinstance(value, str) and value in allowed:
-                    safe[key] = value
-                continue
-            if key in {
-                "payload_count",
-                "expected_count",
-                "received_count",
-                "undispatched_count",
-            }:
-                if isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= 64:
-                    safe[key] = value
-                continue
-            if key in {"host_worker_mismatch", "fanout_reentry_available"}:
-                if isinstance(value, bool):
-                    safe[key] = value
-                continue
-            if key == "configured_worker_backend":
-                from ouroboros.backends.capabilities import get_backend_capability
-
-                capability = get_backend_capability(str(value))
-                safe[key] = capability.name if capability is not None else "other"
-        capture("subagent_dispatch", safe)
-    except Exception:
-        pass
+    """Compatibility no-op: subagent dispatch telemetry is no longer collected."""
+    del properties
 
 
 def capture_job_outcome(
@@ -1229,20 +980,12 @@ def capture_job_outcome(
         )
         properties: dict[str, Any] = {
             "command": command,
-            "phase": "terminal",
             "terminal_status": normalized_status,
-            "ok": normalized_status == "completed",
             "verified": verified,
-            "final_approved": (final_approved if isinstance(final_approved, bool) else None),
             "$insert_id": hashlib.sha256(f"ouroboros-job-outcome\0{job_id}".encode()).hexdigest(),
         }
         if resolution is not None:
-            properties.update(
-                {
-                    "failure_reason_code": resolution.reason_code.value,
-                    "recovery_action": resolution.recovery_action.value,
-                }
-            )
+            properties["failure_reason_code"] = resolution.reason_code.value
         capture(
             "workflow_outcome",
             properties,
@@ -1272,8 +1015,8 @@ def capture_cli_command(subcommand: str | None) -> None:
             "command_run",
             {
                 "command": command,
-                "source": "cli",
-                "is_funnel": subcommand in ("auto", "init", "interview", "seed", "run", "qa", "pm"),
+                "service": "cli",
+                "status": "invoked",
             },
         )
     except Exception:
@@ -1392,16 +1135,13 @@ def _reset_for_tests() -> None:
     with _lock:
         _state_cache = None
         _context.clear()
-        # Reseed from OS entropy so a test that seeded _poll_rng for a
-        # deterministic capture/skip pattern can't leak that determinism
-        # into an unrelated later test.
-        _poll_rng.seed()
 
 
 __all__ = [
     "capture",
     "capture_cli_command",
     "capture_job_outcome",
+    "capture_service_active",
     "capture_tool_call",
     "distinct_id",
     "flush",

--- a/tests/unit/cli/test_cli_telemetry.py
+++ b/tests/unit/cli/test_cli_telemetry.py
@@ -130,7 +130,6 @@ def test_dynamic_plugin_dispatch_captures_extension_command_not_plugin_name(
     assert len(captured) == 1
     assert captured[0]["event"] == "command_run"
     assert captured[0]["properties"]["command"] == "extension_command"
-    assert captured[0]["properties"]["is_funnel"] is False
     assert installed_plugin not in repr(captured[0])
 
 

--- a/tests/unit/cli/test_mcp_startup_cleanup.py
+++ b/tests/unit/cli/test_mcp_startup_cleanup.py
@@ -392,6 +392,7 @@ class TestMCPStartupAutoCleanup:
                 "ouroboros.mcp.server.adapter.create_ouroboros_server",
                 return_value=mock_server,
             ),
+            patch("ouroboros.telemetry.capture_service_active") as capture_service,
         ):
             from ouroboros.cli.commands.mcp import _run_mcp_server
 
@@ -401,6 +402,7 @@ class TestMCPStartupAutoCleanup:
         # Cleanup still ran despite the failure: adapter shutdown owns store
         # closure, so the WAL checkpoint path is reached even when serve fails.
         mock_server.shutdown.assert_awaited_once()
+        capture_service.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_event_store_init_failure_aborts_startup(self) -> None:

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -2709,7 +2709,7 @@ class TestMCPServerAdapterTools:
         boundary drops successful non-lifecycle extension calls entirely.
         """
         adapter = MCPServerAdapter()
-        extension_name = "ouroboros_acme_private_project"
+        extension_name = "custom_tool"
         adapter.register_tool(MockToolHandler(extension_name))
 
         with patch("ouroboros.telemetry.capture") as capture:
@@ -2717,6 +2717,53 @@ class TestMCPServerAdapterTools:
 
         assert result.is_ok
         capture.assert_called_once_with("service_active", {"service": "mcp"})
+
+    async def test_call_tool_non_prefixed_extension_failure_is_folded(self) -> None:
+        adapter = MCPServerAdapter()
+        handler = MockToolHandler("custom_tool")
+        handler.handle_mock.return_value = Result.err(MCPServerError("failed"))
+        adapter.register_tool(handler)
+
+        with patch("ouroboros.telemetry.capture") as capture:
+            result = await adapter.call_tool("custom_tool", {"input": "safe"})
+
+        assert result.is_err
+        assert capture.call_args_list[0].args == ("service_active", {"service": "mcp"})
+        assert capture.call_args_list[1].args == (
+            "command_run",
+            {
+                "command": "extension_tool",
+                "service": "mcp",
+                "status": "failed",
+                "error_type": "MCPServerError",
+            },
+        )
+
+    async def test_call_tool_non_prefixed_extension_logical_block_is_folded(self) -> None:
+        adapter = MCPServerAdapter()
+        handler = MockToolHandler("custom_tool")
+        handler.handle_mock.return_value = Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="input_required"),),
+                is_error=True,
+            )
+        )
+        adapter.register_tool(handler)
+
+        with patch("ouroboros.telemetry.capture") as capture:
+            result = await adapter.call_tool("custom_tool", {"input": "safe"})
+
+        assert result.is_ok
+        assert capture.call_args_list[0].args == ("service_active", {"service": "mcp"})
+        assert capture.call_args_list[1].args == (
+            "command_run",
+            {
+                "command": "extension_tool",
+                "service": "mcp",
+                "status": "blocked",
+                "error_type": None,
+            },
+        )
 
     async def test_call_tool_logical_error_response_counts_as_not_ok(self) -> None:
         """A built-in handler returning Result.ok(MCPToolResult(is_error=True))
@@ -3806,18 +3853,70 @@ class TestServeTransport:
             assert "private-project" not in str(value)
 
     async def test_sdk_call_tool_registered_extension_success_is_not_collected(self) -> None:
-        """SDK-path companion for dropped successful extension telemetry."""
+        """Successful non-product extension calls emit service activity only."""
         pytest.importorskip("mcp.server")
         from ouroboros.mcp.telemetry_boundary import call_sdk_tool
 
         adapter = MCPServerAdapter()
-        extension_name = "ouroboros_acme_private_project"
+        extension_name = "custom_tool"
         adapter.register_tool(MockToolHandler(extension_name))
 
         with patch("ouroboros.telemetry.capture") as capture:
             await call_sdk_tool(adapter, extension_name, {"input": "safe"})
 
         capture.assert_called_once_with("service_active", {"service": "mcp"})
+
+    async def test_sdk_non_prefixed_extension_failure_is_folded(self) -> None:
+        pytest.importorskip("mcp.server")
+        from ouroboros.mcp.telemetry_boundary import call_sdk_tool
+
+        adapter = MCPServerAdapter()
+        handler = MockToolHandler("custom_tool")
+        handler.handle_mock.return_value = Result.err(MCPServerError("failed"))
+        adapter.register_tool(handler)
+
+        with patch("ouroboros.telemetry.capture") as capture:
+            with pytest.raises(RuntimeError, match="failed"):
+                await call_sdk_tool(adapter, "custom_tool", {"input": "safe"})
+
+        assert capture.call_args_list[0].args == ("service_active", {"service": "mcp"})
+        assert capture.call_args_list[1].args == (
+            "command_run",
+            {
+                "command": "extension_tool",
+                "service": "mcp",
+                "status": "failed",
+                "error_type": "MCPServerError",
+            },
+        )
+
+    async def test_sdk_non_prefixed_extension_logical_block_is_folded(self) -> None:
+        pytest.importorskip("mcp.server")
+        from ouroboros.mcp.telemetry_boundary import call_sdk_tool
+
+        adapter = MCPServerAdapter()
+        handler = MockToolHandler("custom_tool")
+        handler.handle_mock.return_value = Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="input_required"),),
+                is_error=True,
+            )
+        )
+        adapter.register_tool(handler)
+
+        with patch("ouroboros.telemetry.capture") as capture:
+            await call_sdk_tool(adapter, "custom_tool", {"input": "safe"})
+
+        assert capture.call_args_list[0].args == ("service_active", {"service": "mcp"})
+        assert capture.call_args_list[1].args == (
+            "command_run",
+            {
+                "command": "extension_tool",
+                "service": "mcp",
+                "status": "blocked",
+                "error_type": None,
+            },
+        )
 
     async def test_sdk_call_tool_logical_error_response_counts_as_not_ok(self) -> None:
         """SDK-path companion to the typed-adapter logical-error test."""

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -2702,22 +2702,11 @@ class TestMCPServerAdapterTools:
         assert capture.call_args.args[0] == "ouroboros_registered_probe"
         assert capture.call_args.kwargs["ok"] is True
 
-    async def test_call_tool_registered_extension_tool_name_is_folded_to_canonical_literal(
-        self,
-    ) -> None:
-        """A genuinely registered but non-canonical (extension) tool name still
-        never reaches PostHog verbatim. Being registered in the adapter's
-        handler map is not the same as being one of the audited, shipped
-        ouroboros_* tools -- only telemetry.py's _CANONICAL_TOOL_NAMES set
-        earns a verbatim ``tool``/``command``; everything else (including a
-        real registered extension tool) folds to the audited
-        ``ouroboros_extension_tool`` literal so an identifying suffix like a
-        customer/project name never becomes a property value.
+    async def test_call_tool_registered_extension_success_is_not_collected(self) -> None:
+        """Successful non-product extension calls do not consume telemetry volume.
 
-        Unlike the boundary-only tests above, this patches the real sink
-        (``ouroboros.telemetry.capture``) rather than ``capture_tool_call``
-        itself, so the actual canonical-set gate inside capture_tool_call
-        runs and its output is what gets asserted on.
+        The real telemetry sink is patched so this proves the canonical folding
+        boundary drops successful non-lifecycle extension calls entirely.
         """
         adapter = MCPServerAdapter()
         extension_name = "ouroboros_acme_private_project"
@@ -2727,15 +2716,7 @@ class TestMCPServerAdapterTools:
             result = await adapter.call_tool(extension_name, {"input": "safe"})
 
         assert result.is_ok
-        capture.assert_called_once()
-        event, props = capture.call_args.args
-        assert event == "command_run"
-        assert props["tool"] == "ouroboros_extension_tool"
-        assert props["command"] == "extension_tool"
-        assert props["ok"] is True
-        for value in props.values():
-            assert "acme" not in str(value)
-            assert "private_project" not in str(value)
+        capture.assert_called_once_with("service_active", {"service": "mcp"})
 
     async def test_call_tool_logical_error_response_counts_as_not_ok(self) -> None:
         """A built-in handler returning Result.ok(MCPToolResult(is_error=True))
@@ -3824,13 +3805,8 @@ class TestServeTransport:
             assert "/home/alice" not in str(value)
             assert "private-project" not in str(value)
 
-    async def test_sdk_call_tool_registered_extension_tool_name_is_folded_to_canonical_literal(
-        self,
-    ) -> None:
-        """Same registered-but-non-canonical fold as the typed-adapter path,
-        through the SDK entry point. Patches the real ``ouroboros.telemetry.capture``
-        sink so the canonical-set gate inside capture_tool_call actually runs.
-        """
+    async def test_sdk_call_tool_registered_extension_success_is_not_collected(self) -> None:
+        """SDK-path companion for dropped successful extension telemetry."""
         pytest.importorskip("mcp.server")
         from ouroboros.mcp.telemetry_boundary import call_sdk_tool
 
@@ -3841,15 +3817,7 @@ class TestServeTransport:
         with patch("ouroboros.telemetry.capture") as capture:
             await call_sdk_tool(adapter, extension_name, {"input": "safe"})
 
-        capture.assert_called_once()
-        event, props = capture.call_args.args
-        assert event == "command_run"
-        assert props["tool"] == "ouroboros_extension_tool"
-        assert props["command"] == "extension_tool"
-        assert props["ok"] is True
-        for value in props.values():
-            assert "acme" not in str(value)
-            assert "private_project" not in str(value)
+        capture.assert_called_once_with("service_active", {"service": "mcp"})
 
     async def test_sdk_call_tool_logical_error_response_counts_as_not_ok(self) -> None:
         """SDK-path companion to the typed-adapter logical-error test."""

--- a/tests/unit/mcp/tools/test_evaluate_telemetry.py
+++ b/tests/unit/mcp/tools/test_evaluate_telemetry.py
@@ -115,11 +115,8 @@ class TestDirectEvaluateSingleACTelemetry:
         event, props = capture.call_args.args
         assert event == "workflow_outcome"
         assert props["command"] == "evaluate"
-        assert props["phase"] == "terminal"
         assert props["terminal_status"] == "completed"
-        assert props["ok"] is True
         assert props["verified"] is True
-        assert props["final_approved"] is True
 
     async def test_success_not_approved_emits_unverified(self) -> None:
         mock_pipeline = _install_pipeline_mock(Result.ok(_eval_result("s2", final_approved=False)))
@@ -145,9 +142,7 @@ class TestDirectEvaluateSingleACTelemetry:
         assert result.is_ok
         capture.assert_called_once()
         _, props = capture.call_args.args
-        assert props["ok"] is True
         assert props["verified"] is False
-        assert props["final_approved"] is False
 
     async def test_pipeline_failure_emits_failed_terminal_status(self) -> None:
         mock_pipeline = _install_pipeline_mock(Result.err(ValueError("semantic stage exploded")))
@@ -174,9 +169,7 @@ class TestDirectEvaluateSingleACTelemetry:
         capture.assert_called_once()
         _, props = capture.call_args.args
         assert props["terminal_status"] == "failed"
-        assert props["ok"] is False
         assert props["verified"] is False
-        assert props["final_approved"] is None
 
     async def test_config_error_before_pipeline_runs_emits_failed(self) -> None:
         """RuntimeError raised while wiring the adapter still counts as an attempt."""
@@ -204,8 +197,6 @@ class TestDirectEvaluateSingleACTelemetry:
         capture.assert_called_once()
         _, props = capture.call_args.args
         assert props["terminal_status"] == "failed"
-        assert props["ok"] is False
-        assert props["final_approved"] is None
         assert props["failure_reason_code"] == "config"
 
     async def test_generic_factory_runtime_error_is_not_config(self) -> None:
@@ -298,7 +289,6 @@ class TestDirectEvaluateMultiACTelemetry:
         _, props = capture.call_args.args
         assert props["terminal_status"] == "completed"
         assert props["verified"] is True
-        assert props["final_approved"] is True
 
     async def test_mixed_outcomes_emit_unverified(self) -> None:
         mock_pipeline = AsyncMock()
@@ -332,7 +322,6 @@ class TestDirectEvaluateMultiACTelemetry:
         capture.assert_called_once()
         _, props = capture.call_args.args
         assert props["verified"] is False
-        assert props["final_approved"] is False
 
     async def test_pipeline_error_mid_checklist_emits_failed(self) -> None:
         mock_pipeline = AsyncMock()
@@ -365,7 +354,6 @@ class TestDirectEvaluateMultiACTelemetry:
         capture.assert_called_once()
         _, props = capture.call_args.args
         assert props["terminal_status"] == "failed"
-        assert props["final_approved"] is None
 
 
 class TestDirectEvaluateArgumentValidationDoesNotEmit:
@@ -397,7 +385,6 @@ class TestRecordDirectEvaluationOutcome:
 
         _, props = capture.call_args.args
         assert props["verified"] is True
-        assert props["ok"] is True
         assert props["terminal_status"] == "completed"
 
     def test_not_verified_when_approved_but_failed(self) -> None:
@@ -407,7 +394,6 @@ class TestRecordDirectEvaluationOutcome:
 
         _, props = capture.call_args.args
         assert props["verified"] is False
-        assert props["ok"] is False
         assert props["terminal_status"] == "failed"
 
     def test_not_verified_when_not_approved(self) -> None:
@@ -416,14 +402,13 @@ class TestRecordDirectEvaluationOutcome:
 
         _, props = capture.call_args.args
         assert props["verified"] is False
-        assert props["final_approved"] is False
 
     def test_none_approval_is_preserved_not_coerced(self) -> None:
         with patch(_CAPTURE_TARGET) as capture:
             record_direct_evaluation_outcome(final_approved=None, failed=True)
 
         _, props = capture.call_args.args
-        assert props["final_approved"] is None
+        assert props["verified"] is False
 
     def test_never_raises_when_capture_explodes(self) -> None:
         with patch(_CAPTURE_TARGET, side_effect=RuntimeError("posthog down")):

--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -274,46 +274,8 @@ def test_installer_absent_config_retains_disclosed_default_on(tmp_path: Path) ->
     assert result.returncode == 0, result.stderr
     captures = _wait_for_telemetry(tmp_path)
     assert "capture-before-notice" not in captures
-    assert '"event":"install_started"' in captures
     assert '"event":"install_completed"' in captures
     assert result.stdout.count("Anonymous usage stats help improve Ouroboros") == 1
-
-
-@pytest.mark.parametrize(
-    ("install_ref", "expected_surface"),
-    (("readme", "readme_quickstart"), ("docs-getting-started", "getting_started")),
-)
-def test_installer_persists_first_command_surface_hint(
-    tmp_path: Path, install_ref: str, expected_surface: str
-) -> None:
-    result = _run_installer(
-        tmp_path,
-        local_repo=False,
-        env={"OUROBOROS_TELEMETRY": "", "OUROBOROS_INSTALL_REF": install_ref},
-        fake_commands=_telemetry_fake_commands(),
-    )
-
-    assert result.returncode == 0, result.stderr
-    hint = tmp_path / "home" / ".ouroboros" / "first_command_surface"
-    assert hint.read_text(encoding="utf-8") == f"{expected_surface}\n"
-
-
-def test_installer_does_not_relabel_existing_first_command_surface_hint(
-    tmp_path: Path,
-) -> None:
-    hint = tmp_path / "home" / ".ouroboros" / "first_command_surface"
-    hint.parent.mkdir(parents=True)
-    hint.write_text("readme_quickstart\n", encoding="utf-8")
-
-    result = _run_installer(
-        tmp_path,
-        local_repo=False,
-        env={"OUROBOROS_TELEMETRY": "", "OUROBOROS_INSTALL_REF": "docs-getting-started"},
-        fake_commands=_telemetry_fake_commands(),
-    )
-
-    assert result.returncode == 0, result.stderr
-    assert hint.read_text(encoding="utf-8") == "readme_quickstart\n"
 
 
 def test_piped_installer_does_not_require_bash_source(tmp_path: Path) -> None:
@@ -370,7 +332,6 @@ def test_installer_old_schema_without_telemetry_fails_closed(tmp_path: Path) -> 
     assert result.returncode == 0, result.stderr
     assert "AttributeError" not in result.stderr
     assert not (tmp_path / "telemetry.log").exists()
-
 
 def test_copied_installer_dangling_config_symlink_fails_closed(tmp_path: Path) -> None:
     config = tmp_path / "home" / ".ouroboros" / "config.yaml"
@@ -1030,7 +991,6 @@ def test_installer_notice_is_persisted_before_first_capture(tmp_path: Path) -> N
     assert result.returncode == 0, result.stderr
     captures = _wait_for_telemetry(tmp_path)
     assert "capture-before-notice" not in captures
-    assert '"event":"install_started"' in captures
     assert '"event":"install_completed"' in captures
     assert result.stdout.count("Anonymous usage stats help improve Ouroboros") == 1
     state = (tmp_path / "home" / ".ouroboros" / "telemetry.json").read_text(encoding="utf-8")
@@ -1470,7 +1430,6 @@ def test_installer_ping_escapes_hostile_uname_output_with_python3(tmp_path: Path
     assert "leaked" not in payload
     assert "leaked" not in payload.get("properties", {})
     assert payload["properties"]["os"] == "unknown"
-    assert payload["properties"]["arch"] == "unknown"
     assert payload["properties"]["is_local"] == "true"
 
 
@@ -1514,7 +1473,6 @@ def test_installer_ping_escapes_hostile_uname_output_without_python3(tmp_path: P
     assert "leaked" not in payload
     assert "leaked" not in payload.get("properties", {})
     assert payload["properties"]["os"] == "unknown"
-    assert payload["properties"]["arch"] == "unknown"
     assert payload["distinct_id"] == "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
 
 
@@ -1542,23 +1500,10 @@ def test_installer_ping_uses_exact_declared_property_structure(tmp_path: Path) -
         assert set(payload.keys()) == {"api_key", "event", "distinct_id", "properties"}
         events[payload["event"]] = payload
 
-    assert set(events) == {"install_started", "install_completed"}
-    assert set(events["install_started"]["properties"].keys()) == {
-        "source",
-        "os",
-        "arch",
-        "is_local",
-        "pre",
-        "version",
-        "ref",
-    }
+    assert set(events) == {"install_completed"}
     assert set(events["install_completed"]["properties"].keys()) == {
-        "source",
         "os",
-        "arch",
-        "method",
         "runtime",
-        "detected_runtimes",
         "version",
         "ref",
     }
@@ -1591,7 +1536,6 @@ def test_installer_ping_ref_defaults_to_direct_when_unset(tmp_path: Path) -> Non
         payload = json.loads(line)
         events[payload["event"]] = payload
 
-    assert events["install_started"]["properties"]["ref"] == "direct"
     assert events["install_completed"]["properties"]["ref"] == "direct"
 
 
@@ -1618,7 +1562,6 @@ def test_installer_ping_ref_carries_valid_channel_token(tmp_path: Path) -> None:
         payload = json.loads(line)
         events[payload["event"]] = payload
 
-    assert events["install_started"]["properties"]["ref"] == "hellogithub"
     assert events["install_completed"]["properties"]["ref"] == "hellogithub"
 
 
@@ -1648,7 +1591,6 @@ def test_installer_ping_ref_degrades_hostile_value_to_direct(tmp_path: Path) -> 
         payload = json.loads(line)
         events[payload["event"]] = payload
 
-    assert events["install_started"]["properties"]["ref"] == "direct"
     assert events["install_completed"]["properties"]["ref"] == "direct"
 
 

--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -1540,14 +1540,10 @@ def test_installer_ping_ref_defaults_to_direct_when_unset(tmp_path: Path) -> Non
     assert events["install_completed"]["properties"]["ref"] == "direct"
 
 
-def test_installer_ping_ref_carries_valid_channel_token(tmp_path: Path) -> None:
-    """A well-formed `OUROBOROS_INSTALL_REF` (matches `^[A-Za-z0-9._-]{1,32}$`)
-    is carried through to both events verbatim -- this is the actual
-    attribution path a docs page or listing is meant to use.
-    """
+def test_installer_ping_ref_carries_approved_channel_token(tmp_path: Path) -> None:
     result = _run_installer(
         tmp_path,
-        env={"OUROBOROS_TELEMETRY": "", "OUROBOROS_INSTALL_REF": "hellogithub"},
+        env={"OUROBOROS_TELEMETRY": "", "OUROBOROS_INSTALL_REF": "readme-hero"},
         fake_commands={
             **_telemetry_fake_commands(),
             "curl": _capture_dashd_curl(),
@@ -1563,17 +1559,28 @@ def test_installer_ping_ref_carries_valid_channel_token(tmp_path: Path) -> None:
         payload = json.loads(line)
         events[payload["event"]] = payload
 
-    assert events["install_completed"]["properties"]["ref"] == "hellogithub"
+    assert events["install_completed"]["properties"]["ref"] == "readme-hero"
+
+
+def test_installer_ping_ref_folds_valid_shaped_unknown_to_direct(tmp_path: Path) -> None:
+    result = _run_installer(
+        tmp_path,
+        env={"OUROBOROS_TELEMETRY": "", "OUROBOROS_INSTALL_REF": "private-project-2278"},
+        fake_commands={
+            **_telemetry_fake_commands(),
+            "curl": _capture_dashd_curl(),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    captures = _wait_for_telemetry(tmp_path)
+    payload = json.loads(next(line for line in captures.splitlines() if line))
+    assert payload["properties"]["ref"] == "direct"
+    assert "private-project-2278" not in captures
 
 
 def test_installer_ping_ref_degrades_hostile_value_to_direct(tmp_path: Path) -> None:
-    """A value outside `^[A-Za-z0-9._-]{1,32}$` (shell metacharacters, spaces,
-    or over-length) must never reach the telemetry payload -- it degrades to
-    `direct` exactly like an unset value. `[[ =~ ]]` never executes its
-    operand, so this is a payload-shape guarantee, not a shell-injection
-    probe; the point is that a hostile value chosen by whoever writes the
-    install command cannot ride into what we record.
-    """
+    """Invalid shell-shaped values also fold to the closed `direct` token."""
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_TELEMETRY": "", "OUROBOROS_INSTALL_REF": "evil; rm -rf /"},

--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -333,6 +333,7 @@ def test_installer_old_schema_without_telemetry_fails_closed(tmp_path: Path) -> 
     assert "AttributeError" not in result.stderr
     assert not (tmp_path / "telemetry.log").exists()
 
+
 def test_copied_installer_dangling_config_symlink_fails_closed(tmp_path: Path) -> None:
     config = tmp_path / "home" / ".ouroboros" / "config.yaml"
     config.parent.mkdir(parents=True)

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -573,13 +573,18 @@ class TestIdentityFailClosed:
 
 
 class TestCapture:
-    def test_lifecycle_command_shape(self, sent: list[dict[str, Any]]) -> None:
+    def test_lifecycle_command_shape(
+        self, monkeypatch: pytest.MonkeyPatch, sent: list[dict[str, Any]]
+    ) -> None:
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
         telemetry.set_context(runtime_backend="codex")
         telemetry.capture_tool_call("ouroboros_start_execute_seed", ok=True)
         telemetry.flush(timeout=2.0)
 
-        assert len(sent) == 1
-        event = sent[0]
+        assert len(sent) == 2
+        service_event, event = sent
+        assert service_event["event"] == "service_active"
         assert event["event"] == "command_run"
         assert event["distinct_id"] == telemetry.distinct_id()
         assert event["properties"] == {
@@ -590,7 +595,6 @@ class TestCapture:
             "runtime_backend": "codex",
             "app_version": telemetry.__version__,
             "os": platform.system().lower(),
-            "ci": True,
         }
 
     def test_failed_internal_command_is_retained(self, sent: list[dict[str, Any]]) -> None:
@@ -599,7 +603,7 @@ class TestCapture:
         )
         telemetry.flush(timeout=2.0)
 
-        props = sent[0]["properties"]
+        props = next(event["properties"] for event in sent if event["event"] == "command_run")
         assert props["command"] == "checklist_verify"
         assert props["status"] == "failed"
         assert props["error_type"] == "MCPToolError"
@@ -610,9 +614,10 @@ class TestCapture:
         telemetry.capture_tool_call("ouroboros_generate_seed", ok=False, blocked=True)
         telemetry.flush(timeout=2.0)
 
-        assert sent[0]["properties"]["command"] == "seed"
-        assert sent[0]["properties"]["status"] == "blocked"
-        assert "error_type" not in sent[0]["properties"]
+        command = next(event for event in sent if event["event"] == "command_run")
+        assert command["properties"]["command"] == "seed"
+        assert command["properties"]["status"] == "blocked"
+        assert "error_type" not in command["properties"]
 
     def test_successful_internal_and_polling_commands_are_dropped(
         self, sent: list[dict[str, Any]]
@@ -621,7 +626,7 @@ class TestCapture:
         telemetry.capture_tool_call("ouroboros_job_status", ok=True)
         telemetry.capture_tool_call("some_other_tool", ok=True)
         telemetry.flush(timeout=2.0)
-        assert sent == []
+        assert [event["event"] for event in sent] == ["service_active"]
 
     def test_subagent_dispatch_is_not_collected(self, sent: list[dict[str, Any]]) -> None:
         telemetry.capture_subagent_dispatch({"phase": "emitted", "payload_count": 5})
@@ -634,9 +639,10 @@ class TestCapture:
         telemetry.capture_tool_call("ouroboros_interview", ok=False, error_type="TimeoutError")
         telemetry.flush(timeout=2.0)
 
-        assert len(sent) == 3
-        assert sent[0]["properties"]["$insert_id"] == sent[1]["properties"]["$insert_id"]
-        assert sent[0]["properties"]["$insert_id"] != sent[2]["properties"]["$insert_id"]
+        commands = [event for event in sent if event["event"] == "command_run"]
+        assert len(commands) == 3
+        assert commands[0]["properties"]["$insert_id"] == commands[1]["properties"]["$insert_id"]
+        assert commands[0]["properties"]["$insert_id"] != commands[2]["properties"]["$insert_id"]
 
     def test_durable_job_outcome_keeps_only_terminal_fields(
         self, sent: list[dict[str, Any]]
@@ -784,8 +790,7 @@ class TestExactPropertySets:
         telemetry.set_context(runtime_backend="claude", execute_runtime_backend="ignored")
         telemetry.capture_tool_call("ouroboros_evaluate", ok=False, error_type="TimeoutError")
         telemetry.flush(timeout=2.0)
-
-        props = sent[0]["properties"]
+        props = next(event["properties"] for event in sent if event["event"] == "command_run")
         assert set(props) == {
             "command",
             "service",

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-import random
+import platform
 import re
 import socket
 import subprocess
@@ -262,7 +262,7 @@ class TestDistinctIdValidation:
             encoding="utf-8",
         )
 
-        telemetry.capture("mcp_serve_started", {"transport": "stdio", "tool_count": 1})
+        telemetry.capture("service_active", {"service": "mcp"})
         telemetry.flush(timeout=2.0)
 
         assert len(sent) == 1
@@ -294,7 +294,7 @@ class TestDistinctIdValidation:
             encoding="utf-8",
         )
 
-        telemetry.capture("mcp_serve_started", {"transport": "stdio", "tool_count": 1})
+        telemetry.capture("service_active", {"service": "mcp"})
         telemetry.flush(timeout=2.0)
 
         assert len(sent) == 1
@@ -491,7 +491,7 @@ class TestIdentityFailClosed:
         )
         os.chmod(state_dir, 0o500)
         try:
-            telemetry.capture("mcp_serve_started", {"transport": "stdio", "tool_count": 1})
+            telemetry.capture("service_active", {"service": "mcp"})
             telemetry.flush(timeout=2.0)
         finally:
             os.chmod(state_dir, 0o700)
@@ -515,7 +515,7 @@ class TestIdentityFailClosed:
         )
         os.chmod(state_dir, 0o500)
         try:
-            telemetry.capture("mcp_serve_started", {"transport": "stdio", "tool_count": 1})
+            telemetry.capture("service_active", {"service": "mcp"})
             telemetry.flush(timeout=2.0)
         finally:
             os.chmod(state_dir, 0o700)
@@ -533,7 +533,7 @@ class TestIdentityFailClosed:
         state_dir.mkdir(parents=True)
         os.chmod(state_dir, 0o500)
         try:
-            telemetry.capture("mcp_serve_started", {"transport": "stdio", "tool_count": 1})
+            telemetry.capture("service_active", {"service": "mcp"})
             telemetry.flush(timeout=2.0)
             result = telemetry.distinct_id()
         finally:
@@ -555,14 +555,14 @@ class TestIdentityFailClosed:
         )
         os.chmod(state_dir, 0o500)
         try:
-            telemetry.capture("mcp_serve_started", {"transport": "stdio", "tool_count": 1})
+            telemetry.capture("service_active", {"service": "mcp"})
             telemetry.flush(timeout=2.0)
             assert sent == []
             assert telemetry.distinct_id() == ""
         finally:
             os.chmod(state_dir, 0o700)
 
-        telemetry.capture("mcp_serve_started", {"transport": "stdio", "tool_count": 2})
+        telemetry.capture("service_active", {"service": "mcp"})
         telemetry.flush(timeout=2.0)
 
         assert len(sent) == 1
@@ -573,393 +573,112 @@ class TestIdentityFailClosed:
 
 
 class TestCapture:
-    def test_event_shape(self, sent: list[dict[str, Any]]) -> None:
+    def test_lifecycle_command_shape(self, sent: list[dict[str, Any]]) -> None:
         telemetry.set_context(runtime_backend="codex")
-        telemetry.capture_tool_call("ouroboros_start_execute_seed", ok=True, duration_ms=12.34)
+        telemetry.capture_tool_call("ouroboros_start_execute_seed", ok=True)
         telemetry.flush(timeout=2.0)
+
         assert len(sent) == 1
         event = sent[0]
         assert event["event"] == "command_run"
         assert event["distinct_id"] == telemetry.distinct_id()
-        props = event["properties"]
-        assert props["command"] == "run"
-        assert props["tool"] == "ouroboros_start_execute_seed"
-        assert props["source"] == "mcp"
-        assert props["is_funnel"] is True
-        assert props["phase"] == "submission"
-        assert props["accepted"] is True
-        assert "ok" not in props
-        assert props["duration_ms"] == 12.3
-        assert props["runtime_backend"] == "codex"
-        assert props["app_version"]
-        assert props["os"]
+        assert event["properties"] == {
+            "command": "run",
+            "service": "mcp",
+            "status": "accepted",
+            "$insert_id": event["properties"]["$insert_id"],
+            "runtime_backend": "codex",
+            "app_version": telemetry.__version__,
+            "os": platform.system().lower(),
+            "ci": True,
+        }
 
-    def test_unmapped_tool_still_captured(self, sent: list[dict[str, Any]]) -> None:
+    def test_failed_internal_command_is_retained(self, sent: list[dict[str, Any]]) -> None:
         telemetry.capture_tool_call(
             "ouroboros_checklist_verify", ok=False, error_type="MCPToolError"
         )
         telemetry.flush(timeout=2.0)
-        assert sent[0]["properties"]["command"] == "checklist_verify"
-        assert sent[0]["properties"]["is_funnel"] is False
-        assert sent[0]["properties"]["error_type"] == "MCPToolError"
-        assert sent[0]["properties"]["phase"] == "completion"
-        assert sent[0]["properties"]["ok"] is False
-
-    def test_subagent_dispatch_event_keeps_only_closed_values(
-        self, sent: list[dict[str, Any]]
-    ) -> None:
-        telemetry.capture_subagent_dispatch(
-            {
-                "phase": "emitted",
-                "fanout_kind": "lateral_persona_panel",
-                "payload_count": 5,
-                "invocation_surface": "mcp_host",
-                "dispatch_authority": "mcp_host",
-                "host_family": "claude_code",
-                "host_identity_status": "known",
-                "host_capability": "undeclared",
-                "capability_source": "none",
-                "delivery_mode": "inline_host",
-                "execution_preference": "parallel",
-                "fallback_strategy": "sequential",
-                "configured_worker_backend": "gemini",
-                "host_worker_mismatch": True,
-                "decision_reason": "host_capability_undeclared",
-                "contract_version": "v2",
-                "fanout_reentry_available": True,
-                "fanout_id": "fanout_private",
-                "prompt": "/private/repo/secret",
-            }
-        )
-        telemetry.flush(timeout=2.0)
-
-        assert len(sent) == 1
-        event = sent[0]
-        assert event["event"] == "subagent_dispatch"
-        props = event["properties"]
-        assert props["host_family"] == "claude_code"
-        assert props["configured_worker_backend"] == "gemini"
-        assert props["host_worker_mismatch"] is True
-        assert "fanout_id" not in props
-        assert "prompt" not in props
-        assert "private" not in str(props)
-
-    def test_subagent_dispatch_folds_custom_backend_and_rejects_open_enums(
-        self, sent: list[dict[str, Any]]
-    ) -> None:
-        telemetry.capture_subagent_dispatch(
-            {
-                "phase": "emitted",
-                "fanout_kind": "private_customer_fanout",
-                "host_family": "private-client-name",
-                "configured_worker_backend": "private-backend",
-            }
-        )
-        telemetry.flush(timeout=2.0)
 
         props = sent[0]["properties"]
-        assert props["configured_worker_backend"] == "other"
-        assert "fanout_kind" not in props
-        assert "host_family" not in props
+        assert props["command"] == "checklist_verify"
+        assert props["status"] == "failed"
+        assert props["error_type"] == "MCPToolError"
 
-    def test_non_ouroboros_tool_skipped(self, sent: list[dict[str, Any]]) -> None:
+    def test_blocked_seed_is_distinct_from_exception_failure(
+        self, sent: list[dict[str, Any]]
+    ) -> None:
+        telemetry.capture_tool_call("ouroboros_generate_seed", ok=False, blocked=True)
+        telemetry.flush(timeout=2.0)
+
+        assert sent[0]["properties"]["command"] == "seed"
+        assert sent[0]["properties"]["status"] == "blocked"
+        assert "error_type" not in sent[0]["properties"]
+
+    def test_successful_internal_and_polling_commands_are_dropped(
+        self, sent: list[dict[str, Any]]
+    ) -> None:
+        telemetry.capture_tool_call("ouroboros_fetch_artifact", ok=True)
+        telemetry.capture_tool_call("ouroboros_job_status", ok=True)
         telemetry.capture_tool_call("some_other_tool", ok=True)
         telemetry.flush(timeout=2.0)
         assert sent == []
 
-    def test_hostile_tool_name_is_replaced_not_forwarded(self, sent: list[dict[str, Any]]) -> None:
-        """A caller-controlled name that merely starts with "ouroboros_" is
-        not automatically a real registered tool -- e.g. a path smuggled
-        past a boundary bug upstream. capture_tool_call must never let it
-        become the `tool`/`command` property value."""
-        hostile = "ouroboros_/home/alice/private-project"
-        telemetry.capture_tool_call(hostile, ok=False, error_type="KeyError")
+    def test_subagent_dispatch_is_not_collected(self, sent: list[dict[str, Any]]) -> None:
+        telemetry.capture_subagent_dispatch({"phase": "emitted", "payload_count": 5})
         telemetry.flush(timeout=2.0)
+        assert sent == []
 
-        assert len(sent) == 1
-        event = sent[0]
-        assert event["properties"]["tool"] == "ouroboros_unknown_tool"
-        assert event["properties"]["command"] == "unknown_tool"
-        # Assert on the full serialized event, not just the two fields
-        # above -- proves the hostile string can't leak through any other
-        # property (e.g. error_type) either.
-        assert "alice" not in repr(event)
-        assert "private-project" not in repr(event)
-        assert hostile not in repr(event)
-
-    def test_hostile_tool_name_variants_are_all_replaced(self, sent: list[dict[str, Any]]) -> None:
-        """Uppercase, dots, and other non-snake-case punctuation are just as
-        invalid as a path -- the charset gate is exact, not a blocklist of
-        specific dangerous characters."""
-        for hostile in ("ouroboros_Evil.Tool", "ouroboros_evil tool", "ouroboros_EVIL_TOOL!"):
-            telemetry.capture_tool_call(hostile, ok=True)
+    def test_daily_insert_id_is_stable_for_same_dimension(self, sent: list[dict[str, Any]]) -> None:
+        telemetry.capture_tool_call("ouroboros_interview", ok=True)
+        telemetry.capture_tool_call("ouroboros_interview", ok=True)
+        telemetry.capture_tool_call("ouroboros_interview", ok=False, error_type="TimeoutError")
         telemetry.flush(timeout=2.0)
 
         assert len(sent) == 3
-        for event in sent:
-            assert event["properties"]["tool"] == "ouroboros_unknown_tool"
-            assert event["properties"]["command"] == "unknown_tool"
+        assert sent[0]["properties"]["$insert_id"] == sent[1]["properties"]["$insert_id"]
+        assert sent[0]["properties"]["$insert_id"] != sent[2]["properties"]["$insert_id"]
 
-    def test_canonical_tool_name_passes_through_unchanged(self, sent: list[dict[str, Any]]) -> None:
-        """The backstop must not false-positive on real tool names -- a
-        canonical, registered name still gets its funnel mapping."""
-        telemetry.capture_tool_call("ouroboros_interview", ok=True)
-        telemetry.flush(timeout=2.0)
-
-        assert len(sent) == 1
-        assert sent[0]["properties"]["tool"] == "ouroboros_interview"
-        assert sent[0]["properties"]["command"] == "interview"
-        assert sent[0]["properties"]["is_funnel"] is True
-
-    def test_overlong_tool_name_is_replaced(self, sent: list[dict[str, Any]]) -> None:
-        """A name that is otherwise charset-valid but exceeds the length
-        bound (no real tool name is anywhere close to 64 chars) is still
-        not a real tool -- must not pass through as free text."""
-        overlong = "ouroboros_" + ("a" * 65)
-        telemetry.capture_tool_call(overlong, ok=True)
-        telemetry.flush(timeout=2.0)
-
-        assert len(sent) == 1
-        assert sent[0]["properties"]["tool"] == "ouroboros_unknown_tool"
-        assert sent[0]["properties"]["command"] == "unknown_tool"
-        assert overlong not in repr(sent[0])
-
-    def test_registered_extension_tool_name_is_replaced_not_forwarded(
+    def test_durable_job_outcome_keeps_only_terminal_fields(
         self, sent: list[dict[str, Any]]
     ) -> None:
-        """A name that is charset-valid AND shaped exactly like a real tool
-        -- but isn't one this project actually ships -- is a REGISTERED
-        extension/custom tool (register_tool() accepts arbitrary names), not
-        a lookup failure. It must still never carry an identifying name
-        through `tool`/`command`."""
-        hostile = "ouroboros_acme_private_project"
-        telemetry.capture_tool_call(hostile, ok=True)
-        telemetry.flush(timeout=2.0)
-
-        assert len(sent) == 1
-        event = sent[0]
-        assert event["properties"]["tool"] == "ouroboros_extension_tool"
-        assert event["properties"]["command"] == "extension_tool"
-        assert "acme" not in repr(event)
-        assert "private_project" not in repr(event)
-        assert hostile not in repr(event)
-
-    def test_unknown_and_extension_literals_stay_distinct(self, sent: list[dict[str, Any]]) -> None:
-        """ouroboros_unknown_tool (charset-invalid -- a lookup failure) and
-        ouroboros_extension_tool (charset-valid but not audited -- a real
-        registered non-Ouroboros tool) must not collapse into each other:
-        the literal ouroboros_unknown_tool itself is charset-valid and not
-        in the canonical set, so the extension-tool check must special-case
-        it rather than re-mapping it a second time."""
-        telemetry.capture_tool_call(telemetry._UNKNOWN_TOOL_NAME, ok=True)
-        telemetry.flush(timeout=2.0)
-
-        assert len(sent) == 1
-        assert sent[0]["properties"]["tool"] == "ouroboros_unknown_tool"
-        assert sent[0]["properties"]["command"] == "unknown_tool"
-
-    def test_canonical_tool_names_are_subsets_of_the_audited_set(self) -> None:
-        """The funnel/polling/submission maps must never name a tool that
-        isn't in the audited canonical set -- if they drift apart, a real
-        tool could silently start getting extension-tool-mangled, or a
-        typo'd/renamed entry in one of the smaller sets would go unnoticed."""
-        assert set(telemetry._TOOL_FUNNEL) <= telemetry._CANONICAL_TOOL_NAMES
-        assert telemetry._POLLING_TOOLS <= telemetry._CANONICAL_TOOL_NAMES
-        assert telemetry._ASYNC_SUBMISSION_TOOLS <= telemetry._CANONICAL_TOOL_NAMES
-
-    def test_polling_tools_sampled(self, sent: list[dict[str, Any]]) -> None:
-        # Sampling is a per-call random draw (see telemetry._poll_rng), not a
-        # deterministic 1-in-50 counter, so the batch needs a seed that is
-        # known (precomputed offline) to produce exactly one hit in 50 draws.
-        telemetry._poll_rng.seed(1)
-        for _ in range(telemetry._POLL_SAMPLE_RATE):
-            telemetry.capture_tool_call("ouroboros_job_status", ok=True)
-        telemetry.flush(timeout=2.0)
-        assert len(sent) == 1
-        assert sent[0]["properties"]["sample_rate"] == telemetry._POLL_SAMPLE_RATE
-
-    @pytest.mark.parametrize(
-        "tool",
-        ("ouroboros_lineage_status", "ouroboros_project_status"),
-    )
-    def test_all_public_status_tools_are_sampled(
-        self,
-        sent: list[dict[str, Any]],
-        tool: str,
-    ) -> None:
-        telemetry._poll_rng.seed(1)  # see test_polling_tools_sampled
-        for _ in range(telemetry._POLL_SAMPLE_RATE):
-            telemetry.capture_tool_call(tool, ok=True)
-        telemetry.flush(timeout=2.0)
-        assert len(sent) == 1
-        assert sent[0]["properties"]["sample_rate"] == telemetry._POLL_SAMPLE_RATE
-
-    @pytest.mark.parametrize(
-        ("job_type", "terminal_status", "meta", "verified", "reported_approval"),
-        (
-            ("evaluate", "completed", {"final_approved": True}, True, True),
-            ("evaluate", "failed", {"final_approved": True}, False, True),
-            ("evaluate", "cancelled", {"final_approved": True}, False, True),
-            ("evaluate", "interrupted", {"final_approved": True}, False, True),
-            ("execute_seed", "completed", {"final_approved": True}, False, True),
-            ("evaluate", "completed", {}, False, None),
-            ("evaluate", "completed", {"final_approved": False}, False, False),
-            ("evaluate", "completed", {"final_approved": "true"}, False, None),
-        ),
-    )
-    def test_durable_job_outcome_distinguishes_verified_success(
-        self,
-        sent: list[dict[str, Any]],
-        job_type: str,
-        terminal_status: str,
-        meta: dict[str, Any],
-        verified: bool,
-        reported_approval: bool | None,
-    ) -> None:
+        telemetry.set_context(runtime_backend="codex")
         telemetry.capture_job_outcome(
             "job_private_id",
-            job_type,
-            terminal_status=terminal_status,
-            result_meta=meta,
-        )
-        telemetry.flush(timeout=2.0)
-        event = sent[0]
-        assert event["event"] == "workflow_outcome"
-        assert event["properties"]["phase"] == "terminal"
-        assert event["properties"]["verified"] is verified
-        assert event["properties"].get("final_approved") is reported_approval
-        assert "job_private_id" not in json.dumps(event)
-
-    def test_extension_job_type_is_replaced_not_forwarded(self, sent: list[dict[str, Any]]) -> None:
-        """job_type is caller-controlled the same way an MCP tool name is:
-        JobManager.start_job() accepts an arbitrary string, so an unaudited
-        job type must never carry an identifying name through `command`."""
-        hostile = "acme_private_project"
-        telemetry.capture_job_outcome(
-            "job-1", hostile, terminal_status="completed", result_meta={"final_approved": True}
-        )
-        telemetry.flush(timeout=2.0)
-
-        assert len(sent) == 1
-        event = sent[0]
-        assert event["properties"]["command"] == "extension_job"
-        assert hostile not in repr(event)
-
-    def test_extension_job_type_never_earns_verified(self, sent: list[dict[str, Any]]) -> None:
-        """An extension job must not earn verified=true just because it
-        isn't literally "evaluate" -- `verified` compares the RAW job_type,
-        never the folded `command`, and folding must not change that."""
-        telemetry.capture_job_outcome(
-            "job-1",
-            "acme_private_project",
+            "evaluate",
             terminal_status="completed",
             result_meta={"final_approved": True},
         )
         telemetry.flush(timeout=2.0)
 
-        assert sent[0]["properties"]["verified"] is False
-        assert sent[0]["properties"]["command"] == "extension_job"
-
-    @pytest.mark.parametrize(
-        ("terminal_status", "meta", "reason", "action"),
-        (
-            ("cancelled", {}, "cancelled", "retry"),
-            ("interrupted", {"interrupted_from_shutdown": True}, "cancelled", "retry"),
-            ("failed", {"failed_from_progress_accounting_stall": True}, "timeout", "retry"),
-            ("failed", {"failure_reason_code": "config"}, "config", "setup"),
-            ("failed", {"failure_reason_code": "auth"}, "auth", "login"),
-            ("failed", {"failure_reason_code": "validation"}, "validation", "inspect_logs"),
-            ("failed", {}, "unknown", "inspect_logs"),
-        ),
-    )
-    def test_failed_outcome_emits_closed_reason_and_action(
-        self,
-        sent: list[dict[str, Any]],
-        terminal_status: str,
-        meta: dict[str, Any],
-        reason: str,
-        action: str,
-    ) -> None:
-        telemetry.capture_job_outcome(
-            "job-private-id",
-            "execute_seed",
-            terminal_status=terminal_status,
-            result_meta=meta,
-        )
-        telemetry.flush(timeout=2.0)
-
         props = sent[0]["properties"]
-        assert props["failure_reason_code"] == reason
-        assert props["recovery_action"] == action
-        assert "job-private-id" not in json.dumps(sent[0])
+        assert props["command"] == "evaluate"
+        assert props["terminal_status"] == "completed"
+        assert props["verified"] is True
+        assert props["runtime_backend"] == "codex"
+        assert "job_private_id" not in json.dumps(sent[0])
 
-    def test_failed_outcome_does_not_forward_raw_error_or_unknown_metadata(
-        self, sent: list[dict[str, Any]]
-    ) -> None:
+    def test_failed_outcome_keeps_closed_reason(self, sent: list[dict[str, Any]]) -> None:
         telemetry.capture_job_outcome(
             "job-private-id",
             "execute_seed",
             terminal_status="failed",
             result_meta={
-                "error": "secret prompt /Users/private/project",
-                "failure_reason_code": "not-a-real-code",
+                "failure_reason_code": "validation",
+                "error": "secret /Users/private/project",
             },
         )
         telemetry.flush(timeout=2.0)
 
         props = sent[0]["properties"]
-        assert props["failure_reason_code"] == "unknown"
-        assert props["recovery_action"] == "inspect_logs"
-        assert "secret prompt" not in json.dumps(sent[0])
-        assert "/Users/private/project" not in json.dumps(sent[0])
-
-    @pytest.mark.parametrize(
-        ("job_type", "expected_command"),
-        (
-            ("execute_seed", "run"),
-            ("evolve_step", "evolve"),
-            ("auto", "auto"),
-            ("evaluate", "evaluate"),
-            ("ralph", "ralph"),
-        ),
-    )
-    def test_shipped_job_types_keep_their_funnel_commands(
-        self,
-        sent: list[dict[str, Any]],
-        job_type: str,
-        expected_command: str,
-    ) -> None:
-        telemetry.capture_job_outcome("job-1", job_type, terminal_status="completed")
-        telemetry.flush(timeout=2.0)
-        assert sent[0]["properties"]["command"] == expected_command
-
-    @pytest.mark.parametrize("job_type", ("detached_probe", "detached_nested_probe"))
-    def test_internal_shipped_job_types_pass_through_unfolded(
-        self,
-        sent: list[dict[str, Any]],
-        job_type: str,
-    ) -> None:
-        """detached_worker.py's process-lifetime probes are shipped and
-        non-identifying -- audited into the canonical set so they aren't
-        mislabeled as a foreign extension_job."""
-        telemetry.capture_job_outcome("job-1", job_type, terminal_status="completed")
-        telemetry.flush(timeout=2.0)
-        assert sent[0]["properties"]["command"] == job_type
-
-    def test_job_funnel_keys_are_subset_of_canonical_job_types(self) -> None:
-        assert set(telemetry._JOB_FUNNEL) <= telemetry._CANONICAL_JOB_TYPES
-
-    def test_funnel_mapping_covers_all_stages(self) -> None:
-        commands = set(telemetry._TOOL_FUNNEL.values())
-        assert {"interview", "seed", "run", "evolve", "auto", "evaluate", "qa"} <= commands
+        assert props["command"] == "run"
+        assert props["terminal_status"] == "failed"
+        assert props["failure_reason_code"] == "validation"
+        assert "secret" not in json.dumps(sent[0])
 
     def test_never_raises_when_post_fails(
         self, monkeypatch: pytest.MonkeyPatch, sent: list[dict[str, Any]]
     ) -> None:
-        def boom(batch: list[dict[str, Any]]) -> None:
-            raise OSError("network down")
-
-        monkeypatch.setattr(telemetry, "_post", boom)
+        monkeypatch.setattr(telemetry, "_post", lambda _batch: (_ for _ in ()).throw(OSError()))
         telemetry.capture_tool_call("ouroboros_interview", ok=True)
         telemetry.flush(timeout=2.0)
 
@@ -1058,183 +777,78 @@ def test_genuine_process_ci_still_stamps_ci_true(
 
 
 class TestExactPropertySets:
-    """Regression: the declared TELEMETRY.md table and the executable
-    per-variant allowlist must match key-for-key, not just "subset of a
-    generic base+context union". A prior round's union-based allowlist over-
-    granted every event every base+context key regardless of what that
-    event's row in TELEMETRY.md actually declared (e.g. mcp_serve_started
-    picked up python_version and all 4 backend fields; the two command_run
-    variants were indistinguishable).
-    """
-
-    def test_command_run_mcp_completion_exact_keys(
+    def test_command_run_mcp_exact_keys(
         self, monkeypatch: pytest.MonkeyPatch, sent: list[dict[str, Any]]
     ) -> None:
         _no_ambient_frontdoor_or_ci(monkeypatch)
-        telemetry.set_context(
-            runtime_backend="claude",
-            execute_runtime_backend="claude",
-            interview_llm_backend="anthropic",
-            evaluate_llm_backend="anthropic",
-        )
-        telemetry.capture_tool_call(
-            "ouroboros_evaluate", ok=True, duration_ms=12.3, error_type="TimeoutError"
-        )
+        telemetry.set_context(runtime_backend="claude", execute_runtime_backend="ignored")
+        telemetry.capture_tool_call("ouroboros_evaluate", ok=False, error_type="TimeoutError")
         telemetry.flush(timeout=2.0)
-        assert len(sent) == 1
-        props = sent[0]["properties"]
-        keys = set(props)
 
-        assert keys <= telemetry._COMMAND_RUN_MCP_KEYS
-        assert keys == {
+        props = sent[0]["properties"]
+        assert set(props) == {
             "command",
-            "tool",
-            "source",
-            "is_funnel",
-            "phase",
-            "ok",
-            "duration_ms",
+            "service",
+            "status",
             "error_type",
+            "$insert_id",
             "runtime_backend",
-            "execute_runtime_backend",
-            "interview_llm_backend",
-            "evaluate_llm_backend",
-            "first_command_surface",
             "app_version",
             "os",
-            "python_version",
         }
-        assert "accepted" not in props
-        assert "sample_rate" not in props
 
-    def test_command_run_mcp_submission_exact_keys(
+    def test_command_run_cli_exact_keys(
         self, monkeypatch: pytest.MonkeyPatch, sent: list[dict[str, Any]]
     ) -> None:
         _no_ambient_frontdoor_or_ci(monkeypatch)
-        telemetry.capture_tool_call("ouroboros_start_execute_seed", ok=True)
-        telemetry.flush(timeout=2.0)
-        assert len(sent) == 1
-        props = sent[0]["properties"]
-        keys = set(props)
-
-        assert keys <= telemetry._COMMAND_RUN_MCP_KEYS
-        assert keys == {
-            "command",
-            "tool",
-            "source",
-            "is_funnel",
-            "phase",
-            "accepted",
-            "first_command_surface",
-            "app_version",
-            "os",
-            "python_version",
-        }
-        assert "ok" not in props  # submission receipts have accepted, never ok
-        assert props["accepted"] is True
-        assert props["phase"] == "submission"
-
-    def test_command_run_cli_exact_keys_even_with_context_set(
-        self, monkeypatch: pytest.MonkeyPatch, sent: list[dict[str, Any]]
-    ) -> None:
-        _no_ambient_frontdoor_or_ci(monkeypatch)
-        # Global context carries backend keys regardless of source -- the cli
-        # variant must strip them even though they're genuinely set, proving
-        # this is per-variant enforcement and not just "nobody happened to
-        # set context in this test".
-        telemetry.set_context(
-            runtime_backend="claude",
-            execute_runtime_backend="claude",
-            interview_llm_backend="anthropic",
-            evaluate_llm_backend="anthropic",
-        )
+        telemetry.set_context(runtime_backend="claude")
         telemetry.capture_cli_command("run")
         telemetry.flush(timeout=2.0)
-        assert len(sent) == 1
-        props = sent[0]["properties"]
-        keys = set(props)
 
-        assert keys <= telemetry._COMMAND_RUN_CLI_KEYS
-        assert keys == {"command", "source", "is_funnel", "app_version", "os", "python_version"}
-        for undeclared in (
-            "tool",
-            "phase",
-            "ok",
-            "accepted",
-            "duration_ms",
-            "error_type",
-            "sample_rate",
-            "runtime_backend",
-            "execute_runtime_backend",
-            "interview_llm_backend",
-            "evaluate_llm_backend",
-        ):
-            assert undeclared not in props, f"cli command_run leaked {undeclared!r}"
+        assert set(sent[0]["properties"]) == {
+            "command",
+            "service",
+            "status",
+            "$insert_id",
+            "app_version",
+            "os",
+        }
 
     def test_workflow_outcome_exact_keys(
         self, monkeypatch: pytest.MonkeyPatch, sent: list[dict[str, Any]]
     ) -> None:
         _no_ambient_frontdoor_or_ci(monkeypatch)
-        telemetry.set_context(
-            runtime_backend="claude",
-            execute_runtime_backend="claude",
-            interview_llm_backend="anthropic",
-            evaluate_llm_backend="anthropic",
-        )
+        telemetry.set_context(runtime_backend="claude")
         telemetry.capture_job_outcome(
             "job-x", "evaluate", terminal_status="completed", result_meta={"final_approved": True}
         )
         telemetry.flush(timeout=2.0)
-        assert len(sent) == 1
-        props = sent[0]["properties"]
-        keys = set(props)
 
-        assert keys <= telemetry._WORKFLOW_OUTCOME_KEYS
-        assert keys == {
+        assert set(sent[0]["properties"]) == {
             "command",
-            "phase",
             "terminal_status",
-            "ok",
             "verified",
-            "final_approved",
             "$insert_id",
             "runtime_backend",
-            "execute_runtime_backend",
-            "interview_llm_backend",
-            "evaluate_llm_backend",
             "app_version",
             "os",
-            "python_version",
         }
 
-    def test_mcp_serve_started_exact_keys_excludes_python_version_and_backends(
+    def test_service_active_exact_keys(
         self, monkeypatch: pytest.MonkeyPatch, sent: list[dict[str, Any]]
     ) -> None:
         _no_ambient_frontdoor_or_ci(monkeypatch)
-        # Set context anyway -- mcp_serve_started must drop it regardless.
-        telemetry.set_context(
-            runtime_backend="claude",
-            execute_runtime_backend="claude",
-            interview_llm_backend="anthropic",
-            evaluate_llm_backend="anthropic",
-        )
-        telemetry.capture("mcp_serve_started", {"transport": "stdio", "tool_count": 12})
+        telemetry.set_context(runtime_backend="codex")
+        telemetry.capture_service_active()
         telemetry.flush(timeout=2.0)
-        assert len(sent) == 1
-        props = sent[0]["properties"]
-        keys = set(props)
 
-        assert keys <= telemetry._MCP_SERVE_STARTED_KEYS
-        assert keys == {
-            "transport",
-            "tool_count",
-            "first_command_surface",
+        assert set(sent[0]["properties"]) == {
+            "service",
+            "$insert_id",
+            "runtime_backend",
             "app_version",
             "os",
         }
-        assert "python_version" not in props
-        for backend_key in telemetry._CONTEXT_ALLOWLIST:
-            assert backend_key not in props
 
 
 class TestCliCapture:
@@ -1242,7 +856,7 @@ class TestCliCapture:
         telemetry.capture_cli_command("init")
         telemetry.flush(timeout=2.0)
         assert sent[0]["properties"]["command"] == "interview"
-        assert sent[0]["properties"]["source"] == "cli"
+        assert sent[0]["properties"]["service"] == "cli"
 
     def test_internal_commands_skipped(self, sent: list[dict[str, Any]]) -> None:
         telemetry.capture_cli_command("dispatch")
@@ -1267,7 +881,7 @@ class TestCliCapture:
         assert len(sent) == 1
         event = sent[0]
         assert event["properties"]["command"] == "extension_command"
-        assert event["properties"]["is_funnel"] is False
+        assert event["properties"]["status"] == "invoked"
         assert hostile not in repr(event)
 
     def test_canonical_cli_command_passes_through_unchanged(
@@ -1281,62 +895,6 @@ class TestCliCapture:
         assert set(telemetry._CLI_FUNNEL) <= telemetry._CANONICAL_CLI_COMMANDS
         is_funnel_names = {"auto", "init", "interview", "seed", "run", "qa", "pm"}
         assert is_funnel_names <= telemetry._CANONICAL_CLI_COMMANDS
-
-
-class TestFrontdoor:
-    def test_claude_marker(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("CODEX_THREAD_ID", raising=False)
-        monkeypatch.delenv("CODEX_SANDBOX_NETWORK_DISABLED", raising=False)
-        monkeypatch.setenv("CLAUDECODE", "1")
-        assert telemetry._detect_frontdoor() == "claude"
-
-    def test_codex_marker(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("CLAUDECODE", raising=False)
-        monkeypatch.setenv("CODEX_THREAD_ID", "thread-1")
-        assert telemetry._detect_frontdoor() == "codex"
-
-    def test_no_marker(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("CLAUDECODE", raising=False)
-        monkeypatch.delenv("CODEX_THREAD_ID", raising=False)
-        monkeypatch.delenv("CODEX_SANDBOX_NETWORK_DISABLED", raising=False)
-        assert telemetry._detect_frontdoor() is None
-
-
-class TestFirstCommandSurface:
-    @pytest.mark.parametrize(
-        "surface", ("setup_complete", "readme_quickstart", "getting_started", "unknown")
-    )
-    def test_explicit_fixed_enum_wins(self, monkeypatch: pytest.MonkeyPatch, surface: str) -> None:
-        monkeypatch.setenv("OUROBOROS_FIRST_COMMAND_SURFACE", surface)
-        (Path.home() / ".ouroboros").mkdir()
-        (Path.home() / ".ouroboros" / "first_command_surface").write_text(
-            "readme_quickstart\n", encoding="utf-8"
-        )
-        (Path.home() / ".ouroboros" / "config.yaml").write_text("{}\n", encoding="utf-8")
-
-        assert telemetry._detect_first_command_surface() == surface
-
-    def test_install_hint_survives_setup(self, tmp_path: Path) -> None:
-        state_dir = tmp_path / ".ouroboros"
-        state_dir.mkdir()
-        (state_dir / "first_command_surface").write_text("readme_quickstart\n", encoding="utf-8")
-        (state_dir / "config.yaml").write_text("{}\n", encoding="utf-8")
-
-        assert telemetry._detect_first_command_surface() == "readme_quickstart"
-
-    def test_config_is_fallback_when_hint_is_absent(self, tmp_path: Path) -> None:
-        state_dir = tmp_path / ".ouroboros"
-        state_dir.mkdir()
-        (state_dir / "config.yaml").write_text("{}\n", encoding="utf-8")
-
-        assert telemetry._detect_first_command_surface() == "setup_complete"
-
-    def test_invalid_hint_without_config_is_unknown(self, tmp_path: Path) -> None:
-        state_dir = tmp_path / ".ouroboros"
-        state_dir.mkdir()
-        (state_dir / "first_command_surface").write_text("private-url\n", encoding="utf-8")
-
-        assert telemetry._detect_first_command_surface() == "unknown"
 
 
 class TestNotice:
@@ -1428,7 +986,7 @@ class TestNotice:
         assert repaired["notice_shown"] is True
         assert repaired["distinct_id"] == valid_id
 
-        telemetry.capture("mcp_serve_started", {"transport": "stdio", "tool_count": 1})
+        telemetry.capture("service_active", {"service": "mcp"})
         telemetry.flush(timeout=2.0)
         assert len(sent) == 1
         assert sent[0]["distinct_id"] == valid_id
@@ -1821,94 +1379,3 @@ class TestNoticeRace:
         assert len(printed) == 1, (
             f"expected exactly one notice print, got {len(printed)}: {stderrs}"
         )
-
-
-class TestUnbiasedPollSampling:
-    """Regression: polling-tool sampling must stay 1/50 per call, not per
-    process (telemetry._poll_rng, replacing a per-process call counter).
-
-    A per-process counter always samples call #1, so a short-lived MCP
-    process that polls once or twice before exiting would be captured at
-    close to 1:1 while still reporting `sample_rate=50` -- an up-to-50x
-    over-count concentrated in exactly the processes least representative of
-    steady-state usage. An independent per-call random draw keeps the
-    probability 1/50 regardless of how long a given process lives.
-    """
-
-    def test_first_call_is_not_structurally_captured(self, sent: list[dict[str, Any]]) -> None:
-        # Precomputed offline: random.Random(1).random() == 0.1344 >= 1/50,
-        # so the very first polling draw with this seed is a miss. A
-        # per-process counter would have captured it regardless (call #1
-        # always sampled) -- this is exactly the bias being fixed.
-        telemetry._poll_rng.seed(1)
-        telemetry.capture_tool_call("ouroboros_job_status", ok=True)
-        telemetry.flush(timeout=2.0)
-        assert sent == []
-
-    def test_seeded_draw_below_threshold_is_captured(self, sent: list[dict[str, Any]]) -> None:
-        # Precomputed offline: random.Random(31).random() == 0.0123 < 1/50.
-        telemetry._poll_rng.seed(31)
-        telemetry.capture_tool_call("ouroboros_job_status", ok=True)
-        telemetry.flush(timeout=2.0)
-        assert len(sent) == 1
-        assert sent[0]["properties"]["sample_rate"] == telemetry._POLL_SAMPLE_RATE
-
-    def test_multi_process_sampling_matches_precomputed_expectation(self, tmp_path: Path) -> None:
-        """Fresh processes must NOT all capture their first polling call.
-
-        Ten fresh processes, each seeding telemetry._poll_rng with a
-        different precomputed seed and making exactly ONE polling capture
-        (their "call #1"). The old per-process-counter bug would have
-        captured every single one of these (5/5 CAPTURED). The expected
-        outcome per seed is precomputed offline from the same
-        random.Random(seed).random() draw the production code makes, so
-        this is a zero-flake proof that fresh-process sampling is unbiased.
-        """
-        # Precomputed offline (random.Random(seed).random() vs. 1/50):
-        # captured: 31, 139, 165, 206, 281 -- skipped: 1, 2, 3, 4, 5
-        seeds = [1, 2, 3, 4, 5, 31, 139, 165, 206, 281]
-        threshold = 1.0 / telemetry._POLL_SAMPLE_RATE
-        expected = [
-            "CAPTURED" if random.Random(seed).random() < threshold else "SKIPPED" for seed in seeds
-        ]
-        assert "CAPTURED" in expected and "SKIPPED" in expected, (
-            "seed selection must cover both outcomes or this test can't "
-            "distinguish the fix from the old always-captures-call-1 bug"
-        )
-
-        script_path = tmp_path / "sampling_worker.py"
-        script_path.write_text(
-            "import sys\n"
-            "from ouroboros import telemetry\n"
-            "\n"
-            "telemetry._poll_rng.seed(int(sys.argv[1]))\n"
-            "captured = []\n"
-            "telemetry._post = lambda batch: captured.extend(batch)\n"
-            "telemetry.capture_tool_call('ouroboros_job_status', ok=True)\n"
-            "telemetry.flush(timeout=2.0)\n"
-            "print('CAPTURED' if captured else 'SKIPPED')\n",
-            encoding="utf-8",
-        )
-
-        repo_root = Path(__file__).resolve().parents[2]
-        observed = []
-        for seed in seeds:
-            home = tmp_path / f"home_{seed}"
-            home.mkdir()
-            env = os.environ.copy()
-            env["HOME"] = str(home)
-            env["PYTHONPATH"] = str(repo_root / "src")
-            env["OUROBOROS_POSTHOG_API_KEY"] = "phc_test"
-            for key in ("DO_NOT_TRACK", "OUROBOROS_TELEMETRY", "OUROBOROS_POSTHOG_HOST"):
-                env.pop(key, None)
-            completed = subprocess.run(
-                [sys.executable, str(script_path), str(seed)],
-                env=env,
-                text=True,
-                capture_output=True,
-                timeout=10,
-                check=True,
-            )
-            observed.append(completed.stdout.strip())
-
-        assert observed == expected, f"seeds={seeds} expected={expected} observed={observed}"


### PR DESCRIPTION
## Summary

- reduce PostHog ingestion to installs, daily activity, adoption dimensions, workflow outcomes, and actionable failures
- remove high-volume session, polling/helper success, subagent dispatch, and unused diagnostic properties
- daily-deduplicate retained service and command activity with deterministic `$insert_id` values

## Retained metrics

- successful installs by day and `ref`
- app version, OS, country, and runtime backend adoption
- service DAU and command DAU
- user lifecycle
- workflow terminal outcomes by status
- blocked seed paths, rejected/failed commands, and workflow failure reasons

## Removed collection

- `install_started`
- per-session `mcp_serve_started`
- `subagent_dispatch`
- successful polling and internal helper calls
- tool names, durations, Python version, provider details, frontdoor/onboarding attribution, and recovery actions

## Production PostHog

- consolidated to one `Ouroboros — Lean Product Metrics` dashboard
- retained 10 requested insights; soft-deleted 32 obsolete insights and 6 obsolete dashboards
- current 30-day baseline: 280,638 service-start events, 42,353 command events, and 4,710 subagent events; the new contract removes or daily-deduplicates these high-volume sources

## Verification

- `pytest` — 208 passed
- `ruff check` — passed
- `mypy` — passed
- `bash -n scripts/install.sh` — passed
- `git diff --check` — passed