### PR TITLE
chore(release): v0.51.16

### DIFF
--- a/.claude-plugin/.mcp.json
+++ b/.claude-plugin/.mcp.json
@@ -7,7 +7,7 @@
         "--python",
         ">=3.12",
         "--from",
-        "ouroboros-ai[mcp]==0.51.15",
+        "ouroboros-ai[mcp]==0.51.16",
         "ouroboros",
         "mcp",
         "serve",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "ouroboros",
       "description": "Sits in front of Claude Code and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
-      "version": "0.51.15",
+      "version": "0.51.16",
       "author": {
         "name": "Q00",
         "email": "jqyu.lee@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros",
-  "version": "0.51.15",
+  "version": "0.51.16",
   "description": "Sits in front of Claude Code and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
   "author": {
     "name": "Q00",

--- a/.claude-plugin/skills/setup/SKILL.md
+++ b/.claude-plugin/skills/setup/SKILL.md
@@ -296,7 +296,7 @@ A backup will be created: CLAUDE.md.bak
 **If "Preview first", show:**
 ````markdown
 <!-- ooo:START -->
-<!-- ooo:VERSION:0.51.15 -->
+<!-- ooo:VERSION:0.51.16 -->
 # Ouroboros — Specification-First AI Development
 
 > Before telling AI what to build, define what should be built.

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros",
-  "version": "0.51.15",
+  "version": "0.51.16",
   "description": "Sits in front of Codex CLI and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
   "author": {
     "name": "Q00",

--- a/.mcp.codex.json
+++ b/.mcp.codex.json
@@ -7,7 +7,7 @@
         "--python",
         ">=3.12",
         "--from",
-        "ouroboros-ai[mcp]==0.51.15",
+        "ouroboros-ai[mcp]==0.51.16",
         "ouroboros",
         "mcp",
         "serve",

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -296,7 +296,7 @@ A backup will be created: CLAUDE.md.bak
 **If "Preview first", show:**
 ````markdown
 <!-- ooo:START -->
-<!-- ooo:VERSION:0.51.15 -->
+<!-- ooo:VERSION:0.51.16 -->
 # Ouroboros — Specification-First AI Development
 
 > Before telling AI what to build, define what should be built.


### PR DESCRIPTION
## Summary
- Patch release v0.51.16 — syncs plugin metadata version across `.claude-plugin/`, `.codex-plugin/`, and `skills/setup/SKILL.md`.
- No source code changes; all included commits already passed CI via their individual PRs.

## What's Changed

### Features
- Host-driven execution runtime for MCP hosts (#2169)

### Bug Fixes
- Reduce PostHog telemetry collection to core metrics (#2278)
- Tolerate piped execution and older schemas during install (#2277)
- Honor explicit transport security overrides in MCP (#2033)
- Preserve independent capability probes in pi (#2255)
- Stop silently discarding the tournament winner's work in orchestrator (#2237)
- Stop blocking on transients — preflight gate, bounded retries, chain parity, blocked UX (#1944)
- Validate batched answer identities in pm (#2258)

### Documentation
- Document CI gates, branch protection, and the tag-after-merge release order (#2270)
- Add the development loop and review conventions (#2272)

🤖 Generated with [Claude Code](https://claude.com/claude-code)