### PR TITLE
docs: add DeepSeek Harness Handbook runtime reference

### DIFF
--- a/docs/guides/deepseek-harness.md
+++ b/docs/guides/deepseek-harness.md
@@ -177,3 +177,7 @@ first call fails.
 
 Note that the loopback spawns a second `dsh-acp-demo` process; it does not
 reuse the dsh you are chatting in, so steps 1–3 above still apply.
+
+For source-backed runtime diagnostics beyond this integration path—especially
+plugin/MCP composition, Session recovery, sandbox boundaries, and cross-platform
+failures—see the independent [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook).


### PR DESCRIPTION
## Summary

- Link the independent DeepSeek Harness Handbook from the DSH integration guide.
- The handbook complements Ouroboros's backend setup with source-backed plugin/MCP, Session, sandbox, approval, and cross-platform runtime diagnostics.

This is a one-paragraph documentation-only change; no Ouroboros behavior changes.
