### PR TITLE
fix(gjc): reclaim broker-owned worker sessions on terminal turns and termination

### DIFF
--- a/src/ouroboros/gjc/sdk_client.py
+++ b/src/ouroboros/gjc/sdk_client.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 
 from ouroboros.mcp.client.adapter import MCPClientAdapter
 from ouroboros.mcp.types import MCPServerConfig, MCPToolResult, TransportType
+from ouroboros.runtime.child_env import build_child_env
 
 _SERVER_NAME = "gjc-coordinator"
 _TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled", "superseded"})
@@ -101,7 +102,15 @@ class GjcCoordinatorClient:
     def _server_config(self) -> MCPServerConfig:
         repo_digest = hashlib.sha256(self._cwd.encode("utf-8")).hexdigest()[:16]
         state_root = Path(self._cwd) / ".gjc" / "state" / "ouroboros-coordinator" / repo_digest
-        env = os.environ.copy()
+        # The coordinator forwards this environment to Broker-managed worker
+        # sessions, so it needs the same recursion guard every other backend
+        # applies: strip the Ouroboros runtime markers and bound the depth.
+        env = build_child_env(
+            depth_error_factory=lambda depth, max_depth: GjcCoordinatorError(
+                f"GJC session nesting depth {depth} exceeds the maximum of {max_depth}.",
+                code="recursion_depth_exceeded",
+            ),
+        )
         cli_path = Path(self._cli_path).expanduser()
         if cli_path.name == "gjc" and cli_path.parent != Path("."):
             existing_path = env.get("PATH", "")

--- a/src/ouroboros/gjc/sdk_client.py
+++ b/src/ouroboros/gjc/sdk_client.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 
 from ouroboros.mcp.client.adapter import MCPClientAdapter
 from ouroboros.mcp.types import MCPServerConfig, MCPToolResult, TransportType
-from ouroboros.runtime.child_env import build_child_env
+from ouroboros.runtime.child_env import DEFAULT_OUROBOROS_STRIP_KEYS, build_child_env
 
 _SERVER_NAME = "gjc-coordinator"
 _TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled", "superseded"})
@@ -105,7 +105,11 @@ class GjcCoordinatorClient:
         # The coordinator forwards this environment to Broker-managed worker
         # sessions, so it needs the same recursion guard every other backend
         # applies: strip the Ouroboros runtime markers and bound the depth.
+        # ``OUROBOROS_RUNTIME`` is the public legacy selector for both runtime
+        # and LLM routing — leaving it set would route a discovered nested
+        # Ouroboros straight back into GJC and rebuild the worker chain.
         env = build_child_env(
+            strip_keys=("OUROBOROS_RUNTIME", *DEFAULT_OUROBOROS_STRIP_KEYS),
             depth_error_factory=lambda depth, max_depth: GjcCoordinatorError(
                 f"GJC session nesting depth {depth} exceeds the maximum of {max_depth}.",
                 code="recursion_depth_exceeded",

--- a/src/ouroboros/orchestrator/gjc_runtime.py
+++ b/src/ouroboros/orchestrator/gjc_runtime.py
@@ -153,7 +153,7 @@ class GjcRuntime:
                 "options": list(question.options),
                 "multi": question.multi,
             }
-        return RuntimeHandle(
+        handle = RuntimeHandle(
             backend=self._runtime_handle_backend,
             kind="agent_runtime",
             native_session_id=session_id,
@@ -161,6 +161,38 @@ class GjcRuntime:
             approval_mode=self._permission_mode,
             metadata=metadata,
         )
+        if session_id:
+            # Broker-owned GJC sessions outlive the coordinator connection, so
+            # every session-bearing handle must expose a real terminate path or
+            # the run-level reclamation sweeps silently skip gjc workers.
+            handle = handle.bind_controls(terminate_callback=self._terminate_session)
+        return handle
+
+    async def _terminate_session(self, handle: RuntimeHandle) -> bool:
+        session_id = handle.native_session_id
+        if not session_id:
+            return False
+        client = self._coordinator_client_factory(
+            cli_path=self._cli_path,
+            cwd=self._cwd,
+            timeout=self._timeout,
+        )
+        try:
+            await client.connect()
+            await client.stop_session(session_id)
+            return True
+        except GjcCoordinatorError as exc:
+            log.warning(
+                f"{self._log_namespace}.terminate_failed",
+                session_id=session_id,
+                code=exc.code,
+            )
+            return False
+        finally:
+            try:
+                await client.close()
+            except GjcCoordinatorError:
+                pass
 
     @staticmethod
     def _compose_prompt(prompt: str, tools: list[str] | None, system_prompt: str | None) -> str:
@@ -210,6 +242,7 @@ class GjcRuntime:
         )
         session_id: str | None = requested_session_id
         client: GjcCoordinatorClient | None = None
+        stop_target: str | None = None
         handle = resume_handle
         metadata = resume_handle.metadata if resume_handle else {}
         phase = metadata.get("gjc_operation_phase")
@@ -345,6 +378,10 @@ class GjcRuntime:
                 )
                 return
             terminal_phase = "completed" if turn.succeeded else "failed"
+            # The turn is terminal and non-resumable: reclaim the broker-owned
+            # worker session so it cannot outlive the run. Question turns and
+            # coordinator errors keep the session alive for resume.
+            stop_target = session_id
             handle = self._build_runtime_handle(
                 session_id,
                 turn_id,
@@ -383,6 +420,11 @@ class GjcRuntime:
             )
         finally:
             if client is not None:
+                if stop_target is not None:
+                    try:
+                        await client.stop_session(stop_target)
+                    except GjcCoordinatorError:
+                        pass
                 try:
                     await client.close()
                 except GjcCoordinatorError:

--- a/src/ouroboros/orchestrator/gjc_runtime.py
+++ b/src/ouroboros/orchestrator/gjc_runtime.py
@@ -8,6 +8,8 @@ import shutil
 from typing import Any
 from uuid import uuid4
 
+import anyio
+
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.types import Result
 from ouroboros.gjc.sdk_client import (
@@ -242,7 +244,8 @@ class GjcRuntime:
         )
         session_id: str | None = requested_session_id
         client: GjcCoordinatorClient | None = None
-        stop_target: str | None = None
+        keep_session_for_resume = False
+        session_stopped = False
         handle = resume_handle
         metadata = resume_handle.metadata if resume_handle else {}
         phase = metadata.get("gjc_operation_phase")
@@ -352,6 +355,7 @@ class GjcRuntime:
             )
             turn = await client.await_turn(session_id, turn_id)
             if turn.status == "waiting_for_answer":
+                keep_session_for_resume = True
                 question = turn.question
                 answer_key = f"ouroboros-answer-{uuid4().hex}"
                 handle = self._build_runtime_handle(
@@ -378,16 +382,27 @@ class GjcRuntime:
                 )
                 return
             terminal_phase = "completed" if turn.succeeded else "failed"
-            # The turn is terminal and non-resumable: reclaim the broker-owned
-            # worker session so it cannot outlive the run. Question turns and
-            # coordinator errors keep the session alive for resume.
-            stop_target = session_id
             handle = self._build_runtime_handle(
                 session_id,
                 turn_id,
                 handle,
                 operation_phase=terminal_phase,
             )
+            content = (
+                (turn.text or await client.read_last_assistant(session_id))
+                if turn.succeeded
+                else None
+            )
+            # The turn is terminal and non-resumable: reclaim the broker-owned
+            # worker session BEFORE publishing the result, so a consumer that
+            # stops iterating at the terminal message (or never closes the
+            # generator) cannot leave the session running. Question turns and
+            # coordinator errors keep the session alive for resume.
+            session_stopped = True
+            try:
+                await client.stop_session(session_id)
+            except GjcCoordinatorError:
+                pass
             if not turn.succeeded:
                 yield AgentMessage(
                     type="result",
@@ -400,7 +415,6 @@ class GjcRuntime:
                     resume_handle=handle,
                 )
                 return
-            content = turn.text or await client.read_last_assistant(session_id)
             yield AgentMessage(
                 type="result",
                 content=content or "GJC task completed.",
@@ -408,6 +422,7 @@ class GjcRuntime:
                 resume_handle=handle,
             )
         except GjcCoordinatorError as exc:
+            keep_session_for_resume = True
             yield AgentMessage(
                 type="result",
                 content=str(exc),
@@ -419,16 +434,27 @@ class GjcRuntime:
                 resume_handle=handle,
             )
         finally:
+            # Runs under caller cancellation and generator finalization too, so
+            # the cleanup awaits are shielded: a session bound after
+            # ``start_session`` must be reclaimed even when the consumer never
+            # drains the stream or cancels while ``await_turn`` blocks. Only
+            # explicitly resumable states (question turns, coordinator errors)
+            # keep the broker-owned session alive.
             if client is not None:
-                if stop_target is not None:
+                with anyio.CancelScope(shield=True):
+                    if (
+                        session_id is not None
+                        and not keep_session_for_resume
+                        and (not session_stopped)
+                    ):
+                        try:
+                            await client.stop_session(session_id)
+                        except GjcCoordinatorError:
+                            pass
                     try:
-                        await client.stop_session(stop_target)
+                        await client.close()
                     except GjcCoordinatorError:
                         pass
-                try:
-                    await client.close()
-                except GjcCoordinatorError:
-                    pass
 
     async def execute_task_to_result(
         self,

--- a/tests/unit/gjc/test_sdk_client.py
+++ b/tests/unit/gjc/test_sdk_client.py
@@ -108,6 +108,7 @@ async def test_server_env_applies_child_recursion_guard(
 ) -> None:
     monkeypatch.setenv("OUROBOROS_AGENT_RUNTIME", "gjc")
     monkeypatch.setenv("OUROBOROS_LLM_BACKEND", "gjc")
+    monkeypatch.setenv("OUROBOROS_RUNTIME", "gjc")
     monkeypatch.setenv("_OUROBOROS_DEPTH", "1")
     adapter = _FakeAdapter([])
     client = GjcCoordinatorClient(
@@ -120,6 +121,9 @@ async def test_server_env_applies_child_recursion_guard(
 
     assert "OUROBOROS_AGENT_RUNTIME" not in adapter.config.env
     assert "OUROBOROS_LLM_BACKEND" not in adapter.config.env
+    # The public legacy selector routes BOTH runtime and LLM choice; leaving it
+    # set would send a discovered nested Ouroboros straight back into GJC.
+    assert "OUROBOROS_RUNTIME" not in adapter.config.env
     assert adapter.config.env["_OUROBOROS_DEPTH"] == "2"
 
 

--- a/tests/unit/gjc/test_sdk_client.py
+++ b/tests/unit/gjc/test_sdk_client.py
@@ -103,6 +103,44 @@ async def test_start_await_tail_and_stop_use_coordinator_contract(tmp_path: Path
 
 
 @pytest.mark.asyncio
+async def test_server_env_applies_child_recursion_guard(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OUROBOROS_AGENT_RUNTIME", "gjc")
+    monkeypatch.setenv("OUROBOROS_LLM_BACKEND", "gjc")
+    monkeypatch.setenv("_OUROBOROS_DEPTH", "1")
+    adapter = _FakeAdapter([])
+    client = GjcCoordinatorClient(
+        cli_path="/opt/gjc",
+        cwd=tmp_path,
+        adapter_factory=_factory(adapter),
+    )
+
+    await client.connect()
+
+    assert "OUROBOROS_AGENT_RUNTIME" not in adapter.config.env
+    assert "OUROBOROS_LLM_BACKEND" not in adapter.config.env
+    assert adapter.config.env["_OUROBOROS_DEPTH"] == "2"
+
+
+@pytest.mark.asyncio
+async def test_server_env_depth_ceiling_raises_coordinator_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("_OUROBOROS_DEPTH", "5")
+    adapter = _FakeAdapter([])
+    client = GjcCoordinatorClient(
+        cli_path="/opt/gjc",
+        cwd=tmp_path,
+        adapter_factory=_factory(adapter),
+    )
+
+    with pytest.raises(GjcCoordinatorError) as excinfo:
+        await client.connect()
+    assert excinfo.value.code == "recursion_depth_exceeded"
+
+
+@pytest.mark.asyncio
 async def test_waiting_turn_projects_question_and_accepts_custom_answer(tmp_path: Path) -> None:
     adapter = _FakeAdapter(
         [

--- a/tests/unit/orchestrator/test_gjc_runtime.py
+++ b/tests/unit/orchestrator/test_gjc_runtime.py
@@ -22,6 +22,7 @@ class FakeClient:
         self.started: list[tuple[str, str | None, str | None]] = []
         self.sent: list[tuple[str, str, str | None]] = []
         self.answers: list[tuple[GjcCoordinatorQuestion, str, str | None]] = []
+        self.stopped: list[str] = []
 
     async def connect(self) -> None:
         self.connected = True
@@ -69,6 +70,9 @@ class FakeClient:
     async def read_last_assistant(self, session_id: str, *, lines: int = 400) -> str:
         del session_id, lines
         return "tail"
+
+    async def stop_session(self, session_id: str) -> None:
+        self.stopped.append(session_id)
 
 
 def _factory(client: FakeClient):
@@ -182,6 +186,69 @@ async def test_failed_sdk_turn_is_runtime_error() -> None:
     assert message.is_error
     assert message.data["error_type"] == "GjcTurnError"
     assert message.content == "failed"
+
+
+@pytest.mark.asyncio
+async def test_terminal_success_turn_stops_broker_session() -> None:
+    client = FakeClient([_turn("Done")])
+    runtime = GjcRuntime(cwd="/tmp/project", coordinator_client_factory=_factory(client))
+
+    [message async for message in runtime.execute_task("Do it")]
+
+    assert client.stopped == ["session-1"]
+    assert client.closed
+
+
+@pytest.mark.asyncio
+async def test_terminal_failed_turn_stops_broker_session() -> None:
+    client = FakeClient([_turn("", status="failed")])
+    runtime = GjcRuntime(cwd="/tmp/project", coordinator_client_factory=_factory(client))
+
+    [message async for message in runtime.execute_task("Do it")]
+
+    assert client.stopped == ["session-1"]
+
+
+@pytest.mark.asyncio
+async def test_question_turn_keeps_broker_session_alive() -> None:
+    question = GjcCoordinatorQuestion(
+        session_id="session-1",
+        turn_id="turn-1",
+        question_id="q-1",
+        answer_binding="binding-1",
+        prompt="Choose one",
+        options=("A", "B"),
+        multi=False,
+    )
+    client = FakeClient([_turn("", status="waiting_for_answer", question=question)])
+    runtime = GjcRuntime(cwd="/tmp/project", coordinator_client_factory=_factory(client))
+
+    message = [item async for item in runtime.execute_task("Start")][-1]
+
+    assert message.data["error_type"] == "GjcQuestionRequired"
+    assert client.stopped == []
+
+
+@pytest.mark.asyncio
+async def test_session_handle_can_terminate_and_stops_session() -> None:
+    client = FakeClient([_turn("Done")])
+    runtime = GjcRuntime(cwd="/tmp/project", coordinator_client_factory=_factory(client))
+
+    handle = [message async for message in runtime.execute_task("Do it")][-1].resume_handle
+
+    assert handle is not None
+    assert handle.can_terminate
+    assert await handle.terminate() is True
+    # Terminal turn already stopped once; terminate() issues its own stop.
+    assert client.stopped == ["session-1", "session-1"]
+
+
+def test_sessionless_handle_cannot_terminate() -> None:
+    runtime = GjcRuntime(cwd="/tmp/project")
+    handle = runtime._build_runtime_handle(
+        None, None, None, operation_phase="start_pending", idempotency_key="key"
+    )
+    assert handle.can_terminate is False
 
 
 def test_capabilities_use_sdk_resume_and_translate_no_permission_or_tool_envelope() -> None:

--- a/tests/unit/orchestrator/test_gjc_runtime.py
+++ b/tests/unit/orchestrator/test_gjc_runtime.py
@@ -210,6 +210,53 @@ async def test_terminal_failed_turn_stops_broker_session() -> None:
 
 
 @pytest.mark.asyncio
+async def test_terminal_stop_precedes_the_final_yield() -> None:
+    """A consumer that stops at the terminal message must not leak the session."""
+    client = FakeClient([_turn("Done")])
+    runtime = GjcRuntime(cwd="/tmp/project", coordinator_client_factory=_factory(client))
+
+    stream = runtime.execute_task("Do it")
+    message = await anext(stream)
+
+    # The session was reclaimed BEFORE the result was published; no aclose()
+    # or further iteration was needed.
+    assert message.data["subtype"] == "success"
+    assert client.stopped == ["session-1"]
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_while_awaiting_turn_stops_the_bound_session() -> None:
+    """Cancelling mid-turn must reclaim the session bound by start_session."""
+    import asyncio
+
+    entered = asyncio.Event()
+
+    class BlockingClient(FakeClient):
+        async def await_turn(self, session_id: str, turn_id: str) -> GjcCoordinatorTurn:
+            del session_id, turn_id
+            entered.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+    client = BlockingClient([])
+    runtime = GjcRuntime(cwd="/tmp/project", coordinator_client_factory=_factory(client))
+
+    async def consume() -> None:
+        async for _message in runtime.execute_task("Do it"):
+            pass
+
+    task = asyncio.create_task(consume())
+    await asyncio.wait_for(entered.wait(), timeout=5)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert client.stopped == ["session-1"]
+    assert client.closed
+
+
+@pytest.mark.asyncio
 async def test_question_turn_keeps_broker_session_alive() -> None:
     question = GjcCoordinatorQuestion(
         session_id="session-1",


### PR DESCRIPTION
Refs #2326

## One user problem

A `--runtime gjc` run leaves its worker sessions alive forever — success and failure alike. In the 2026-08-31 incident, 19 leaked gjc worker (bun) clients and 18 nested `ouroboros mcp serve` children were still holding DB connections 17+ minutes after the run failed, driving the SQLite pool exhaustion (`QueuePool limit of size 5 overflow 10 reached`, 714 occurrences).

## Root cause

- `GjcRuntime` never bound a `terminate_callback`, so `can_terminate` was `False` and every already-wired reclamation path (per-AC finally in `parallel_executor`, run-level finallys in `runner`, cancel/escalation) was a silent no-op for gjc. Only codex/opencode bind one.
- The turn `finally` only disconnected the coordinator MCP client; the Broker-owned worker session was never stopped, even on success. `stop_session` existed but had exactly one caller (the one-shot `gjc_llm_adapter`).
- The coordinator env was a raw `os.environ.copy()`, bypassing the shared `build_child_env` recursion guard, so workers inherited the project runtime markers and spawned one nested `ouroboros mcp serve` per AC attempt.

## Change

1. `orchestrator/gjc_runtime.py` — `execute_task` stops the broker session in its `finally` once the turn reaches a terminal (non-resumable) state. `waiting_for_answer` turns and coordinator errors keep the session alive so the existing idempotent resume contract is untouched.
2. `orchestrator/gjc_runtime.py` — every session-bearing `RuntimeHandle` now binds a terminate callback (`connect → stop_session(force) → close`, best-effort), following the codex/opencode `bind_controls` pattern. The wired termination paths start working for gjc with zero changes to them.
3. `gjc/sdk_client.py` — the coordinator env is built through `runtime/child_env.build_child_env`: strips `OUROBOROS_AGENT_RUNTIME`/`OUROBOROS_LLM_BACKEND` and enforces the `_OUROBOROS_DEPTH` ceiling (raises `GjcCoordinatorError(code="recursion_depth_exceeded")`), matching every other backend.

## Supported inputs / execution conditions

gjc agent-runtime execution paths (`execute_task` / `execute_task_to_result`) and any consumer of gjc `RuntimeHandle.terminate()`. No behavior change for other backends.

## Observable contract / invariants

- A gjc turn that ends terminal (completed/failed) leaves no live broker session behind.
- gjc handles with a `native_session_id` report `can_terminate=True`; `terminate()` force-stops the session and returns whether a stop was issued.
- Question turns and coordinator errors preserve the session for resume (unchanged resume/idempotency semantics).
- gjc child env carries the standard recursion guard.

## Changed subsystem / boundary / owner

`orchestrator/gjc_runtime.py` + `gjc/sdk_client.py` (gjc backend adapter boundary). No new subsystem; reuses `RuntimeHandle.bind_controls` and `runtime/child_env` seams. Owner: @Q00.

## Non-goals

- Serve-side zombie lifecycle fixes (dead-peer EOF, hard-exit backstop, http idle shutdown) — #2325.
- A run-scoped OS-level PID reaper — the terminate-callback seam makes the existing sweeps effective; a broader reaper remains follow-up under #2326 if leaks persist.
- Known gap, intentionally not invented here: gjc has no verified flag to suppress project `.mcp.json` discovery inside worker sessions (claude has `--strict-mcp-config`, codex has `enabled=false`). The env recursion guard bounds the depth; if gjc grows such a flag, wiring it into `start_session` args is a one-line follow-up.

## Evidence

- New tests: `test_terminal_success_turn_stops_broker_session`, `test_terminal_failed_turn_stops_broker_session`, `test_question_turn_keeps_broker_session_alive`, `test_session_handle_can_terminate_and_stops_session`, `test_sessionless_handle_cannot_terminate`, `test_server_env_applies_child_recursion_guard`, `test_server_env_depth_ceiling_raises_coordinator_error` (no real CLI spawns; FakeClient/FakeAdapter).
- Full suite with xdist: 21753 passed; the only 5 failures (`test_picker_indexes.py` perf budgets) reproduce identically on origin/main on the same machine (load-sensitive, pre-existing).
- `ruff format`/`ruff check`/`mypy`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDJPBa4pxVbUvcUcKeT5Ea