### PR TITLE
chore(release): v0.52.0

### DIFF
--- a/.claude-plugin/.mcp.json
+++ b/.claude-plugin/.mcp.json
@@ -7,7 +7,7 @@
         "--python",
         ">=3.12",
         "--from",
-        "ouroboros-ai[mcp]==0.51.17",
+        "ouroboros-ai[mcp]==0.52.0",
         "ouroboros",
         "mcp",
         "serve",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "ouroboros",
       "description": "Sits in front of Claude Code and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
-      "version": "0.51.17",
+      "version": "0.52.0",
       "author": {
         "name": "Q00",
         "email": "jqyu.lee@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros",
-  "version": "0.51.17",
+  "version": "0.52.0",
   "description": "Sits in front of Claude Code and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
   "author": {
     "name": "Q00",

--- a/.claude-plugin/skills/setup/SKILL.md
+++ b/.claude-plugin/skills/setup/SKILL.md
@@ -296,7 +296,7 @@ A backup will be created: CLAUDE.md.bak
 **If "Preview first", show:**
 ````markdown
 <!-- ooo:START -->
-<!-- ooo:VERSION:0.51.17 -->
+<!-- ooo:VERSION:0.52.0 -->
 # Ouroboros — Specification-First AI Development
 
 > Before telling AI what to build, define what should be built.

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros",
-  "version": "0.51.17",
+  "version": "0.52.0",
   "description": "Sits in front of Codex CLI and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
   "author": {
     "name": "Q00",

--- a/.mcp.codex.json
+++ b/.mcp.codex.json
@@ -7,7 +7,7 @@
         "--python",
         ">=3.12",
         "--from",
-        "ouroboros-ai[mcp]==0.51.17",
+        "ouroboros-ai[mcp]==0.52.0",
         "ouroboros",
         "mcp",
         "serve",

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -296,7 +296,7 @@ A backup will be created: CLAUDE.md.bak
 **If "Preview first", show:**
 ````markdown
 <!-- ooo:START -->
-<!-- ooo:VERSION:0.51.17 -->
+<!-- ooo:VERSION:0.52.0 -->
 # Ouroboros — Specification-First AI Development
 
 > Before telling AI what to build, define what should be built.


### PR DESCRIPTION
Minor version bump: `v0.51.17` → `v0.52.0`.

Metadata-only change. `scripts/sync-plugin-version.py --write --version 0.52.0` updated the plugin manifests and the setup skill version marker; no `src/` or `tests/` files are touched. The package version itself is derived by `hatch-vcs` from the `v0.52.0` tag, which will be created on the merged `main` commit.

## What's Changed

### Features
- Default compatible installs to MCP v2 in `ooo setup` (#2307)
- Proactive MCP activation routing + verification failure analytics (#2295)

### Bug Fixes
- Migrate GJC backend from RPC to SDK coordinator (#2302)
- Make GJC bridge setup fail closed (#2288)

### Testing
- Make orchestrator shell execution portable on Windows (#2306)

**Full Changelog**: https://github.com/Q00/ouroboros/compare/v0.51.17...v0.52.0

## Evidence

- `uv run ruff format src/ tests/` — 1398 files unchanged
- `uv run ruff check src/ tests/ --fix` — all checks passed
- `uv run mypy src/ouroboros` — no issues in 614 source files
- `uv run pytest` — 21744 passed; 3 local failures are macOS-environment-only (`test_picker_projection_write_and_disk_budgets` is a load-sensitive perf-ratio benchmark, and `test_undecodable_filename_exports_and_applies` fails because APFS rejects non-UTF-8 filenames with `Errno 92`). The `Tests` workflow on `main` at 229144db passed on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMntndqRHb4skiT4WchFwf