### PR TITLE
fix(orchestrator): preflight the runtime before dispatch; stop retrying auth/provider 5xx

### DIFF
--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -623,6 +623,7 @@ async def _run_orchestrator(
         OrchestratorRunner,
         create_agent_runtime,
         create_agent_runtime_async,
+        preflight_agent_runtime,
         resolve_agent_runtime_backend,
     )
     from ouroboros.orchestrator.session import SessionRepository
@@ -750,6 +751,10 @@ async def _run_orchestrator(
         model=execution_model,
         cwd=Path(workspace.effective_cwd) if workspace else project_dir,
     )
+    runtime_blocker = preflight_agent_runtime(adapter)
+    if runtime_blocker is not None:
+        print_error(f"Runtime '{resolved_runtime_backend}' cannot execute: {runtime_blocker}")
+        raise typer.Exit(1)
     runner = OrchestratorRunner(
         adapter,
         event_store,

--- a/src/ouroboros/core/retry.py
+++ b/src/ouroboros/core/retry.py
@@ -117,6 +117,25 @@ def _pattern_matcher(pattern: str) -> re.Pattern[str]:
     return re.compile(source, re.MULTILINE)
 
 
+# A gateway can wrap a configuration failure in a 5xx: a proxy answering
+# "503 auth_unavailable: no auth available" or "502 unknown provider for model"
+# answers the same way on every retry. These override the status-code match so
+# the run fails once with the real reason instead of burning the retry budget
+# and every route on an AC that cannot start.
+NON_TRANSIENT_OVERRIDE_PATTERNS: tuple[str, ...] = (
+    "auth_unavailable",
+    "no auth available",
+    "unknown provider",
+    "unknown model",
+    "invalid api key",
+    "invalid_api_key",
+    "authentication_error",
+    "unauthorized",
+    "forbidden",
+    "permission denied",
+)
+
+
 def is_transient_error(
     message: str,
     *,
@@ -124,6 +143,8 @@ def is_transient_error(
 ) -> bool:
     """Return whether *message* looks like a transient, retry-worthy failure."""
     lowered = message.lower()
+    if any(pattern in lowered for pattern in NON_TRANSIENT_OVERRIDE_PATTERNS):
+        return False
     for pattern in (*BASE_TRANSIENT_PATTERNS, *extra_patterns):
         if _pattern_matcher(pattern).search(lowered):
             return True
@@ -212,6 +233,7 @@ def retry_async(
 
 __all__ = [
     "BASE_TRANSIENT_PATTERNS",
+    "NON_TRANSIENT_OVERRIDE_PATTERNS",
     "DEFAULT_JITTER_RATIO",
     "MIN_WAIT_SECONDS",
     "is_transient_error",

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -72,7 +72,11 @@ from ouroboros.mcp.types import (
     MCPToolResult,
     ToolInputType,
 )
-from ouroboros.orchestrator import create_agent_runtime, create_agent_runtime_async
+from ouroboros.orchestrator import (
+    create_agent_runtime,
+    create_agent_runtime_async,
+    preflight_agent_runtime,
+)
 from ouroboros.orchestrator.adapter import (
     DELEGATED_PARENT_CWD_ARG,
     DELEGATED_PARENT_EFFECTIVE_TOOLS_ARG,
@@ -1602,6 +1606,12 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                             else {}
                         ),
                     )
+                    runtime_blocker = preflight_agent_runtime(agent_adapter)
+                    if runtime_blocker is not None:
+                        raise RuntimeError(
+                            f"Runtime '{self.agent_runtime_backend}' cannot execute: "
+                            f"{runtime_blocker}"
+                        )
                     # Host-driven execution: attach the composed bridge and the
                     # job identity its dispatch records correlate under. A
                     # retained-owner resume keeps the adapter this already

--- a/src/ouroboros/orchestrator/__init__.py
+++ b/src/ouroboros/orchestrator/__init__.py
@@ -143,6 +143,7 @@ from ouroboros.orchestrator.runner import (
 from ouroboros.orchestrator.runtime_factory import (
     create_agent_runtime,
     create_agent_runtime_async,
+    preflight_agent_runtime,
     resolve_agent_runtime_backend,
 )
 from ouroboros.orchestrator.session import (
@@ -167,6 +168,7 @@ __all__ = [
     "TaskResult",
     "create_agent_runtime",
     "create_agent_runtime_async",
+    "preflight_agent_runtime",
     "resolve_agent_runtime_backend",
     # Session
     "SessionRepository",

--- a/src/ouroboros/orchestrator/adapter.py
+++ b/src/ouroboros/orchestrator/adapter.py
@@ -22,6 +22,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from enum import StrEnum
+import importlib.util
 import math
 import os
 from pathlib import Path
@@ -1191,6 +1192,23 @@ class ClaudeAgentAdapter:
             cli_path=self._cli_path,
             shared_rate_limit_enabled=self._rate_limit_bucket.enabled,
         )
+
+    def preflight(self) -> str | None:
+        """Return why this runtime cannot execute yet, or ``None`` when it can.
+
+        The SDK import happens lazily inside ``execute_task``; without this
+        check a missing ``claude-agent-sdk`` surfaces only as a per-AC error
+        result, which the executor then retries and route-escalates for every
+        AC before giving up. Checked once, before any dispatch, it is a single
+        actionable configuration error instead.
+        """
+        if importlib.util.find_spec("claude_agent_sdk") is None:
+            return (
+                "Claude Agent SDK is not installed for the 'claude' runtime. "
+                "Install it (pip install claude-agent-sdk, or the ouroboros-ai[claude] "
+                "extra) or use the dependency-free CLI worker: --runtime claude-cli."
+            )
+        return None
 
     # -- AgentRuntime protocol properties ----------------------------------
 

--- a/src/ouroboros/orchestrator/runtime_factory.py
+++ b/src/ouroboros/orchestrator/runtime_factory.py
@@ -342,6 +342,21 @@ def create_agent_runtime(
     )
 
 
+def preflight_agent_runtime(runtime: AgentRuntime) -> str | None:
+    """Return the runtime's blocking configuration problem, if it reports one.
+
+    Runtimes that can tell before the first dispatch that they will fail on
+    every AC (a missing SDK, an unusable CLI) expose ``preflight()``. Callers
+    surface the reason once, up front, instead of paying for an AC dispatch,
+    its retries, and route escalation to learn the same thing.
+    """
+    probe = getattr(runtime, "preflight", None)
+    if probe is None:
+        return None
+    reason = probe()
+    return reason if isinstance(reason, str) and reason.strip() else None
+
+
 async def create_agent_runtime_async(
     runtime_factory: Callable[..., AgentRuntime] = create_agent_runtime,
     **kwargs: object,
@@ -353,5 +368,6 @@ async def create_agent_runtime_async(
 __all__ = [
     "create_agent_runtime",
     "create_agent_runtime_async",
+    "preflight_agent_runtime",
     "resolve_agent_runtime_backend",
 ]

--- a/tests/unit/orchestrator/test_runtime_preflight.py
+++ b/tests/unit/orchestrator/test_runtime_preflight.py
@@ -1,0 +1,91 @@
+"""Runtime preflight: a runtime that cannot start says so once, before dispatch.
+
+In the July event store, "Claude Agent SDK is not installed" accounted for 15
+AC-session failures: the SDK import happens lazily inside ``execute_task``, so
+every AC paid for a dispatch, its retries, and route escalation to learn the
+same configuration fact. ``preflight_agent_runtime`` asks the runtime up front.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from ouroboros.core.retry import NON_TRANSIENT_OVERRIDE_PATTERNS, is_transient_error
+from ouroboros.orchestrator.adapter import ClaudeAgentAdapter
+from ouroboros.orchestrator.runtime_factory import preflight_agent_runtime
+
+
+class TestClaudeAdapterPreflight:
+    def test_missing_sdk_is_reported_with_the_two_remedies(self) -> None:
+        adapter = ClaudeAgentAdapter(cwd="/tmp/project")
+        with patch("ouroboros.orchestrator.adapter.importlib.util.find_spec", return_value=None):
+            reason = adapter.preflight()
+            assert preflight_agent_runtime(adapter) == reason
+
+        assert reason is not None
+        assert "claude-agent-sdk" in reason
+        assert "--runtime claude-cli" in reason
+
+    def test_installed_sdk_passes_preflight(self) -> None:
+        adapter = ClaudeAgentAdapter(cwd="/tmp/project")
+        with patch(
+            "ouroboros.orchestrator.adapter.importlib.util.find_spec", return_value=object()
+        ):
+            assert adapter.preflight() is None
+            assert preflight_agent_runtime(adapter) is None
+
+
+class TestPreflightHelper:
+    def test_runtime_without_preflight_is_not_blocked(self) -> None:
+        class Runtime:
+            pass
+
+        assert preflight_agent_runtime(Runtime()) is None  # type: ignore[arg-type]
+
+    def test_blank_or_non_string_reasons_are_ignored(self) -> None:
+        class Blank:
+            def preflight(self) -> str:
+                return "   "
+
+        class Wrong:
+            def preflight(self) -> object:
+                return {"reason": "x"}
+
+        assert preflight_agent_runtime(Blank()) is None  # type: ignore[arg-type]
+        assert preflight_agent_runtime(Wrong()) is None  # type: ignore[arg-type]
+
+    def test_reason_is_passed_through(self) -> None:
+        class Blocked:
+            def preflight(self) -> str:
+                return "CLI missing"
+
+        assert preflight_agent_runtime(Blocked()) == "CLI missing"  # type: ignore[arg-type]
+
+
+class TestNonTransientOverrides:
+    """A 5xx that wraps a configuration failure must not be retried."""
+
+    def test_proxy_auth_and_provider_failures_are_not_transient(self) -> None:
+        for message in (
+            "unexpected status 503 Service Unavailable: auth_unavailable: no auth available "
+            "(providers=codex, model=gpt-5.6)",
+            "unexpected status 502 Bad Gateway: unknown provider for model gpt-4o, "
+            "url: https://proxy.example/v1/responses",
+            "HTTP 401 Unauthorized: invalid_api_key",
+            "status 403 Forbidden: permission denied for this model",
+        ):
+            assert is_transient_error(message) is False, message
+
+    def test_genuine_gateway_failures_stay_transient(self) -> None:
+        for message in (
+            "unexpected status 503 Service Unavailable",
+            "HTTP 502 Bad Gateway",
+            "rate_limit_error: too many requests (429)",
+            "overloaded_error: Anthropic is overloaded (529)",
+            "stream disconnected before completion: connection reset",
+        ):
+            assert is_transient_error(message) is True, message
+
+    def test_override_vocabulary_is_closed_and_lowercase(self) -> None:
+        assert NON_TRANSIENT_OVERRIDE_PATTERNS
+        assert all(pattern == pattern.lower() for pattern in NON_TRANSIENT_OVERRIDE_PATTERNS)


### PR DESCRIPTION
## Summary

Third lever of #2311 (L2), independent of the #2312→#2314 stack. Environment faults are ~18% of AC-session failures in the July event store, and each one was discovered only after every AC had been dispatched, retried, and route-escalated. This PR surfaces them once, up front, and stops retrying the ones that cannot change.

## Review boundary

- **User problem**: (a) `ouroboros run --runtime claude` without `claude-agent-sdk` installed blocks all ACs with `Claude Agent SDK is not installed … routes_exhausted` after paying for dispatch and retries (reproduced on a fresh cli-todo seed). (b) A gateway 5xx that wraps a configuration failure (`503 … auth_unavailable`, `502 … unknown provider for model`) is retried up to the transient budget on every AC.
- **Inputs and execution conditions**: `ouroboros run` and `ouroboros_execute_seed` runtime construction; `ClaudeAgentAdapter` (SDK runtime); every caller of `core.retry.is_transient_error`.
- **Promised contract**: (1) `ClaudeAgentAdapter.preflight()` returns an actionable reason when `claude_agent_sdk` is not importable, naming both remedies (install, or `--runtime claude-cli`); `None` otherwise. (2) `preflight_agent_runtime(runtime)` returns that reason for any runtime exposing `preflight()`; runtimes without it, blank or non-string reasons → `None` (never blocks). (3) `ouroboros run` prints `Runtime '<backend>' cannot execute: <reason>` and exits 1 **before** any AC dispatch; `ouroboros_execute_seed` fails the tool call with the same message through its existing `Seed execution failed:` path. (4) `is_transient_error` returns `False` when the message contains any of a closed lowercase vocabulary (`auth_unavailable`, `no auth available`, `unknown provider`, `unknown model`, `invalid api key`, `invalid_api_key`, `authentication_error`, `unauthorized`, `forbidden`, `permission denied`), before the status-code match; genuine 5xx/429/529/connection errors are unchanged.
- **Implementation boundary and owner**: `orchestrator/adapter.py` (one method), `orchestrator/runtime_factory.py` + `orchestrator/__init__.py` (helper + export), `cli/commands/run.py` (4 lines), `mcp/tools/execution_handlers.py` (6 lines; grandfathered budget 2869, now 2847), `core/retry.py`. Runtime *construction* is unchanged, so MCP server boot with an SDK-less `claude` config still succeeds; only execution is gated.
- **Non-goals**: preflighting other runtimes (the hook is there; codex/opencode/etc. keep their own probes), classifying every provider error string, changing retry counts/backoff.
- **Evidence**: `tests/unit/orchestrator/test_runtime_preflight.py` (missing/installed SDK, helper semantics, non-transient vs transient message matrix); `test_runtime_factory.py`, `core/`, `providers/`, `test_adapter.py`, retry/resume suites pass. `tests/unit/cli/test_setup.py` / `test_mcp_doctor.py` show 24 failures in my worktree venv that reproduce identically on an untouched sibling worktree and pass on the main checkout — environment (dev-build path) not this change; CI is the arbiter.

## Test plan

- [x] targeted + wider unit suites (see Evidence); ruff/mypy; module-size ratchet
- [x] manual: `ouroboros run seed.yaml --runtime claude` on an SDK-less env now exits 1 with the remedy instead of blocking 4 ACs

## Related issues

Refs #2311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145uCSmu29DhCtDR5yGkLQd