### PR TITLE
fix(codex): select workspace-write sandbox explicitly — exec dropped --full-auto

### DIFF
--- a/src/ouroboros/codex_permissions.py
+++ b/src/ouroboros/codex_permissions.py
@@ -2,7 +2,7 @@
 
 This module is the *translation table* between the engine-owned
 :class:`~ouroboros.orchestrator.policy.SandboxClass` vocabulary and the Codex
-CLI's native ``--sandbox`` / ``--full-auto`` flags.  It deliberately does not
+CLI's native ``--sandbox`` flags.  It deliberately does not
 make policy decisions; those live in ``orchestrator/policy.py``.  Both the
 Codex agent runtime and the Codex-based LLM adapter go through this module,
 so Codex-side behavior stays consistent and is derived from the same sandbox
@@ -24,8 +24,8 @@ CodexPermissionMode = Literal["default", "acceptEdits", "bypassPermissions"]
 _VALID_PERMISSION_MODES = frozenset({"default", "acceptEdits", "bypassPermissions"})
 
 # Legacy permission-mode vocabulary → engine SandboxClass.  The ``default``
-# mode is read-only, ``acceptEdits`` maps to workspace-write (the Codex
-# ``--full-auto`` flag), and ``bypassPermissions`` removes both the sandbox
+# mode is read-only, ``acceptEdits`` maps to the workspace-write sandbox, and
+# ``bypassPermissions`` removes both the sandbox
 # and the approval gate.  External callers that still speak the string
 # vocabulary funnel through this mapping on their way to the sandbox enum.
 _PERMISSION_MODE_TO_SANDBOX: dict[CodexPermissionMode, SandboxClass] = {
@@ -39,7 +39,13 @@ _PERMISSION_MODE_TO_SANDBOX: dict[CodexPermissionMode, SandboxClass] = {
 # classes must add an entry here or the invariant test fails.
 _SANDBOX_TO_CODEX_ARGS: dict[SandboxClass, list[str]] = {
     SandboxClass.READ_ONLY: ["--sandbox", "read-only"],
-    SandboxClass.WORKSPACE_WRITE: ["--full-auto"],
+    # Spelled as the explicit sandbox flag rather than the ``--full-auto``
+    # alias: codex-cli 0.149 removed ``--full-auto`` from ``codex exec``
+    # ("error: unexpected argument '--full-auto' found"), while
+    # ``--sandbox workspace-write`` — the policy the alias selected — is
+    # accepted by both current and older CLIs. ``exec`` is non-interactive,
+    # so the alias's approval-mode half has no effect there.
+    SandboxClass.WORKSPACE_WRITE: ["--sandbox", "workspace-write"],
     SandboxClass.UNRESTRICTED: ["--dangerously-bypass-approvals-and-sandbox"],
 }
 
@@ -105,7 +111,7 @@ def build_codex_exec_permission_args(
 
     Mapping:
     - ``default`` -> ``SandboxClass.READ_ONLY`` -> read-only sandbox
-    - ``acceptEdits`` -> ``SandboxClass.WORKSPACE_WRITE`` -> ``--full-auto``
+    - ``acceptEdits`` -> ``SandboxClass.WORKSPACE_WRITE`` -> ``--sandbox workspace-write``
     - ``bypassPermissions`` -> ``SandboxClass.UNRESTRICTED`` -> no approvals,
       no sandbox
     """

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -1743,7 +1743,8 @@ class TestCodexCliRuntime:
 
         assert command[:2] == [_test_cli_path(), "exec"]
         assert "--json" in command
-        assert "--full-auto" in command
+        assert "--full-auto" not in command
+        assert "workspace-write" in command
         assert "--model" in command
         assert "o3" in command
         assert "-C" in command

--- a/tests/unit/providers/test_codex_cli_adapter.py
+++ b/tests/unit/providers/test_codex_cli_adapter.py
@@ -980,8 +980,13 @@ class TestCodexCliLLMAdapter:
         assert result.is_ok
         assert result.value.content == "Profiled answer"
 
-    def test_build_command_uses_full_auto_for_accept_edits(self) -> None:
-        """acceptEdits maps to Codex full-auto mode."""
+    def test_build_command_uses_workspace_write_sandbox_for_accept_edits(self) -> None:
+        """acceptEdits selects the workspace-write sandbox explicitly.
+
+        codex-cli 0.149 removed the ``--full-auto`` alias from ``codex exec``;
+        the explicit ``--sandbox workspace-write`` pair is accepted by both
+        current and older CLIs.
+        """
         adapter = CodexCliLLMAdapter(cli_path="codex", permission_mode="acceptEdits")
 
         command = adapter._build_command(
@@ -990,8 +995,9 @@ class TestCodexCliLLMAdapter:
             model=None,
         )
 
-        assert "--full-auto" in command
-        assert "--sandbox" not in command
+        assert "--full-auto" not in command
+        sandbox_index = command.index("--sandbox")
+        assert command[sandbox_index + 1] == "workspace-write"
 
     def test_build_command_uses_dangerous_bypass_when_requested(self) -> None:
         """bypassPermissions maps to the Codex dangerous bypass flag."""


### PR DESCRIPTION
## Summary

On codex-cli ≥ 0.149, `codex exec --full-auto` fails with `error: unexpected argument '--full-auto' found`, so **every Ouroboros codex run under the default `acceptEdits` mode dies before the first turn**. Reproduced live on codex-cli 0.149.1: a cli-todo run on main fails all ACs in ~0.2 s each; with this one-mapping change the same runtime completes turns (verified `PONG` probe through `CodexCliRuntime.execute_task`).

## Review boundary

- **User problem**: codex runs fail instantly on current codex CLIs; the error is swallowed into generic AC failures.
- **Inputs and execution conditions**: any `--runtime codex` execution or codex LLM adapter call with `acceptEdits` (default). Both call paths funnel through `codex_permissions._SANDBOX_TO_CODEX_ARGS`.
- **Promised contract**: `SandboxClass.WORKSPACE_WRITE` translates to `--sandbox workspace-write` — the exact policy `--full-auto` aliased — accepted by current and older codex CLIs; `READ_ONLY` and `UNRESTRICTED` mappings unchanged. `exec` is non-interactive, so the alias's approval-mode half (`-a on-failure`) had no observable effect there.
- **Implementation boundary and owner**: `src/ouroboros/codex_permissions.py` (one mapping entry + comments) and the two tests that pinned the alias.
- **Non-goals**: version-adaptive flag selection; interactive (non-exec) codex sessions; approval-policy configuration.
- **Evidence**: `tests/unit/orchestrator/test_codex_cli_runtime.py`, `tests/unit/providers/test_codex_cli_adapter.py` (assert the `--sandbox workspace-write` pair, alias absent), `test_sandbox_class.py` invariant — 231 passed; mypy clean. Live probe on codex-cli 0.149.1 via family proxy: main → argument error; this branch → completed turn.

## Test plan

- [x] codex runtime/adapter/sandbox suites, ruff, mypy
- [x] live probe on codex-cli 0.149.1 (before: argument error; after: PONG)
- [ ] 10-run codex-runtime live benchmark riding on this fix (#2311, starting now)

## Related issues

Refs #2311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145uCSmu29DhCtDR5yGkLQd