### PR TITLE
feat(install): install uv on macOS/Linux when nothing else can install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,6 +9,10 @@
 #      unless OUROBOROS_INSTALL_RECONFIGURE=1 (or --reconfigure flag) is set.
 #   3. Interactive prompt when stdin is a TTY.
 #   4. Auto-detect single CLI on PATH; default to claude in pipe mode.
+#
+# When no usable installer is present, uv is fetched from astral.sh because it
+# carries its own Python. Set OUROBOROS_INSTALL_BOOTSTRAP_UV=0 to decline that
+# and get installation instructions instead.
 set -euo pipefail
 
 PACKAGE_NAME="ouroboros-ai"
@@ -19,6 +23,7 @@ LITELLM_PYTHON_SPEC=">=3.12,<3.14"
 IS_LOCAL=false
 RECONFIGURE="${OUROBOROS_INSTALL_RECONFIGURE:-}"
 EXPLICIT_RUNTIME="${OUROBOROS_INSTALL_RUNTIME:-}"
+BOOTSTRAP_UV="${OUROBOROS_INSTALL_BOOTSTRAP_UV:-1}"
 
 if [ -z "${NO_COLOR:-}" ] && { [ -t 1 ] || [ -n "${FORCE_COLOR:-}" ]; } && { [ "${TERM:-}" != "dumb" ] || [ -n "${FORCE_COLOR:-}" ]; }; then
   BOLD="$(printf '\033[1m')"
@@ -893,7 +898,7 @@ HAS_UV=false
 HAS_PIPX=false
 PYTHON=""
 
-_step "1/4  Checking Python tooling" "Prefer uv, then pipx, then pip."
+_step "1/4  Checking Python tooling" "Prefer uv, then pipx, then pip. uv is installed when none of them can run."
 
 if command -v uv &>/dev/null; then
   HAS_UV=true
@@ -927,6 +932,52 @@ _python_requirement_message() {
   else
     printf 'Python %s' "$DEFAULT_PYTHON_SPEC"
   fi
+}
+
+_bootstrap_uv() {
+  # uv carries its own Python, so installing uv is the single move that unblocks
+  # a machine with no usable interpreter — the case that previously just exited.
+  # install.ps1 does the same on Windows (winget, then this script as fallback);
+  # here the script is the only path needing no package manager and no
+  # privileges. Everything that already works — an existing uv, or pipx with a
+  # supported Python — reaches its installer before this is ever called.
+  if [ "$BOOTSTRAP_UV" = "0" ]; then
+    # Fetching and running an installer from the network is the one thing here
+    # a caller may reasonably refuse; declining returns to the instructions.
+    return 1
+  fi
+  if ! command -v curl >/dev/null 2>&1; then
+    _err "curl is required to install uv automatically."
+    return 1
+  fi
+
+  _blank
+  _say "${BOLD}Installing uv${RESET} — it provides its own Python, so none needs to be installed separately."
+  _info "Source: https://astral.sh/uv/install.sh"
+  if ! curl -LsSf https://astral.sh/uv/install.sh | sh; then
+    _err "uv installation failed."
+    return 1
+  fi
+
+  # The installer does not touch the running shell's PATH, so look where it
+  # actually writes before deciding it failed.
+  local candidate
+  for candidate in "${XDG_BIN_HOME:-}" "${CARGO_HOME:-$HOME/.cargo}/bin" "$HOME/.local/bin"; do
+    if [ -n "$candidate" ] && [ -x "$candidate/uv" ]; then
+      PATH="$candidate:$PATH"
+      export PATH
+      break
+    fi
+  done
+
+  if ! command -v uv >/dev/null 2>&1; then
+    _err "uv was installed but is not on PATH yet."
+    _info "Open a new shell and run this installer again."
+    return 1
+  fi
+
+  _ok "uv installed: $(uv --version)"
+  return 0
 }
 
 _print_python_install_remediation() {
@@ -1211,12 +1262,21 @@ if [ "$HAS_UV" = false ]; then
     done
     if [ -z "$PYTHON" ]; then
       _blank
-      _err "pipx requires $(_python_requirement_message), but none was found."
-      _blank
-      _print_python_install_remediation
-      exit 1
+      _warn "pipx requires $(_python_requirement_message), but none was found."
+      if _bootstrap_uv; then
+        HAS_UV=true
+        HAS_PIPX=false
+      else
+        _blank
+        _err "pipx requires $(_python_requirement_message), but none was found."
+        _blank
+        _print_python_install_remediation
+        exit 1
+      fi
     fi
-    _ok "Python found: $($PYTHON --version)"
+    if [ "$HAS_UV" = false ]; then
+      _ok "Python found: $($PYTHON --version)"
+    fi
   else
     # pip fallback: prefer explicit compatible versions for constrained profiles.
     if [ "$INSTALL_PYTHON_SPEC" = "$LITELLM_PYTHON_SPEC" ]; then
@@ -1232,12 +1292,20 @@ if [ "$HAS_UV" = false ]; then
     done
     if [ -z "$PYTHON" ]; then
       _blank
-      _err "No installer found: uv, pipx, or $(_python_requirement_message)."
-      _blank
-      _print_python_install_remediation
-      exit 1
+      _warn "No installer found: uv, pipx, or $(_python_requirement_message)."
+      if _bootstrap_uv; then
+        HAS_UV=true
+      else
+        _blank
+        _err "No installer found: uv, pipx, or $(_python_requirement_message)."
+        _blank
+        _print_python_install_remediation
+        exit 1
+      fi
     fi
-    _ok "Python found: $($PYTHON --version)"
+    if [ "$HAS_UV" = false ]; then
+      _ok "Python found: $($PYTHON --version)"
+    fi
   fi
 fi
 

--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -171,6 +171,10 @@ exit 0
             TOOL_BIN_VAR: str(tool_bin_dir),
             OUROBOROS_STUB_VAR: str(_cached_executable(_OUROBOROS_STUB)),
             CAPTURES_LOG_VAR: str(tmp_path / "telemetry.log"),
+            # The installer fetches uv from astral.sh when nothing else can
+            # install. Off by default here so no test reaches the network by
+            # accident; the bootstrap tests below opt back in with a fake curl.
+            "OUROBOROS_INSTALL_BOOTSTRAP_UV": "0",
         }
     )
     if env:
@@ -2745,3 +2749,98 @@ def test_installer_survives_a_failing_dsh(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     assert "install skipped" in result.stdout
     assert "Manual install: dsh plugin --profile web add" in result.stdout
+
+
+def _uv_bootstrap_curl(installed_uv: str) -> str:
+    """Fake curl that plays astral.sh's installer: emit a script that drops a
+    working `uv` into ~/.local/bin, which is where the real one writes when
+    XDG_BIN_HOME and CARGO_HOME are unset."""
+    return (
+        "#!/bin/sh\n"
+        'case "$*" in\n'
+        "  *astral.sh/uv/install.sh*)\n"
+        '    printf \'%s\\n\' "mkdir -p \\"$HOME/.local/bin\\"" \\\n'
+        '      "cat > \\"$HOME/.local/bin/uv\\" <<\'UVEOF\'" \\\n'
+        f"      {shlex.quote(installed_uv)} \\\n"
+        '      "UVEOF" "chmod 755 \\"$HOME/.local/bin/uv\\""\n'
+        "    exit 0\n"
+        "    ;;\n"
+        "esac\n"
+        "exit 0\n"
+    )
+
+
+def test_installer_bootstraps_uv_when_no_installer_is_usable(tmp_path: Path) -> None:
+    """With no uv, no pipx and no supported Python, the installer fetches uv
+    rather than exiting — uv carries its own Python, so this is recoverable."""
+    tool_bin_dir = tmp_path / "uv-tool-bin"
+    installed_uv = f"""#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "uv 0.0.0-bootstrapped"
+  exit 0
+fi
+if [ "$1" = "tool" ] && [ "$2" = "dir" ] && [ "$3" = "--bin" ]; then
+  echo "{tool_bin_dir}"
+  exit 0
+fi
+if [ "$1" = "tool" ] && [ "$2" = "install" ]; then
+  ln -sf "${OUROBOROS_STUB_VAR}" "{tool_bin_dir}/ouroboros"
+fi
+printf 'uv %s\\n' "$*" >> "${CALLS_LOG_VAR}"
+exit 0
+"""
+
+    result = _run_installer(
+        tmp_path,
+        include_uv=False,
+        env={
+            "OUROBOROS_INSTALL_RUNTIME": "codex",
+            "OUROBOROS_INSTALL_BOOTSTRAP_UV": "1",
+        },
+        fake_commands={"curl": _uv_bootstrap_curl(installed_uv)},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "uv installed: uv 0.0.0-bootstrapped" in result.stdout
+    calls = (tmp_path / "calls.log").read_text(encoding="utf-8")
+    assert "uv tool install" in calls
+
+
+def test_installer_declines_to_bootstrap_uv_when_opted_out(tmp_path: Path) -> None:
+    """OUROBOROS_INSTALL_BOOTSTRAP_UV=0 keeps the pre-existing behaviour: print
+    instructions and exit rather than fetch an installer from the network."""
+    result = _run_installer(
+        tmp_path,
+        include_uv=False,
+        env={
+            "OUROBOROS_INSTALL_RUNTIME": "codex",
+            "OUROBOROS_INSTALL_BOOTSTRAP_UV": "0",
+        },
+        fake_commands={"curl": "#!/bin/sh\nexit 1\n"},
+    )
+
+    assert result.returncode == 1
+    assert "No installer found" in result.stdout
+    assert "https://astral.sh/uv/install.sh" in result.stdout
+    calls_path = tmp_path / "calls.log"
+    assert not calls_path.exists() or "uv tool install" not in calls_path.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_installer_reports_failure_when_uv_bootstrap_does_not_land(tmp_path: Path) -> None:
+    """A curl that reports success but installs nothing must not be treated as a
+    working uv — the installer falls back to the instructions and exits."""
+    result = _run_installer(
+        tmp_path,
+        include_uv=False,
+        env={
+            "OUROBOROS_INSTALL_RUNTIME": "codex",
+            "OUROBOROS_INSTALL_BOOTSTRAP_UV": "1",
+        },
+        fake_commands={"curl": "#!/bin/sh\nexit 0\n"},
+    )
+
+    assert result.returncode == 1
+    assert "not on PATH yet" in result.stdout
+    assert "No installer found" in result.stdout


### PR DESCRIPTION
Refs #2322

## The one user problem

`curl -fsSL .../install.sh | bash` on a clean macOS or Linux machine exits 1 and tells the user to go install something first. The same one-liner on a clean Windows machine completes, because `install.ps1` (#2309) installs Git and uv itself. uv carries its own Python, so the Unix dead end is recoverable by installing one thing.

## Supported inputs and execution conditions

Reached only where the script already gave up — `install.sh:1216` (pipx with no supported Python) and `install.sh:1237` (no uv, no pipx, no supported Python). Requires `curl`. Fetches `https://astral.sh/uv/install.sh`, the same script `install.ps1` falls back to when winget is unavailable.

## Observable contract and invariants

- Every path that works today is untouched. An existing uv, or pipx with a supported Python, reaches its installer before the bootstrap is evaluated — the two call sites are inside the `if [ -z "$PYTHON" ]` branches that previously ended in `exit 1`.
- After a successful bootstrap the run continues through the normal uv path and installs the same pins as before.
- `OUROBOROS_INSTALL_BOOTSTRAP_UV=0` restores the previous behaviour exactly: instructions, then exit 1. Fetching and running an installer from the network is the one step a caller may reasonably refuse.
- A bootstrap that reports success but leaves no `uv` on PATH is not treated as success. The installer re-probes `XDG_BIN_HOME`, `CARGO_HOME/bin` and `~/.local/bin` — the installer cannot alter the running shell's PATH — and falls back to instructions and exit 1 if uv is still absent.

## Changed subsystem, boundary, owner

`scripts/install.sh` plus its test harness. No `src/` change, no runtime behaviour change, no packaging change.

## Non-goals

No Git bootstrap (`install.ps1` needs it for a plugin clone; install.sh does not reach for it here). No package-manager branch — no `brew install uv` — one deterministic path is easier to reason about than a matrix, and Homebrew is not present on most Linux hosts. No change to what the installer does after installing.

## Evidence

Three behavioural tests through the existing `_run_installer` harness, which runs the real script against a stubbed PATH:

- `test_installer_bootstraps_uv_when_no_installer_is_usable` — no uv, no pipx, every Python candidate failing: the run now exits 0, reports the bootstrapped uv, and reaches `uv tool install`.
- `test_installer_declines_to_bootstrap_uv_when_opted_out` — with the opt-out set, exits 1 with the remediation text and never calls `uv tool install`.
- `test_installer_reports_failure_when_uv_bootstrap_does_not_land` — a curl that succeeds but installs nothing exits 1 rather than continuing on a phantom uv.

Suite and gates: `tests/unit/scripts/` 530 passed, 1 skipped. `ruff check` clean, `ruff format` applied, `mypy src/ouroboros` clean over 614 files. `shellcheck scripts/install.sh` reports 7 findings, the same 7 as before this change (lines 158-161 and 1435-1442); none in the new block.

One harness change worth flagging in review: `_run_installer` now sets `OUROBOROS_INSTALL_BOOTSTRAP_UV=0` by default. Without it, existing tests that assert `returncode == 1` on the no-Python paths would reach the real `astral.sh` over the network. The bootstrap tests opt back in with a fake curl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMntndqRHb4skiT4WchFwf