### PR TITLE
chore(release): v0.51.17

### DIFF
--- a/.claude-plugin/.mcp.json
+++ b/.claude-plugin/.mcp.json
@@ -7,7 +7,7 @@
         "--python",
         ">=3.12",
         "--from",
-        "ouroboros-ai[mcp]==0.51.16",
+        "ouroboros-ai[mcp]==0.51.17",
         "ouroboros",
         "mcp",
         "serve",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "ouroboros",
       "description": "Sits in front of Claude Code and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
-      "version": "0.51.16",
+      "version": "0.51.17",
       "author": {
         "name": "Q00",
         "email": "jqyu.lee@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros",
-  "version": "0.51.16",
+  "version": "0.51.17",
   "description": "Sits in front of Claude Code and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
   "author": {
     "name": "Q00",

--- a/.claude-plugin/skills/setup/SKILL.md
+++ b/.claude-plugin/skills/setup/SKILL.md
@@ -296,7 +296,7 @@ A backup will be created: CLAUDE.md.bak
 **If "Preview first", show:**
 ````markdown
 <!-- ooo:START -->
-<!-- ooo:VERSION:0.51.16 -->
+<!-- ooo:VERSION:0.51.17 -->
 # Ouroboros — Specification-First AI Development
 
 > Before telling AI what to build, define what should be built.

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros",
-  "version": "0.51.16",
+  "version": "0.51.17",
   "description": "Sits in front of Codex CLI and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
   "author": {
     "name": "Q00",

--- a/.mcp.codex.json
+++ b/.mcp.codex.json
@@ -7,7 +7,7 @@
         "--python",
         ">=3.12",
         "--from",
-        "ouroboros-ai[mcp]==0.51.16",
+        "ouroboros-ai[mcp]==0.51.17",
         "ouroboros",
         "mcp",
         "serve",

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -296,7 +296,7 @@ A backup will be created: CLAUDE.md.bak
 **If "Preview first", show:**
 ````markdown
 <!-- ooo:START -->
-<!-- ooo:VERSION:0.51.16 -->
+<!-- ooo:VERSION:0.51.17 -->
 # Ouroboros — Specification-First AI Development
 
 > Before telling AI what to build, define what should be built.


### PR DESCRIPTION
## Summary

- sync Claude and Codex plugin metadata to `0.51.17`
- prepare the patch release after `v0.51.16`

## Validation

- `uv run ruff format src/ tests/ && uv run ruff check src/ tests/ --fix`
- `uv run mypy src/ouroboros`
- `bun install && bunx tsc --noEmit && bun test` (`152 passed`)
- `cargo test` (`16 passed`)
- `uv run pytest`: `21,773 passed`, `95 skipped`, `1 xfailed`; one remaining macOS filesystem failure in `TestNonAsciiAndQuotedFilenames::test_undecodable_filename_exports_and_applies` (`OSError: [Errno 92] Illegal byte sequence`). The initially generated bridge `node_modules` discovery failure passed after cleanup.
