### PR TITLE
feat(install): PowerShell installer for Windows without Python

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -41,7 +41,13 @@
 </p>
 
 ```bash
+# macOS / Linux / WSL 2
 curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | OUROBOROS_INSTALL_REF=readme-hero-ko bash
+```
+
+```powershell
+# Windows (PowerShell) — Python 없어도 됩니다. Git과 uv를 대신 설치합니다
+irm https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.ps1 | iex
 ```
 
 <p align="center"><sub>설치는 위 한 줄입니다. 이후 코딩 에이전트 안에서 <code>ooo setup</code>을 한 번 실행하세요. 자세한 내용은 <a href="#빠른-시작">빠른 시작</a>에 있습니다.</sub></p>
@@ -139,8 +145,19 @@ Ouroboros는 이 철학을 **Double Diamond** 구조로 풀어냅니다:
 **설치** — 한 줄이면 전부 자동:
 
 ```bash
+# macOS / Linux / WSL 2
 curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | OUROBOROS_INSTALL_REF=readme-ko bash
 ```
+
+```powershell
+# Windows (PowerShell 5.1+ 또는 pwsh 7+) — 미리 설치할 것 없음
+irm https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.ps1 | iex
+```
+
+Windows 설치 스크립트는 Git과 uv가 없으면 winget으로 설치하고, Python은 uv가
+직접 내려받습니다. 그다음 `ouroboros-ai`를 설치하고 발견한 호스트를 연결합니다.
+네이티브 Windows는 실험 단계이고 Codex CLI는 WSL 2가 필요합니다.
+[플랫폼 지원](./docs/platform-support.md)을 참고하세요.
 
 **첫 명령** — AI 코딩 에이전트를 열고 아래 두 명령을 순서대로 입력하세요:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,13 @@
 </p>
 
 ```bash
+# macOS / Linux / WSL 2
 curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | OUROBOROS_INSTALL_REF=readme-hero bash
+```
+
+```powershell
+# Windows (PowerShell) — no Python needed; installs Git and uv for you
+irm https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.ps1 | iex
 ```
 
 <p align="center"><sub>One command installs it. Then run <code>ooo setup</code> once inside your coding agent — details in <a href="#quick-start">Quick Start</a>.</sub></p>
@@ -140,8 +146,19 @@ Most AI coding fails at the **input**, not the output. The bottleneck is not AI 
 **Install** — one command, everything auto-detected:
 
 ```bash
+# macOS / Linux / WSL 2
 curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | OUROBOROS_INSTALL_REF=readme bash
 ```
+
+```powershell
+# Windows (PowerShell 5.1+ or pwsh 7+) — nothing to install first
+irm https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.ps1 | iex
+```
+
+The Windows installer installs Git and uv through winget when they are missing,
+lets uv download its own Python, then installs `ouroboros-ai` and wires the
+host it finds. Native Windows is experimental and Codex CLI needs WSL 2; see
+[platform support](./docs/platform-support.md).
 
 **First command** — open your AI coding agent and run these in order:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,7 +42,13 @@
 </p>
 
 ```bash
+# macOS / Linux / WSL 2
 curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | OUROBOROS_INSTALL_REF=readme-hero-zh bash
+```
+
+```powershell
+# Windows (PowerShell) — 无需 Python；会自动安装 Git 和 uv
+irm https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.ps1 | iex
 ```
 
 <p align="center"><sub>一行命令完成安装。然后在你的编码 agent 里运行一次 <code>ooo setup</code>，详见<a href="#快速开始">快速开始</a>。</sub></p>
@@ -115,8 +121,18 @@ Ouroboros 是面向 AI 编码的 Agent OS：一层本地优先的运行时，把
 **安装** —— 一条命令，环境自动识别：
 
 ```bash
+# macOS / Linux / WSL 2
 curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | OUROBOROS_INSTALL_REF=readme-zh bash
 ```
+
+```powershell
+# Windows (PowerShell 5.1+ 或 pwsh 7+) —— 无需预先安装任何东西
+irm https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.ps1 | iex
+```
+
+Windows 安装脚本会在缺少 Git 和 uv 时通过 winget 安装它们，Python 由 uv 自行下载，
+然后安装 `ouroboros-ai` 并接入检测到的宿主。原生 Windows 仍是实验性支持，Codex CLI
+需要 WSL 2，详见[平台支持](./docs/platform-support.md)。
 
 **第一条命令** —— 打开你的 AI 编码 agent，按顺序运行：
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -82,7 +82,7 @@ use. Each row below is the exact property set accepted by the serializer.
 
 | Event | When | Properties (exact set) |
 |---|---|---|
-| `install_completed` | `install.sh` finishes successfully (the Windows `install.ps1` sends nothing) | os, runtime, version, ref |
+| `install_completed` | `install.sh` finishes successfully (the Windows `install.ps1` emits neither installer event) | os, runtime, version, ref |
 | `install_started` | `install.sh` begins — deliberately per-invocation, NOT daily-deduplicated: each row pairs with (or lacks) an `install_completed` to measure install drop-off and retry behavior, and volume is bounded by install attempts (~hundreds/month) | os, version, ref |
 | `service_active` | The running MCP service receives its first tool request that day | service (`mcp`), runtime_backend, app_version, os, ci, `$insert_id` |
 | `mcp_serve_started` | A host attaches the Ouroboros MCP server — at most one row per user/day/transport | transport (`stdio`/`sse`/`streamable-http`/`unknown`), runtime_backend, app_version, os, ci, `$insert_id` |
@@ -165,4 +165,7 @@ Collection is triggered only at these audited call sites:
   the same handler runs behind the job-backed `ouroboros_start_evaluate` path;
 - [`scripts/install.sh`](scripts/install.sh) — successful install completion.
   [`scripts/install.ps1`](scripts/install.ps1), the Windows installer, emits
-  no events at all.
+  neither `install_started` nor `install_completed`. The `ouroboros setup`
+  calls it makes are ordinary CLI invocations and produce the `command_run`
+  (service=cli) rows above under the usual controls, as they do for
+  `install.sh`.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -82,7 +82,7 @@ use. Each row below is the exact property set accepted by the serializer.
 
 | Event | When | Properties (exact set) |
 |---|---|---|
-| `install_completed` | `install.sh` finishes successfully | os, runtime, version, ref |
+| `install_completed` | `install.sh` finishes successfully (the Windows `install.ps1` sends nothing) | os, runtime, version, ref |
 | `install_started` | `install.sh` begins — deliberately per-invocation, NOT daily-deduplicated: each row pairs with (or lacks) an `install_completed` to measure install drop-off and retry behavior, and volume is bounded by install attempts (~hundreds/month) | os, version, ref |
 | `service_active` | The running MCP service receives its first tool request that day | service (`mcp`), runtime_backend, app_version, os, ci, `$insert_id` |
 | `mcp_serve_started` | A host attaches the Ouroboros MCP server — at most one row per user/day/transport | transport (`stdio`/`sse`/`streamable-http`/`unknown`), runtime_backend, app_version, os, ci, `$insert_id` |
@@ -164,3 +164,5 @@ Collection is triggered only at these audited call sites:
   `ChecklistVerifyHandler`'s nested multi-AC delegation; suppresses it when
   the same handler runs behind the job-backed `ouroboros_start_evaluate` path;
 - [`scripts/install.sh`](scripts/install.sh) — successful install completion.
+  [`scripts/install.ps1`](scripts/install.ps1), the Windows installer, emits
+  no events at all.

--- a/UNINSTALL.md
+++ b/UNINSTALL.md
@@ -20,6 +20,11 @@ uv tool uninstall ouroboros-ai            # or: pip uninstall ouroboros-ai
 claude plugin uninstall ouroboros         # if using Claude Code plugin
 ```
 
+On Windows (installed with `scripts/install.ps1`), the same two commands work
+in PowerShell. Git and uv were installed through winget and stay in place;
+remove them with `winget uninstall --id astral-sh.uv -e` and
+`winget uninstall --id Git.Git -e` if you no longer want them.
+
 ### Options
 
 | Flag | Effect |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -231,7 +231,35 @@ uv run --python 3.13 pytest tests/unit/ -q
 
 ### Windows users
 
-Use WSL 2 for the supported Windows path, then run the Linux install commands from inside the WSL distribution. Windows 11 Home can run WSL 2; if `wsl --install` or distro installation fails, see [Windows WSL 2 troubleshooting](guides/windows-wsl-troubleshooting.md).
+Two paths. Pick by the host you use:
+
+**Native Windows (PowerShell) — experimental.** Nothing needs to be installed
+first: the script installs Git and uv through winget when they are missing, uv
+downloads its own Python, and the plugin's MCP server runs through `uvx`.
+
+```powershell
+irm https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.ps1 | iex
+```
+
+Options go through environment variables, same names as `install.sh`
+(`OUROBOROS_INSTALL_RUNTIME`, `OUROBOROS_INSTALL_RECONFIGURE`,
+`OUROBOROS_INSTALL_PRE`), or bind the script and pass parameters:
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.ps1))) -Runtime claude -Reconfigure
+```
+
+Open a new PowerShell window afterwards so the PATH change applies. Use
+Windows Terminal for `ouroboros config` (the TUI needs ANSI support; `cmd.exe`
+is not supported). The PowerShell installer sends no telemetry. Limits are
+listed in [platform support](platform-support.md#windows-native-caveats); in
+short, Claude Code works and Codex CLI does not.
+
+**WSL 2 — supported.** Run the Linux install command from inside the WSL
+distribution. This is the path for Codex CLI and for every feature in the
+support matrix. Windows 11 Home can run WSL 2; if `wsl --install` or distro
+installation fails, see
+[Windows WSL 2 troubleshooting](guides/windows-wsl-troubleshooting.md).
 
 ### Prerequisites
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -251,7 +251,8 @@ Options go through environment variables, same names as `install.sh`
 
 Open a new PowerShell window afterwards so the PATH change applies. Use
 Windows Terminal for `ouroboros config` (the TUI needs ANSI support; `cmd.exe`
-is not supported). The PowerShell installer sends no telemetry. Limits are
+is not supported). The PowerShell installer emits no installer telemetry
+events; the `ouroboros setup` it runs follows the normal [controls](../TELEMETRY.md). Limits are
 listed in [platform support](platform-support.md#windows-native-caveats); in
 short, Claude Code works and Codex CLI does not.
 

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -43,7 +43,14 @@ Windows 11 Home is a valid WSL 2 host when virtualization and the required Windo
 
 ## Windows (native) Caveats
 
-Native Windows support is **experimental**. Known limitations:
+Native Windows support is **experimental**. Install with the PowerShell script,
+which needs no Python, Git, or uv beforehand:
+
+```powershell
+irm https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.ps1 | iex
+```
+
+Known limitations:
 
 - **File path handling**: Some workflow operations assume POSIX-style paths.
 - **Process management**: Subprocess spawning and signal handling differ on Windows.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -21,8 +21,10 @@
 #   4. `ouroboros setup --runtime <backend> --non-interactive`, `setup refresh`,
 #      and the Claude Code plugin when `claude` is on PATH.
 #
-# This installer sends no telemetry (see TELEMETRY.md). Native Windows support is
-# experimental; Codex CLI is only supported under WSL 2 (docs/platform-support.md).
+# This installer emits no installer events of its own (no install_started /
+# install_completed). The `ouroboros` CLI it invokes for setup follows the normal
+# telemetry controls in TELEMETRY.md, exactly as it does under install.sh.
+# Native Windows support is experimental; Codex CLI is only supported under WSL 2 (docs/platform-support.md).
 
 [CmdletBinding()]
 param(

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,434 @@
+# Ouroboros installer for native Windows (PowerShell 5.1+ / pwsh 7+).
+#
+# Usage (no Python, no uv, no Git needed beforehand):
+#   irm https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.ps1 | iex
+#
+# With options (the pipe form cannot take parameters, so bind the script first):
+#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.ps1))) -Runtime codex
+#
+# Environment variables mirror scripts/install.sh and work with the pipe form:
+#   OUROBOROS_INSTALL_RUNTIME       claude|claude-sdk|claude-cli|codex|opencode|hermes|gemini|goose|kiro|copilot|pi|gjc|all
+#   OUROBOROS_INSTALL_RECONFIGURE   set to 1 to ignore the runtime saved in ~/.ouroboros/config.yaml
+#   OUROBOROS_INSTALL_PRE           set to 1 to allow pre-release versions
+#
+# What it does, in order:
+#   1. Git >= 2.36 and uv: installed through winget when missing (uv falls back
+#      to the astral.sh installer). uv downloads its own Python, so the machine
+#      does not need one.
+#   2. Picks a backend the same way install.sh does: explicit > saved config >
+#      single detected CLI > prompt.
+#   3. `uv tool install ouroboros-ai` with the same pins as install.sh.
+#   4. `ouroboros setup --runtime <backend> --non-interactive`, `setup refresh`,
+#      and the Claude Code plugin when `claude` is on PATH.
+#
+# This installer sends no telemetry (see TELEMETRY.md). Native Windows support is
+# experimental; Codex CLI is only supported under WSL 2 (docs/platform-support.md).
+
+[CmdletBinding()]
+param(
+    [string]$Runtime = $env:OUROBOROS_INSTALL_RUNTIME,
+    [switch]$Reconfigure,
+    [switch]$Pre
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+# NOTE: pin specs MUST mirror scripts/install.sh and [project.optional-dependencies]
+# in pyproject.toml. tests/unit/scripts/test_install_ps1.py fails on drift.
+$PackageName = 'ouroboros-ai'
+$ClickSpec = 'click>=8.1.0,<9.0.0'
+$DefaultPythonSpec = '>=3.12'
+$LiteLLMPythonSpec = '>=3.12,<3.14'
+$MinGitVersion = [version]'2.36.0'
+$MinPython = [version]'3.12'
+$HookPythonVersion = '3.13'
+$AllRuntimes = @('claude', 'claude-sdk', 'claude-cli', 'codex', 'opencode', 'hermes', 'gemini', 'goose', 'kiro', 'copilot', 'pi', 'gjc')
+
+if ([string]::IsNullOrWhiteSpace($Runtime)) { $Runtime = '' }
+if (-not $Reconfigure -and $env:OUROBOROS_INSTALL_RECONFIGURE) { $Reconfigure = $true }
+if (-not $Pre -and $env:OUROBOROS_INSTALL_PRE) { $Pre = $true }
+
+# --- output helpers -----------------------------------------------------------
+
+function Write-Step([string]$Title, [string]$Detail) {
+    Write-Host ''
+    Write-Host "== $Title" -ForegroundColor Cyan
+    if ($Detail) { Write-Host "   $Detail" -ForegroundColor DarkGray }
+}
+function Write-Ok([string]$Message) { Write-Host "  [ok] $Message" -ForegroundColor Green }
+function Write-Info([string]$Message) { Write-Host "  -  $Message" -ForegroundColor DarkGray }
+function Write-Warn([string]$Message) { Write-Host "  [!] $Message" -ForegroundColor Yellow }
+function Write-Err([string]$Message) { Write-Host "  [x] $Message" -ForegroundColor Red }
+
+function Test-Interactive {
+    try { return -not [Console]::IsInputRedirected } catch { return $false }
+}
+
+# Installers register their directories in the user/machine PATH, but the
+# current session keeps the PATH it started with. Merge the registry PATH in so
+# a tool installed a moment ago is visible without opening a new terminal.
+function Sync-SessionPath {
+    $parts = New-Object System.Collections.Generic.List[string]
+    $seen = @{}
+    foreach ($scope in @('Process', 'User', 'Machine')) {
+        $value = [Environment]::GetEnvironmentVariable('Path', $scope)
+        if (-not $value) { continue }
+        foreach ($entry in $value.Split(';')) {
+            $trimmed = $entry.Trim()
+            if (-not $trimmed) { continue }
+            $key = $trimmed.TrimEnd('\').ToLowerInvariant()
+            if ($seen.ContainsKey($key)) { continue }
+            $seen[$key] = $true
+            $parts.Add($trimmed)
+        }
+    }
+    $env:Path = ($parts -join ';')
+}
+
+function Add-SessionPathFront([string]$Directory) {
+    if (-not $Directory) { return }
+    $current = $env:Path.Split(';') | ForEach-Object { $_.TrimEnd('\').ToLowerInvariant() }
+    if ($current -contains $Directory.TrimEnd('\').ToLowerInvariant()) { return }
+    $env:Path = "$Directory;$env:Path"
+}
+
+function Get-CommandPath([string]$Name) {
+    $found = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($found) { return $found.Source }
+    return $null
+}
+
+# Native commands do not throw on Windows PowerShell 5.1; check the exit code.
+function Invoke-Native([string]$Command, [string[]]$Arguments) {
+    $global:LASTEXITCODE = 0
+    # Output goes straight to the host so the function returns only the bool.
+    & $Command @Arguments | Out-Host
+    return ($LASTEXITCODE -eq 0)
+}
+
+function Test-Winget {
+    return [bool](Get-CommandPath 'winget')
+}
+
+function Install-WithWinget([string]$Id, [string]$Label) {
+    if (-not (Test-Winget)) { return $false }
+    Write-Info "Installing $Label with winget ($Id)..."
+    $ok = Invoke-Native 'winget' @('install', '--id', $Id, '-e', '--silent', '--accept-source-agreements', '--accept-package-agreements')
+    Sync-SessionPath
+    return $ok
+}
+
+# --- banner -------------------------------------------------------------------
+
+Write-Host ''
+Write-Host '  Ouroboros installer (Windows)' -ForegroundColor Magenta
+Write-Host '  Specification-first AI development' -ForegroundColor DarkGray
+Write-Host ''
+Write-Warn 'Native Windows support is experimental. Codex CLI needs WSL 2; for the fully supported path run scripts/install.sh inside WSL 2.'
+
+# --- 1/4 prerequisites: Git and uv -------------------------------------------
+
+Write-Step '1/4  Checking Git and uv' 'Both are installed automatically when missing. No Python is required.'
+
+Sync-SessionPath
+
+$gitPath = Get-CommandPath 'git'
+if (-not $gitPath) {
+    Write-Warn 'Git not found.'
+    if (-not (Install-WithWinget 'Git.Git' 'Git')) {
+        Write-Err 'Git >= 2.36 is required and could not be installed automatically.'
+        Write-Info 'Install it from https://git-scm.com/download/win, open a new PowerShell window, and run this installer again.'
+        exit 1
+    }
+    $gitPath = Get-CommandPath 'git'
+    if (-not $gitPath) {
+        Write-Err 'Git was installed but is not on PATH yet. Open a new PowerShell window and run this installer again.'
+        exit 1
+    }
+}
+$gitVersionText = (& git --version 2>$null) -join ' '
+$gitMatch = [regex]::Match($gitVersionText, '(\d+)\.(\d+)\.(\d+)')
+if ($gitMatch.Success) {
+    $gitVersion = [version]("{0}.{1}.{2}" -f $gitMatch.Groups[1].Value, $gitMatch.Groups[2].Value, $gitMatch.Groups[3].Value)
+    if ($gitVersion -lt $MinGitVersion) {
+        Write-Err "Git $gitVersion found, but Ouroboros needs Git >= $MinGitVersion."
+        Write-Info 'Upgrade with: winget upgrade --id Git.Git -e'
+        exit 1
+    }
+    Write-Ok "Git found: $gitVersionText"
+} else {
+    Write-Warn "Could not parse the Git version from '$gitVersionText'; continuing."
+}
+
+$uvPath = Get-CommandPath 'uv'
+if (-not $uvPath) {
+    Write-Warn 'uv not found.'
+    if (-not (Install-WithWinget 'astral-sh.uv' 'uv')) {
+        Write-Info 'winget unavailable or failed; using the astral.sh installer...'
+        try {
+            [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+            $uvInstaller = Invoke-RestMethod -Uri 'https://astral.sh/uv/install.ps1' -UseBasicParsing
+            Invoke-Expression $uvInstaller
+        } catch {
+            Write-Err "uv could not be installed: $($_.Exception.Message)"
+            Write-Info 'Install it manually: winget install --id astral-sh.uv -e   (or see https://docs.astral.sh/uv/getting-started/installation/)'
+            exit 1
+        }
+        Sync-SessionPath
+    }
+    $uvPath = Get-CommandPath 'uv'
+    if (-not $uvPath) {
+        $fallbackBin = Join-Path $env:USERPROFILE '.local\bin'
+        if (Test-Path (Join-Path $fallbackBin 'uv.exe')) {
+            Add-SessionPathFront $fallbackBin
+            $uvPath = Get-CommandPath 'uv'
+        }
+    }
+    if (-not $uvPath) {
+        Write-Err 'uv was installed but is not on PATH yet. Open a new PowerShell window and run this installer again.'
+        exit 1
+    }
+}
+Write-Ok "uv found: $((& uv --version 2>$null) -join ' ')"
+
+# --- 2/4 backend selection ------------------------------------------------------
+
+Write-Step '2/4  Choosing an agent backend' 'Claude, Codex, Hermes, OpenCode, Gemini, Goose, Kiro, Copilot, Pi, and GJC are supported.'
+
+$detected = @{}
+foreach ($pair in @(
+        @('claude', 'claude'), @('codex', 'codex'), @('hermes', 'hermes'), @('opencode', 'opencode'),
+        @('gemini', 'gemini'), @('goose', 'goose'), @('kiro', 'kiro-cli'), @('copilot', 'copilot'),
+        @('pi', 'pi'), @('gjc', 'gjc'))) {
+    $key = $pair[0]
+    $exe = $pair[1]
+    $found = Get-CommandPath $exe
+    if ($found) {
+        $detected[$key] = $found
+        Write-Ok "$key found: $found"
+    }
+}
+
+# Read the previously configured runtime so upgrades keep the user's choice.
+function Get-SavedRuntime {
+    $config = Join-Path $env:USERPROFILE '.ouroboros\config.yaml'
+    if (-not (Test-Path $config)) { return '' }
+    $supported = @('claude', 'claude_mcp', 'codex', 'opencode', 'hermes', 'gemini', 'goose', 'kiro', 'copilot', 'pi', 'gjc')
+    $inOrchestrator = $false
+    foreach ($line in (Get-Content $config -ErrorAction SilentlyContinue)) {
+        if ($line -match '^orchestrator:\s*(#.*)?$') { $inOrchestrator = $true; continue }
+        if ($inOrchestrator -and $line -and -not [char]::IsWhiteSpace($line[0])) { break }
+        if ($inOrchestrator) {
+            $m = [regex]::Match($line, '^\s+runtime_backend:\s*["'']?([^"''\s#]+)')
+            if ($m.Success -and ($supported -contains $m.Groups[1].Value)) {
+                # claude is the SDK/MCP 1 profile; claude_mcp is the CLI/MCP 2 worker profile.
+                if ($m.Groups[1].Value -eq 'claude_mcp') { return 'claude-cli' }
+                return $m.Groups[1].Value
+            }
+        }
+    }
+    return ''
+}
+
+function Read-Choice([string]$Prompt, [string]$Default) {
+    $answer = Read-Host $Prompt
+    if ([string]::IsNullOrWhiteSpace($answer)) { return $Default }
+    return $answer.Trim()
+}
+
+function Select-RuntimeInteractive([bool]$AllowNone) {
+    $menu = @(
+        @('1', 'claude', "Claude SDK (MCP 1.x) + skills; MCP 2 server is isolated ($PackageName[claude,tui])"),
+        @('2', 'codex', "Codex plugin artifacts ($PackageName[tui]) -- native Windows: WSL 2 recommended"),
+        @('3', 'hermes', "Hermes agent guides + MCP server ($PackageName[mcp,tui])"),
+        @('4', 'opencode', "OpenCode commands and agent files ($PackageName[tui])"),
+        @('5', 'gemini', "Gemini CLI integration ($PackageName[tui])"),
+        @('6', 'goose', "Goose CLI integration ($PackageName[tui])"),
+        @('7', 'kiro', "Kiro CLI integration ($PackageName[tui])"),
+        @('8', 'copilot', "GitHub Copilot integration ($PackageName[tui])"),
+        @('9', 'pi', "Pi CLI bridge and instruction artifacts ($PackageName[tui])"),
+        @('10', 'gjc', "GJC CLI bridge and instruction artifacts ($PackageName[tui])"),
+        @('11', 'all', "Install every optional integration ($PackageName[all])")
+    )
+    foreach ($item in $menu) { Write-Host ("  {0,2}) {1,-9} {2}" -f $item[0], $item[1], $item[2]) }
+    if ($AllowNone) { Write-Host ("  {0,2}) {1,-9} {2}" -f '0', 'none', 'Base CLI only; choose a backend later') }
+    $choice = Read-Choice 'Select [1]' '1'
+    if ($AllowNone -and $choice -eq '0') { return '' }
+    foreach ($item in $menu) { if ($item[0] -eq $choice) { return $item[1] } }
+    return 'claude'
+}
+
+$selected = ''
+if ($Runtime) {
+    if ($AllRuntimes -notcontains $Runtime -and $Runtime -ne 'all') {
+        Write-Err "unsupported runtime '$Runtime'"
+        Write-Info "Expected one of: $($AllRuntimes -join ', '), all"
+        exit 1
+    }
+    $selected = $Runtime
+    Write-Ok "Runtime: $selected (from -Runtime / OUROBOROS_INSTALL_RUNTIME)"
+} else {
+    $saved = ''
+    if (-not $Reconfigure) { $saved = Get-SavedRuntime }
+    if ($saved) {
+        $selected = $saved
+        Write-Ok "Runtime: $selected (preserved from ~/.ouroboros/config.yaml)"
+        Write-Info 'Re-run with -Reconfigure (or OUROBOROS_INSTALL_RECONFIGURE=1) to choose again.'
+    } elseif ($detected.Count -gt 1) {
+        if (Test-Interactive) {
+            Write-Host ''
+            Write-Host 'Multiple runtimes detected. Pick where Ouroboros should appear first:'
+            $selected = Select-RuntimeInteractive $false
+        } else {
+            Write-Warn 'Multiple runtimes detected in non-interactive mode; defaulting to Claude.'
+            $selected = 'claude'
+        }
+    } elseif ($detected.Count -eq 1) {
+        $selected = @($detected.Keys)[0]
+    } else {
+        if (Test-Interactive) {
+            Write-Host ''
+            Write-Host 'No runtime CLI detected yet. Choose the agent you plan to use:'
+            $selected = Select-RuntimeInteractive $true
+        } else {
+            Write-Warn 'No runtime detected in non-interactive mode; installing the base package.'
+            Write-Info "Pick a backend afterwards with: ouroboros setup --runtime <$($AllRuntimes -join '|')>"
+            $selected = ''
+        }
+    }
+}
+
+if ($selected -eq 'codex') {
+    Write-Warn 'Codex CLI is not supported on native Windows. Setup will not register a persistent MCP server here; use WSL 2 for Codex.'
+}
+
+# Map the backend to the uv --with pins. `tui` ships with every selection so
+# `ouroboros config` works out of the box; `[all]` stays on the MCP 1.x bundle.
+$extraPins = @()
+$extrasLabel = '[tui]'
+$setupRuntime = $selected
+$pythonSpec = $DefaultPythonSpec
+switch ($selected) {
+    'claude' { $extrasLabel = '[claude,tui]'; $extraPins = @('claude-agent-sdk==0.2.139', 'anthropic==0.122.0') }
+    'claude-sdk' { $extrasLabel = '[claude-sdk,tui]'; $extraPins = @('claude-agent-sdk==0.2.139', 'anthropic==0.122.0') }
+    'claude-cli' { $extrasLabel = '[claude-cli,tui]' }
+    'hermes' { $extrasLabel = '[mcp,tui]'; $extraPins = @('mcp==2.0.0') }
+    'all' {
+        $extrasLabel = '[all]'
+        $extraPins = @('claude-agent-sdk==0.2.139', 'anthropic==0.122.0', 'litellm==1.91.0')
+        $pythonSpec = $LiteLLMPythonSpec
+        $setupRuntime = ''
+    }
+    default { }
+}
+if ($setupRuntime) { Write-Ok "Selected backend: $setupRuntime" }
+elseif ($selected -eq 'all') { Write-Ok 'Selected backend: all' }
+else { Write-Info 'Selected backend: none yet' }
+
+# --- 3/4 install ------------------------------------------------------------------
+
+Write-Step '3/4  Installing Ouroboros' "Package: $PackageName$extrasLabel via uv tool install (uv downloads Python $pythonSpec itself)"
+
+$uvArgs = @('tool', 'install', '--upgrade', '--python', $pythonSpec, $PackageName, '--with', $ClickSpec)
+if ($Pre) { $uvArgs += '--prerelease=allow' }
+foreach ($pin in $extraPins) { $uvArgs += @('--with', $pin) }
+$uvArgs += @('--with', 'textual==8.2.8', '--with', 'textual-serve==1.1.3')
+
+Write-Info "Running: uv $($uvArgs -join ' ')"
+if (-not (Invoke-Native 'uv' $uvArgs)) {
+    Write-Err 'uv tool install failed. Fix the error above and run the installer again.'
+    exit 1
+}
+
+# Put the tool bin directory on PATH: persistently (uv edits the user PATH) and
+# for this session, so setup below runs the binary that was just installed.
+$toolBin = ((& uv tool dir --bin 2>$null) -join '').Trim()
+if (-not (Invoke-Native 'uv' @('tool', 'update-shell'))) {
+    Write-Warn "Could not update the user PATH automatically. Add this directory to PATH: $toolBin"
+}
+if ($toolBin) { Add-SessionPathFront $toolBin }
+$ouroborosExe = $null
+if ($toolBin -and (Test-Path (Join-Path $toolBin 'ouroboros.exe'))) {
+    $ouroborosExe = Join-Path $toolBin 'ouroboros.exe'
+} else {
+    $ouroborosExe = Get-CommandPath 'ouroboros'
+}
+if (-not $ouroborosExe) {
+    Write-Err "Ouroboros was installed but 'ouroboros' is not on PATH. Add $toolBin to PATH, open a new window, and run: ouroboros setup --runtime <backend>"
+    exit 1
+}
+Write-Ok "Installed: $((& $ouroborosExe --version 2>$null) -join ' ')"
+
+# Optional: the Claude Code plugin hooks look for python3/python on PATH and
+# skip themselves when none is found. Skills fall back to uv on their own, so
+# this is a convenience, not a requirement, and its failure is not fatal.
+function Test-PythonAtLeast([string]$Exe) {
+    $found = Get-CommandPath $Exe
+    if (-not $found) { return $false }
+    # The Microsoft Store alias python.exe/python3.exe prints a hint and fails
+    # here, so it counts as absent instead of as an interpreter.
+    $out = (& $found -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>$null) -join ''
+    if ($LASTEXITCODE -ne 0 -or -not ($out -match '^\d+\.\d+$')) { return $false }
+    return ([version]$out -ge $MinPython)
+}
+if ((Test-PythonAtLeast 'python3') -or (Test-PythonAtLeast 'python')) {
+    Write-Ok "Python >= $MinPython found on PATH (used by the Claude Code plugin hooks)"
+} else {
+    Write-Info "No Python >= $MinPython on PATH; installing a uv-managed Python $HookPythonVersion for the plugin hooks..."
+    if (Invoke-Native 'uv' @('python', 'install', '--default', $HookPythonVersion)) {
+        Write-Ok "Python $HookPythonVersion installed (python/python3 in $((& uv python dir --bin 2>$null) -join ''))"
+        Write-Info 'If `python` still opens the Microsoft Store, turn off its App execution alias in Settings > Apps > Advanced app settings.'
+    } else {
+        Write-Warn 'Could not install a default Python; plugin hooks will skip themselves until one is on PATH. Skills keep working through uv.'
+    }
+}
+
+# --- 4/4 setup ------------------------------------------------------------------
+
+Write-Step '4/4  Wiring local integrations' 'Creates config and runtime-specific files when a backend was selected.'
+if ($setupRuntime) {
+    Write-Info "Running: ouroboros setup --runtime $setupRuntime --non-interactive"
+    if (-not (Invoke-Native $ouroborosExe @('setup', '--runtime', $setupRuntime, '--non-interactive'))) {
+        Write-Warn 'Runtime setup failed; installation is incomplete. Fix the error above and re-run setup.'
+        exit $LASTEXITCODE
+    }
+} else {
+    Write-Info 'No backend selected; skipping runtime setup.'
+}
+
+# Refresh artifacts for every detected runtime (presence-gated, never touches
+# MCP registrations or config), so upgrades do not leave other hosts stale.
+Write-Info 'Refreshing runtime artifacts for detected runtimes'
+if (-not (Invoke-Native $ouroborosExe @('setup', 'refresh'))) {
+    Write-Warn 'Artifact refresh skipped; run: ouroboros setup refresh'
+}
+
+if ($detected.ContainsKey('claude')) {
+    Write-Host ''
+    Write-Host '  Claude Code skills' -ForegroundColor Blue
+    Write-Info 'Installing Ouroboros skills via Claude plugin marketplace...'
+    Invoke-Native 'claude' @('plugin', 'marketplace', 'add', 'Q00/ouroboros') | Out-Null
+    Invoke-Native 'claude' @('plugin', 'marketplace', 'update', 'ouroboros') | Out-Null
+    if (Invoke-Native 'claude' @('plugin', 'install', 'ouroboros@ouroboros')) {
+        # `install` is a no-op for an already-installed plugin; `update` moves it to the latest version.
+        Invoke-Native 'claude' @('plugin', 'update', 'ouroboros@ouroboros') | Out-Null
+        Write-Ok 'Skills installed'
+    } else {
+        Write-Warn 'Skills skipped. Manual install: claude plugin marketplace add Q00/ouroboros; claude plugin install ouroboros@ouroboros'
+    }
+}
+
+Write-Host ''
+Write-Host 'Done! Ouroboros is ready.' -ForegroundColor Green
+Write-Host ''
+Write-Host 'Get started'
+Write-Info 'Open a NEW PowerShell window (PATH changes apply there), then in your AI coding agent run: > ooo interview "your idea here"'
+Write-Info 'Or from the terminal: ouroboros init start "your idea here"'
+if ($setupRuntime) { Write-Info "Current backend: $setupRuntime" }
+Write-Info "Switch backend later: ouroboros setup --runtime <$($AllRuntimes -join '|')>"
+Write-Host 'Model settings'
+Write-Info 'Inside your AI agent: > ooo config   (opens in your browser)'
+Write-Info 'From this terminal:  ouroboros config   (full-screen TUI; use Windows Terminal, not cmd.exe)'
+Write-Host ''
+Write-Host 'Like Ouroboros? Star the repo: https://github.com/Q00/ouroboros'

--- a/tests/unit/scripts/test_install_ps1.py
+++ b/tests/unit/scripts/test_install_ps1.py
@@ -1,0 +1,83 @@
+"""Windows installer (scripts/install.ps1) parity and syntax checks.
+
+The PowerShell installer cannot run in CI (no Windows runner), so these tests
+pin the two things that drift silently: the dependency pins it passes to
+`uv tool install` must equal install.sh's, and the file must still parse.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+import pytest
+
+from tests.unit.scripts.test_install_runtime_selection import _expected_pins_for_extras
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+_PIN_RE = re.compile(r"\b([A-Za-z0-9][A-Za-z0-9_.-]*==[0-9][0-9A-Za-z.]*)")
+
+
+def _pins(path: Path) -> set[str]:
+    return set(_PIN_RE.findall(path.read_text(encoding="utf-8")))
+
+
+def test_ps1_pins_match_install_sh() -> None:
+    sh_pins = _pins(INSTALL_SH)
+    ps1_pins = _pins(INSTALL_PS1)
+    assert sh_pins, "no pins found in install.sh — parity check inert"
+    assert ps1_pins == sh_pins, (
+        "install.ps1 pins drifted from install.sh.\n"
+        f"only in install.sh:  {sorted(sh_pins - ps1_pins)}\n"
+        f"only in install.ps1: {sorted(ps1_pins - sh_pins)}"
+    )
+
+
+def test_ps1_pins_match_pyproject() -> None:
+    ps1_text = INSTALL_PS1.read_text(encoding="utf-8")
+    expected = _expected_pins_for_extras("claude", "claude-sdk", "mcp", "tui", "litellm")
+    assert expected, "no pyproject pins discovered — parity check inert"
+    drifted = sorted(pin for pin in expected if pin not in ps1_text)
+    assert not drifted, f"install.ps1 is missing pyproject pins: {drifted}"
+
+
+def test_ps1_shares_python_and_click_contract_with_install_sh() -> None:
+    sh_text = INSTALL_SH.read_text(encoding="utf-8")
+    ps1_text = INSTALL_PS1.read_text(encoding="utf-8")
+    for var in ("CLICK_SPEC", "DEFAULT_PYTHON_SPEC", "LITELLM_PYTHON_SPEC"):
+        match = re.search(rf'^{var}="([^"]+)"', sh_text, re.MULTILINE)
+        assert match is not None, f"{var} missing from install.sh"
+        assert f"'{match.group(1)}'" in ps1_text, (
+            f"install.ps1 does not carry install.sh's {var}={match.group(1)!r}"
+        )
+
+
+def test_ps1_declares_no_telemetry() -> None:
+    """TELEMETRY.md promises the Windows installer sends nothing; keep it honest."""
+    text = INSTALL_PS1.read_text(encoding="utf-8")
+    assert "sends no telemetry" in text
+    assert "posthog" not in text.lower()
+    assert "install_completed" not in text
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason="pwsh not installed")
+def test_ps1_parses_under_pwsh() -> None:
+    script = (
+        "$errors = $null; $tokens = $null; "
+        "[System.Management.Automation.Language.Parser]::ParseFile("
+        f"'{INSTALL_PS1}', [ref]$tokens, [ref]$errors) | Out-Null; "
+        "if ($errors.Count -gt 0) { $errors | ForEach-Object { $_.ToString() }; exit 1 }"
+    )
+    result = subprocess.run(
+        ["pwsh", "-NoProfile", "-NonInteractive", "-Command", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/unit/scripts/test_install_ps1.py
+++ b/tests/unit/scripts/test_install_ps1.py
@@ -57,12 +57,23 @@ def test_ps1_shares_python_and_click_contract_with_install_sh() -> None:
         )
 
 
-def test_ps1_declares_no_telemetry() -> None:
-    """TELEMETRY.md promises the Windows installer sends nothing; keep it honest."""
+def test_ps1_emits_no_installer_events() -> None:
+    """TELEMETRY.md: install.ps1 emits neither installer event itself.
+
+    The `ouroboros setup` subprocesses it runs are ordinary CLI invocations and
+    keep their normal telemetry controls, so this only pins the installer's own
+    behavior: no PostHog client, no capture call, and no event name outside the
+    contract comment.
+    """
     text = INSTALL_PS1.read_text(encoding="utf-8")
-    assert "sends no telemetry" in text
+    assert "emits no installer events of its own" in text
     assert "posthog" not in text.lower()
-    assert "install_completed" not in text
+    assert "Invoke-RestMethod" not in text.replace(
+        "Invoke-RestMethod -Uri 'https://astral.sh/uv/install.ps1'", ""
+    ), "install.ps1 must not make network calls beyond fetching the uv installer"
+    body = "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
+    assert "install_started" not in body
+    assert "install_completed" not in body
 
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason="pwsh not installed")


### PR DESCRIPTION
## Summary

Adds `scripts/install.ps1` so a Windows machine with no Python, uv, or Git can install Ouroboros with one PowerShell command, and documents that path next to the existing `curl | bash` one-liner. `install.sh` never bootstraps uv, so a Python-less Windows user had no entry point short of setting up WSL 2 first.

```powershell
irm https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.ps1 | iex
```

## Review boundary

- **User problem**: A native Windows user without Python/uv/Git cannot install Ouroboros with one command; the README only shows the bash one-liner.
- **Inputs and execution conditions**: Windows PowerShell 5.1 or pwsh 7 on native Windows, run as `irm | iex` or as a bound scriptblock with `-Runtime/-Reconfigure/-Pre`. Options also come from `OUROBOROS_INSTALL_RUNTIME`, `OUROBOROS_INSTALL_RECONFIGURE`, `OUROBOROS_INSTALL_PRE` (same names as `install.sh`). Network access to winget/astral.sh/PyPI.
- **Promised contract**: (1) Git >= 2.36 and uv are present after step 1 or the script exits non-zero with remediation. (2) `uv tool install ouroboros-ai` is invoked with exactly the pins `install.sh` uses (`click`, `textual`, `textual-serve`, and the per-backend `claude-agent-sdk`/`anthropic`/`mcp`/`litellm` pins); `[all]` uses the `>=3.12,<3.14` Python spec. (3) Backend resolution order equals `install.sh`: explicit > saved `~/.ouroboros/config.yaml` runtime (`claude_mcp` → `claude-cli`) > single detected CLI > prompt (non-interactive defaults match the bash script). (4) `ouroboros setup --runtime <b> --non-interactive` failure exits with that status; `setup refresh` and the Claude plugin install are non-fatal, as in `install.sh`. (5) The script emits no installer-owned events (`install_started`/`install_completed`); its `ouroboros setup` calls are ordinary CLI invocations and keep the normal `command_run` telemetry controls, same as under `install.sh`.
- **Implementation boundary and owner**: New file `scripts/install.ps1` plus docs (README en/ko/zh-CN, `docs/getting-started.md`, `docs/platform-support.md`, `TELEMETRY.md`, `UNINSTALL.md`) and `tests/unit/scripts/test_install_ps1.py`. No Python source changes; no change to `install.sh`, the plugin manifest, or `ouroboros setup`. Owner: installer/docs (maintainer).
- **Non-goals**: Installer-owned telemetry events (`install_started`/`install_completed`) on Windows — the bash implementation validates config through the real schema and porting it blind risks polluting the metric; documented as absent in `TELEMETRY.md`. Suppressing CLI telemetry inside the installer's `setup` subprocesses is also out of scope: it would diverge from `install.sh` and override the user's default silently. Native-Windows Codex support (still WSL 2; the script warns). The optional `ouroboros config` GUI prompt at the end of `install.sh`. A single-file exe (#2050). Changing native Windows from "experimental".
- **Evidence**: `tests/unit/scripts/test_install_ps1.py` — pin set equality with `install.sh`, pyproject pin coverage, Python/click spec parity, no-telemetry assertion, and a `pwsh` parse check (runs on ubuntu CI where pwsh is present). Locally with portable pwsh 7.6.5: parse clean, PSScriptAnalyzer clean apart from intentional `Write-Host` and the uv-fallback `Invoke-Expression`; `irm | iex` and scriptblock-bound parameter forms both verified to bind `-Runtime/-Reconfigure` and the env var; `Get-SavedRuntime` maps a fixture `runtime_backend: "claude_mcp"` to `claude-cli`. **Not yet run end-to-end on a real Windows machine** — winget flow, `uv python install --default` placement, and the Microsoft Store `python` alias interaction need a live check before this is called more than experimental.

## Test plan

- [x] `uv run pytest tests/unit/scripts/test_install_ps1.py tests/unit/scripts/test_install_runtime_selection.py -q` — 125 passed
- [x] `uv run ruff check` / `ruff format --check` clean on the new test
- [x] `uv run mypy src/` — no `src/` changes
- [ ] End-to-end run on a native Windows machine (winget-fresh) — follow-up before promoting beyond experimental

## Related issues

Refs #2308
Related: #2050

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145uCSmu29DhCtDR5yGkLQd
