### PR TITLE
docs(contributing): define executable PR boundaries

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,26 @@
 - [ ] `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/` clean
 - [ ] `uv run mypy src/` clean (or noted exception)
 
+## PR Boundary Contract
+
+<!-- Keep the review target explicit. Do not let a small user problem silently
+grow into a new lifecycle, rollback, concurrency, filesystem, or ownership
+subsystem. -->
+- User problem:
+- Promised behavior:
+- Inputs and preconditions:
+- Execution conditions:
+- Owned files/subsystems/owners:
+- Non-goals:
+- Verification scenario or command:
+
+### Scope decision
+
+- [ ] This PR stays within the owned surface above.
+- [ ] Any extra risk is a follow-up with a named owner.
+- [ ] If separation leaves immediate user-data or security risk, I requested a maintainer RFC/scope decision.
+
+
 ## R-run comparison (required for `src/ouroboros/auto/` changes)
 
 <!--

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,37 @@ Other gates fire conditionally and are easy to trip blind:
 Full reference, including every escape hatch and the release sequence:
 **[docs/contributing/ci-gates.md](docs/contributing/ci-gates.md)**.
 
+### Review Boundary Contract
+
+For every PR, recover the contributor's structured boundary before evaluating
+implementation details. The boundary must identify the user problem, promised
+behavior, inputs/preconditions, execution conditions, owned subsystems and
+owners, non-goals, and verification scenario.
+
+Use this five-question decision gate:
+
+1. Does the finding reproduce under the promised inputs and execution conditions?
+2. Does it break the PR's promised contract?
+3. Does fixing it require a new subsystem or new ownership?
+4. Can the original user problem be solved without the PR-introduced subsystem?
+5. Would splitting the extra scope leave immediate user-data or security risk?
+
+Decision rules:
+
+- Questions 1 and 2 true: `REQUEST_CHANGES`, with current-HEAD evidence.
+- Question 3 or 4 true and question 5 false: non-blocking follow-up, named owner,
+  and no scope expansion in the current PR.
+- Questions 3 and 5 true: stop the review escalation and ask the maintainer for
+  an RFC/scope decision. Do not design the new subsystem in the blocker.
+- Missing boundary: request the missing contract fields once; do not invent
+  blockers from an ambiguous or unsupported assumption.
+
+The contributor owns the contract and boundary. The review bot owns only
+contract violations and direct risks. A risk outside the valid boundary is a
+follow-up owned by the appropriate subsystem owner. The maintainer decides
+whether scope expansion is allowed. Consolidate one root cause into one
+finding; never drip the same assumption into repeated rollback, concurrency,
+filesystem, or lifecycle blockers.
 <!-- ooo:START -->
 <!-- ooo:VERSION:0.26.0 -->
 # Ouroboros — Specification-First AI Development
@@ -88,6 +119,8 @@ Most AI coding fails at the input, not the output. Ouroboros fixes this by
 3. **Evolutionary Loops** — Each evaluation cycle feeds back into better specs
 
 ```
+
+
 Interview → Seed → Execute → Evaluate
     ↑                           ↓
     └─── Evolutionary Loop ─────┘

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,33 @@ Other gates fire conditionally and are easy to trip blind:
 Full reference, including every escape hatch and the release sequence:
 **[docs/contributing/ci-gates.md](docs/contributing/ci-gates.md)**.
 
+
+## Review Boundary Contract
+
+Before changing or reviewing a PR, recover its structured boundary: user
+problem, promised behavior, inputs/preconditions, execution conditions, owned
+subsystems and owners, non-goals, and verification scenario.
+
+Use this five-question decision gate:
+
+1. Does the finding reproduce under the promised inputs and execution conditions?
+2. Does it break the PR's promised contract?
+3. Does fixing it require a new subsystem or new ownership?
+4. Can the original user problem be solved without the PR-introduced subsystem?
+5. Would splitting the extra scope leave immediate user-data or security risk?
+
+Only questions 1 and 2 together justify `REQUEST_CHANGES`. If question 3 or 4
+is true and question 5 is false, create a non-blocking follow-up with a named
+owner; do not expand the current PR. If questions 3 and 5 are true, stop and
+ask the maintainer for an RFC/scope decision instead of designing the new
+subsystem in review comments.
+
+If the boundary is missing, request the missing contract fields once. Never
+turn an unsupported solution assumption into successive lifecycle, rollback,
+concurrency, filesystem-authority, or ownership blockers. Consolidate one root
+cause into one finding. The contributor owns the contract, the review bot owns
+contract violations and direct risks, and the maintainer decides scope
+expansion.
 <!-- ooo:START -->
 <!-- ooo:VERSION:0.26.0 -->
 # Ouroboros — Specification-First AI Development

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,8 @@ Thank you for your interest in contributing to Ouroboros! This guide covers ever
 - [Quick Setup](#quick-setup)
 - [Development Workflow](#development-workflow)
 - [Ways to Contribute](#ways-to-contribute)
+- [PR Boundary Contract](#pr-boundary-contract)
+
 - [Development Environment](#development-environment)
 - [Code Style Guide](#code-style-guide)
 - [Commit Message Convention](#commit-message-convention)
@@ -64,6 +66,47 @@ uv run --python 3.13 pytest tests/unit/ -q
 - For new features, open an issue first to discuss the approach
 - Label your issue with appropriate tags: `bug`, `enhancement`, `documentation`, etc.
 - Treat actionable issues as structured work artifacts, not casual notes. See [Issue Quality Policy](./docs/contributing/issue-quality-policy.md).
+
+### PR Boundary Contract
+
+Before implementation, write the boundary the PR promises to own. A small user
+problem must not silently grow into a new lifecycle, rollback protocol,
+concurrency model, filesystem authority, or subsystem ownership.
+
+Every implementation issue and PR must state:
+
+1. **User problem** — the observable problem being solved.
+2. **Promised behavior** — what becomes true for the user.
+3. **Inputs and preconditions** — the inputs for which the promise applies.
+4. **Execution conditions** — runtime, platform, lifecycle, and failure conditions in scope.
+5. **Owned surface** — files, subsystems, and existing owners the PR may change.
+6. **Non-goals** — adjacent behavior the PR explicitly does not own.
+7. **Verification** — one or more commands or scenarios that prove the promise.
+
+If the implementation discovers that it needs a new subsystem or a new effect
+owner, stop expanding the patch. Record the discovery as a follow-up or ask a
+maintainer whether an RFC is required. Do not make the current PR absorb new
+lifecycle, rollback, concurrency, or filesystem-authority responsibilities just
+to satisfy review feedback.
+
+The review bot applies this decision contract:
+
+1. Does a finding reproduce under the PR's promised inputs and execution conditions?
+2. Does that finding break the behavior the PR promised?
+3. Would fixing it require a new subsystem or new ownership?
+4. Can the original user problem be solved without the subsystem introduced by the PR?
+5. Would separating the extra scope leave an immediate user-data or security risk?
+
+| Result | Review action |
+|---|---|
+| 1 and 2 are both true | `REQUEST_CHANGES` with current-HEAD evidence. |
+| 3 or 4 is true, and 5 is false | Non-blocking follow-up with an explicit owner; do not expand this PR. |
+| 3 and 5 are true | Stop the PR and ask a maintainer for an RFC/scope decision. Do not prescribe the new architecture inside review comments. |
+| The boundary is missing or ambiguous | Ask once for the missing contract fields; do not invent speculative blockers. |
+
+One root cause gets one consolidated finding. A reviewer must not turn one
+unsupported solution assumption into a sequence of rollback, concurrency,
+filesystem, and lifecycle blockers across repeated rounds.
 
 ### 2. Branch
 

--- a/docs/contributing/review-conventions.md
+++ b/docs/contributing/review-conventions.md
@@ -42,12 +42,39 @@ Treat these as concepts, not an exhaustive heading template; the authoritative
 contract may add or rename sections without changing how contributors should
 interpret the review.
 
+## Boundary before direction
+
+Structural review starts from the contributor-declared PR Boundary Contract,
+not from every architecture the reviewer can imagine. The contract states the
+user problem, promised behavior, inputs and execution conditions, owned
+surface, non-goals, and verification.
+
+For each finding, the bot asks:
+
+1. Does it reproduce under the promised inputs and execution conditions?
+2. Does it break the promised behavior?
+3. Would fixing it require a new subsystem or new ownership?
+4. Can the user problem be solved without the subsystem introduced by the PR?
+5. Would separating that extra scope leave immediate user-data or security risk?
+
+Only questions 1 and 2 together make a blocker. Questions 3 or 4 without the
+immediate risk in question 5 become a named-owner follow-up; they do not expand
+the current PR. Questions 3 and 5 together stop the PR for a maintainer
+RFC/scope decision. The review bot does not design the expanded architecture
+inside a blocker.
+
+This prevents a small user problem from turning into a sequence of
+reviewer-required lifecycle, rollback, concurrency, filesystem-authority, and
+ownership changes. One root cause gets one consolidated finding.
+
+
 Two consequences worth internalizing:
 
-- **Your PR is graded against the issue, not against your PR description.** A
-  vague issue produces a vague grade; a requirement you decided was out of
-  scope reads as *Partially met* unless you say in the PR why it is deferred.
-  This is why [issue quality](./issue-quality-policy.md) is enforced.
+- **Your PR is graded against the linked issue plus the PR Boundary Contract.**
+  A vague issue or missing boundary is a request for clarification, not license
+  to invent a broader solution. Explicitly record deferred requirements and
+  non-goals so they can be routed to an owner-assigned follow-up.
+
 - **The bot reproduces things.** Findings routinely cite a probe it ran —
   *"a focused probe classified such a companion as `decide_later` and made it
   skip-eligible"*, *"A focused runtime probe with `process.wait()` returning
@@ -99,8 +126,11 @@ signs that the next round will not be the last one:
 - The blocker count is **not trending down** after three rounds.
 - You are arguing about **which inputs are legitimate** rather than about what
   the code does.
-- You find yourself thinking *"the reviewer keeps finding edge cases"*. Edge
-  cases that keep existing are not edge cases. They are the shape.
+- You find yourself thinking *"the reviewer keeps finding edge cases"*. First
+  check whether they reproduce inside the declared boundary and break the
+  promised contract. Outside-boundary cases are follow-ups unless separation
+  leaves immediate user-data or security risk.
+
 
 ### What asking it actually looks like
 
@@ -152,16 +182,20 @@ In all three, specific line findings exposed an authority, parsing, or
 compatibility boundary. The durable repair stated that boundary in code and
 tests instead of patching each observed example.
 
-### Not an escape hatch
+### Not an escape hatch or a scope-expansion license
 
-This is not permission to dismiss a finding you do not want to fix. "The
-structure is wrong" is a claim that has to survive step 3 above — a different
-shape that still solves the original problem. Without that, it is just a
-disagreement, and the reviewer is probably right.
+The boundary contract cannot dismiss a finding that reproduces under the
+promised conditions and breaks the promised behavior. It also cannot be used
+by the reviewer to force a new subsystem into the current PR. A different
+shape must still solve the original user problem; new ownership requires a
+named follow-up or a maintainer RFC decision.
 
-## The recurring blockers
 
-Ordered by how often they appear in review bodies.
+## Recurring in-boundary blockers
+
+The examples below are blockers only when the affected input or behavior is
+inside the declared PR contract. Otherwise, route them to the responsible
+owner as follow-up work.
 
 ### 1. Validate untrusted input — never coerce it
 
@@ -177,8 +211,8 @@ accepted values.
 
 ### 2. Honor the public schema and never report silent success
 
-A code path that accepts a request, does nothing, and reports success is
-always a blocker:
+A code path that accepts a promised request, does nothing, and reports success
+is a blocker because it violates the declared public contract:
 
 > "The public tool schema accepts `answers`, but plugin mode only examines the
 > singular `answer` variable. A request such as `{"session_id": id, "answers":


### PR DESCRIPTION
## Summary

- Require every issue and PR to declare its user problem, promised behavior, inputs, execution conditions, owned surface, non-goals, and verification.
- Align contributor, agent, and Claude guidance around the same five-question review decision gate.
- Prevent small user problems from turning into reviewer-invented lifecycle, rollback, concurrency, filesystem-authority, or ownership scope.

## Review decision contract

- Questions 1 and 2 both proven: REQUEST_CHANGES.
- Questions 3 or 4 without immediate data/security risk: named-owner follow-up; do not expand the PR.
- Questions 3 and 5 both true: stop and request maintainer RFC/scope decision.
- Missing boundary: request clarification once; do not invent blockers.

## Verification

-  passes on the documentation changes.
- Contract wording checked across CONTRIBUTING.md, AGENTS.md, CLAUDE.md, and the PR template.