### PR TITLE
test(orchestrator): make shell execution portable on Windows

### DIFF
--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -280,19 +280,18 @@ def test_files_touched_rejects_reconstructed_pathlib_with_inert_touch_argv(tmp_p
     claimed_file = tmp_path / "claimed.py"
     other_file = tmp_path / "other.py"
     claimed_file.write_text("original\n", encoding="utf-8")
-    command = shlex.join(
-        [
-            str(Path(sys.executable).resolve()),
-            "-I",
-            "-S",
-            "-c",
-            "getattr(__import__('path' 'lib'), 'Pa' 'th')('other.py').write_text('changed')",
-            "touch",
-            "claimed.py",
-        ]
-    )
+    argv = [
+        str(Path(sys.executable).resolve()),
+        "-I",
+        "-S",
+        "-c",
+        "getattr(__import__('path' 'lib'), 'Pa' 'th')('other.py').write_text('changed')",
+        "touch",
+        "claimed.py",
+    ]
+    command = shlex.join(argv)
 
-    completed = subprocess.run(command, cwd=tmp_path, shell=True, check=False)  # noqa: S602
+    completed = subprocess.run(argv, cwd=tmp_path, shell=False, check=False)
 
     assert completed.returncode == 0
     assert claimed_file.read_text(encoding="utf-8") == "original\n"
@@ -317,6 +316,7 @@ def test_files_touched_rejects_reconstructed_pathlib_with_inert_touch_argv(tmp_p
     )
 
 
+@pytest.mark.skipif(os.name == "nt", reason="requires POSIX /bin/bash")
 def test_files_touched_rejects_wrapped_reconstructed_pathlib_with_inert_touch_argv(
     tmp_path,
 ) -> None:


### PR DESCRIPTION
## Summary

Closes #2252.

Make the two reported mutation-proof tests honest about which shell contract they exercise:

- execute the Python-only probe as argv with `shell=False`
- retain the same `shlex.join(argv)` command text for evidence-parser assertions
- skip only the wrapper execution test that genuinely invokes `/bin/bash` on native Windows

## Review boundary

### User problem

Native Windows contributors cannot run the two #2252 reproduction tests because one sends POSIX-quoted `shlex` text to `cmd.exe` and the other requires `/bin/bash`. Both fail before reaching the evidence-safety assertions they are meant to prove.

### Promised contract

Supported inputs and conditions:

- the Python-only test uses the current interpreter plus its fixed test argv on every platform
- the wrapped test continues to execute `/bin/bash -lc` on POSIX CI
- native Windows is identified by `os.name == "nt"`

Observable behavior and invariants:

- the Python child executes successfully on native Windows without a shell
- the parser still receives the original POSIX-rendered command string, so the evidence-classification assertion is unchanged
- the genuine `/bin/bash` execution test is narrowly skipped only on native Windows
- production evidence matching and runtime behavior do not change

### Implementation boundary

One test module owned by the orchestrator test suite:

- `tests/unit/orchestrator/test_parallel_executor.py`

No production module, data boundary, runtime authority, or security boundary is changed.

### Non-goals

- adding a Windows CI matrix
- making the entire repository test suite native-Windows clean
- replacing parser-only POSIX fixtures such as `touch` or `sed`
- changing production shell parsing or evidence acceptance
- absorbing unrelated baseline failures in Hermes Mypy analysis or auto-pipeline timing tests

### Evidence

On native Windows 11 with CPython 3.12.13:

```text
1 passed, 1 skipped
```

Command:

```powershell
uv run --python 3.12 --frozen pytest -q `
  tests/unit/orchestrator/test_parallel_executor.py::test_files_touched_rejects_reconstructed_pathlib_with_inert_touch_argv `
  tests/unit/orchestrator/test_parallel_executor.py::test_files_touched_rejects_wrapped_reconstructed_pathlib_with_inert_touch_argv
```

Additional checks:

- `uv run --frozen ruff check src/ tests/` — passed
- `uv run --frozen ruff format --check src/ tests/` — 1,396 files formatted
- `python scripts/check-module-size.py --baseline-ref origin/main` — passed
- `git diff --check` — passed

The full Mypy command on native Windows reaches an unrelated current-main platform analysis at `src/ouroboros/hermes/artifacts.py:205` (`result` may be undefined); upstream Linux CI for the base commit passes Mypy. The PR's required Linux Mypy and full-suite signals are left to repository CI.