### PR TITLE
fix(mcp): bound idle network serves and make job polling incremental

### DIFF
--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -79,9 +79,55 @@ _JOB_DRAIN_GRACE_SECONDS = 5.0
 _IDLE_CHECKPOINT_POLL_SECONDS = 300.0
 _IDLE_CHECKPOINT_THRESHOLD_SECONDS = 600.0
 
+# Idle lifetime bound for network transports: unlike stdio, an sse or
+# streamable-http server has no stdin EOF and — once its spawner dies and it
+# is reparented to launchd/systemd — no parent tether either (the orphan
+# watchdog stands down at ppid 1). Without a bound such a server runs
+# forever, pinning the shared database.
+_IDLE_SHUTDOWN_POLL_SECONDS = 60.0
+_NETWORK_IDLE_SHUTDOWN_DEFAULT_SECONDS = 7200.0
+
 # Separate stderr console for stdio transport (stdout is JSON-RPC channel)
 _stderr_console = Console(stderr=True)
 log = structlog.get_logger(__name__)
+
+
+def _effective_idle_timeout(transport: str, idle_timeout_seconds: float | None) -> float:
+    """Resolve the idle-shutdown bound; ``None`` picks the transport default."""
+    if idle_timeout_seconds is not None:
+        return idle_timeout_seconds
+    return 0.0 if transport == "stdio" else _NETWORK_IDLE_SHUTDOWN_DEFAULT_SECONDS
+
+
+async def _idle_shutdown_loop(
+    stop: asyncio.Event,
+    server: Any,
+    idle_timeout_seconds: float,
+    *,
+    poll_seconds: float = _IDLE_SHUTDOWN_POLL_SECONDS,
+) -> None:
+    """Set ``stop`` once no tool call has arrived for ``idle_timeout_seconds``.
+
+    Network transports only: stdio keeps its EOF/watchdog lifecycle, but an
+    sse/streamable-http server reparented to launchd/systemd has no other
+    tether (the orphan watchdog stands down at ppid 1) and would otherwise
+    run forever, pinning the shared database.
+    """
+    while not stop.is_set():
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(stop.wait(), timeout=poll_seconds)
+        if stop.is_set():
+            return
+        idle_for = getattr(server, "seconds_since_last_tool_call", None)
+        if not isinstance(idle_for, int | float):
+            return
+        if idle_for < idle_timeout_seconds:
+            continue
+        _stderr_console.print(
+            f"[yellow]No tool call for {int(idle_for)}s (--idle-timeout) — shutting down[/yellow]"
+        )
+        stop.set()
+        return
 
 
 class LLMBackend(str, Enum):  # noqa: UP042
@@ -602,6 +648,7 @@ async def _run_mcp_server(
     allowed_hosts: tuple[str, ...] = (),
     allowed_origins: tuple[str, ...] = (),
     workspace_roots: tuple[str, ...] = (),
+    idle_timeout_seconds: float | None = None,
 ) -> None:
     """Run the MCP server.
 
@@ -618,6 +665,9 @@ async def _run_mcp_server(
         allowed_origins: ``Origin`` header allowlist for network transports.
         workspace_roots: Directories seed execution is confined to. Empty
             leaves execution unrestricted, the historical local behaviour.
+        idle_timeout_seconds: Shut down after this many seconds without a
+            tool call. ``None`` picks the transport default (network
+            transports get a bound, stdio stays unbounded); ``0`` disables.
     """
     from ouroboros.mcp.server.adapter import validate_transport
 
@@ -675,6 +725,7 @@ async def _run_mcp_server(
     stop_task: asyncio.Task[bool] | None = None
     watchdog_task: asyncio.Task[None] | None = None
     idle_checkpoint_task: asyncio.Task[None] | None = None
+    idle_shutdown_task: asyncio.Task[None] | None = None
     serve_exc: BaseException | None = None
 
     # The protective try spans store init -> composition -> serve: a failure
@@ -889,6 +940,8 @@ async def _run_mcp_server(
                 with contextlib.suppress(asyncio.TimeoutError):
                     await asyncio.wait_for(stop.wait(), timeout=5.0)
 
+        effective_idle_timeout = _effective_idle_timeout(transport, idle_timeout_seconds)
+
         async def _idle_wal_checkpoint() -> None:
             # Long-lived idle servers pin the shared WAL: passive autocheckpoints
             # cannot truncate while any reader is active, so N concurrent idle
@@ -923,6 +976,11 @@ async def _run_mcp_server(
         idle_checkpoint_task = asyncio.create_task(
             _idle_wal_checkpoint(), name="ouroboros-mcp-idle-checkpoint"
         )
+        if effective_idle_timeout > 0:
+            idle_shutdown_task = asyncio.create_task(
+                _idle_shutdown_loop(stop, server, effective_idle_timeout),
+                name="ouroboros-mcp-idle-shutdown",
+            )
 
         # One daily-deduplicated "MCP attached" row per user — the denominator
         # of the attached → used activation funnel. The row must reflect a
@@ -953,7 +1011,9 @@ async def _run_mcp_server(
         # Runs for SIGTERM, orphan-exit and KeyboardInterrupt too, so
         # EventStore.close() always gets to collapse the WAL.
         helper_tasks = [
-            t for t in (watchdog_task, stop_task, idle_checkpoint_task) if t is not None
+            t
+            for t in (watchdog_task, stop_task, idle_checkpoint_task, idle_shutdown_task)
+            if t is not None
         ]
         for _task in helper_tasks:
             if not _task.done():
@@ -1221,6 +1281,17 @@ def serve(
             ),
         ),
     ] = "",
+    idle_timeout: Annotated[
+        float | None,
+        typer.Option(
+            "--idle-timeout",
+            help=(
+                "Shut the server down after this many seconds without a tool "
+                "call. Defaults to 7200 for network transports (sse, "
+                "streamable-http) and disabled for stdio. Pass 0 to disable."
+            ),
+        ),
+    ] = None,
     runtime: Annotated[
         AgentRuntimeBackend | None,
         typer.Option(
@@ -1357,6 +1428,7 @@ def serve(
                 allowed_hosts=allowed_hosts,
                 allowed_origins=allowed_origins,
                 workspace_roots=workspace_roots,
+                idle_timeout_seconds=idle_timeout,
             )
         )
     except KeyboardInterrupt:

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable, Mapping
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
-from enum import StrEnum
 import inspect
 import json
 import logging
@@ -19,6 +18,13 @@ import structlog
 from ouroboros.core.errors import PersistenceError
 from ouroboros.events.base import BaseEvent
 from ouroboros.mcp.failure_taxonomy import classify_failure
+from ouroboros.mcp.job_snapshot import (
+    JobEventFold,
+    JobLinks,
+    JobSnapshot,
+    JobStatus,
+    fold_job_events,
+)
 from ouroboros.mcp.telemetry_boundary import JobTelemetryBoundary
 from ouroboros.orchestrator.agent_process import AgentProcessHandle
 from ouroboros.orchestrator.events import create_execution_terminal_event
@@ -46,55 +52,6 @@ from ouroboros.persistence.event_store import (
     EventStore,
     validate_acceptance_finalization_payload,
 )
-
-
-class JobStatus(StrEnum):
-    """Lifecycle states for async MCP jobs."""
-
-    QUEUED = "queued"
-    RUNNING = "running"
-    CANCEL_REQUESTED = "cancel_requested"
-    COMPLETED = "completed"
-    FAILED = "failed"
-    CANCELLED = "cancelled"
-    INTERRUPTED = "interrupted"
-
-
-@dataclass(frozen=True, slots=True)
-class JobLinks:
-    """Cross-reference IDs attached to a job."""
-
-    session_id: str | None = None
-    execution_id: str | None = None
-    lineage_id: str | None = None
-    preserve_runner_result: bool = False
-
-
-@dataclass(frozen=True, slots=True)
-class JobSnapshot:
-    """Materialized view of a background job."""
-
-    job_id: str
-    job_type: str
-    status: JobStatus
-    message: str
-    created_at: datetime
-    updated_at: datetime
-    cursor: int = 0
-    links: JobLinks = field(default_factory=JobLinks)
-    result_text: str | None = None
-    result_meta: dict[str, Any] = field(default_factory=dict)
-    result_payload: dict[str, Any] | None = None
-    error: str | None = None
-
-    @property
-    def is_terminal(self) -> bool:
-        return self.status in {
-            JobStatus.COMPLETED,
-            JobStatus.FAILED,
-            JobStatus.CANCELLED,
-            JobStatus.INTERRUPTED,
-        }
 
 
 @dataclass(frozen=True, slots=True)
@@ -458,6 +415,7 @@ class JobManager:
         self._cleanup_running = False
         self._last_cleanup_monotonic = time.monotonic()
         self._live_snapshots: dict[str, JobSnapshot] = {}
+        self._fold_cache: dict[str, JobEventFold] = {}
         self._telemetry = JobTelemetryBoundary()
 
     def get_cached_snapshot(self, job_id: str) -> JobSnapshot | None:
@@ -887,7 +845,7 @@ class JobManager:
         _HEARTBEAT_INTERVAL = 60.0
         while True:
             await asyncio.sleep(interval)
-            snapshot = await self.get_snapshot(job_id)
+            snapshot = await self._get_snapshot_tail(job_id)
             if snapshot.is_terminal:
                 return
 
@@ -1970,72 +1928,44 @@ class JobManager:
         events, cursor = await self._event_store.get_events_after("job", job_id, last_row_id=0)
         if not events:
             raise ValueError(f"Job not found: {job_id}")
+        fold = fold_job_events(None, events, cursor=cursor)
+        # A full replay is authoritative: refresh the tail cache so polling
+        # loops resume from here and self-heal any divergence.
+        self._fold_cache[job_id] = fold
+        return await self._finalize_fold_snapshot(job_id, fold)
 
-        created = events[0]
-        self._telemetry.remember(job_id, created.data)
-        created_links = created.data.get("links", {})
-        status = JobStatus(created.data.get("status", JobStatus.QUEUED.value))
-        message = created.data.get("message", "")
-        links = JobLinks(
-            session_id=created_links.get("session_id"),
-            execution_id=created_links.get("execution_id"),
-            lineage_id=created_links.get("lineage_id"),
-            preserve_runner_result=created_links.get("preserve_runner_result") is True,
+    async def _get_snapshot_tail(self, job_id: str) -> JobSnapshot:
+        """``get_snapshot`` variant for polling loops: fold only new events.
+
+        Resumes the cached fold at its rowid cursor instead of replaying the
+        job's whole stream every tick. Falls back to a full replay when no
+        fold is cached yet. The derived reconcilers still run on every call —
+        only the per-tick replay cost drops to O(new events).
+        """
+        await self._ensure_initialized()
+        await self._maybe_cleanup_expired()
+        fold = self._fold_cache.get(job_id)
+        if fold is None:
+            return await self.get_snapshot(job_id)
+        events, cursor = await self._event_store.get_events_after(
+            "job", job_id, last_row_id=fold.cursor
         )
-        result_text: str | None = None
-        result_meta: dict[str, Any] = {}
-        result_payload: dict[str, Any] | None = None
-        error: str | None = None
+        if events:
+            fold = fold_job_events(fold, events, cursor=cursor)
+        return await self._finalize_fold_snapshot(job_id, fold)
 
-        for event in events[1:]:
-            data = event.data
-            link_data = data.get("links") or {}
-            links = JobLinks(
-                session_id=link_data.get("session_id") or links.session_id,
-                execution_id=link_data.get("execution_id") or links.execution_id,
-                lineage_id=link_data.get("lineage_id") or links.lineage_id,
-                preserve_runner_result=(
-                    link_data.get("preserve_runner_result")
-                    if isinstance(link_data.get("preserve_runner_result"), bool)
-                    else links.preserve_runner_result
-                ),
-            )
-
-            if "status" in data:
-                status = JobStatus(data["status"])
-            if "message" in data:
-                message = data["message"]
-            if "result_text" in data:
-                result_text = data["result_text"]
-            if "result_meta" in data and isinstance(data["result_meta"], dict):
-                result_meta = data["result_meta"]
-            if "result_payload" in data and isinstance(data["result_payload"], dict):
-                result_payload = data["result_payload"]
-            if "error" in data:
-                error = data["error"]
-
-        snapshot = JobSnapshot(
-            job_id=job_id,
-            job_type=created.data.get("job_type", "unknown"),
-            status=status,
-            message=message,
-            created_at=created.timestamp,
-            updated_at=events[-1].timestamp,
-            cursor=cursor,
-            links=links,
-            result_text=result_text,
-            result_meta=result_meta,
-            result_payload=result_payload,
-            error=error,
-        )
-        owner_is_dead = self._job_owner_is_dead(created.data)
+    async def _finalize_fold_snapshot(self, job_id: str, fold: JobEventFold) -> JobSnapshot:
+        """Turn a fold into the reconciled snapshot ``get_snapshot`` promises."""
+        self._telemetry.remember(job_id, fold.created_data)
+        snapshot = fold.to_snapshot(job_id)
+        owner_is_dead = self._job_owner_is_dead(fold.created_data)
         snapshot = await self._recover_linked_execution_terminal_snapshot(
             snapshot,
             owner_is_dead=owner_is_dead,
         )
         snapshot = await self._reconcile_orphaned_job_snapshot(
             snapshot,
-            owner_data=created.data,
+            owner_data=fold.created_data,
         )
         return await self._reconcile_stranded_started_job_snapshot(snapshot)
 
@@ -2348,7 +2278,7 @@ class JobManager:
                 snapshot = await self.get_snapshot(job_id)
                 return replace(snapshot, cursor=new_cursor), True
 
-            snapshot = await self.get_snapshot(job_id)
+            snapshot = await self._get_snapshot_tail(job_id)
             if snapshot.is_terminal or asyncio.get_running_loop().time() >= deadline:
                 return snapshot, False
 
@@ -2904,6 +2834,7 @@ class JobManager:
         for job_id in expired:
             self._known_job_ids.discard(job_id)
             self._live_snapshots.pop(job_id, None)
+            self._fold_cache.pop(job_id, None)
             self._tasks.pop(job_id, None)
             self._runner_tasks.pop(job_id, None)
             self._monitors.pop(job_id, None)

--- a/src/ouroboros/mcp/job_snapshot.py
+++ b/src/ouroboros/mcp/job_snapshot.py
@@ -1,0 +1,165 @@
+"""Job snapshot types and the resumable event fold behind them.
+
+``JobManager.get_snapshot`` materializes a job by left-folding its event
+stream. Polling loops (the per-job monitor, ``wait_for_change``) used to
+replay that stream from row 0 on every tick, so their cost grew linearly
+with a job's event count. ``JobEventFold`` captures the fold state together
+with the event-store rowid cursor it has consumed, letting those loops fold
+only the events appended since the previous tick. The stream is append-only
+(TTL cleanup prunes in-memory registries, never persisted rows), which is
+what makes the resumable fold sound.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from ouroboros.events.base import BaseEvent
+
+
+class JobStatus(StrEnum):
+    """Lifecycle states for async MCP jobs."""
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    CANCEL_REQUESTED = "cancel_requested"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    INTERRUPTED = "interrupted"
+
+
+@dataclass(frozen=True, slots=True)
+class JobLinks:
+    """Cross-reference IDs attached to a job."""
+
+    session_id: str | None = None
+    execution_id: str | None = None
+    lineage_id: str | None = None
+    preserve_runner_result: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class JobSnapshot:
+    """Materialized view of a background job."""
+
+    job_id: str
+    job_type: str
+    status: JobStatus
+    message: str
+    created_at: datetime
+    updated_at: datetime
+    cursor: int = 0
+    links: JobLinks = field(default_factory=JobLinks)
+    result_text: str | None = None
+    result_meta: dict[str, Any] = field(default_factory=dict)
+    result_payload: dict[str, Any] | None = None
+    error: str | None = None
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in {
+            JobStatus.COMPLETED,
+            JobStatus.FAILED,
+            JobStatus.CANCELLED,
+            JobStatus.INTERRUPTED,
+        }
+
+
+@dataclass(slots=True)
+class JobEventFold:
+    """Mutable fold of one job aggregate, resumable at ``cursor``."""
+
+    created_data: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+    cursor: int
+    status: JobStatus
+    message: str
+    links: JobLinks
+    result_text: str | None = None
+    result_meta: dict[str, Any] = field(default_factory=dict)
+    result_payload: dict[str, Any] | None = None
+    error: str | None = None
+
+    def to_snapshot(self, job_id: str) -> JobSnapshot:
+        return JobSnapshot(
+            job_id=job_id,
+            job_type=self.created_data.get("job_type", "unknown"),
+            status=self.status,
+            message=self.message,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+            cursor=self.cursor,
+            links=self.links,
+            result_text=self.result_text,
+            result_meta=self.result_meta,
+            result_payload=self.result_payload,
+            error=self.error,
+        )
+
+
+def fold_job_events(
+    prior: JobEventFold | None,
+    events: Sequence[BaseEvent],
+    *,
+    cursor: int,
+) -> JobEventFold:
+    """Fold ``events`` into ``prior`` (mutated in place) or start a new fold.
+
+    With ``prior=None`` the first event must be the job's creation event and
+    ``events`` must be non-empty; this path reproduces a full replay. With a
+    prior fold, ``events`` are the rows appended after ``prior.cursor``.
+    """
+    if prior is None:
+        created = events[0]
+        created_links = created.data.get("links", {})
+        prior = JobEventFold(
+            created_data=created.data,
+            created_at=created.timestamp,
+            updated_at=created.timestamp,
+            cursor=cursor,
+            status=JobStatus(created.data.get("status", JobStatus.QUEUED.value)),
+            message=created.data.get("message", ""),
+            links=JobLinks(
+                session_id=created_links.get("session_id"),
+                execution_id=created_links.get("execution_id"),
+                lineage_id=created_links.get("lineage_id"),
+                preserve_runner_result=created_links.get("preserve_runner_result") is True,
+            ),
+        )
+        events = events[1:]
+
+    for event in events:
+        data = event.data
+        link_data = data.get("links") or {}
+        prior.links = JobLinks(
+            session_id=link_data.get("session_id") or prior.links.session_id,
+            execution_id=link_data.get("execution_id") or prior.links.execution_id,
+            lineage_id=link_data.get("lineage_id") or prior.links.lineage_id,
+            preserve_runner_result=(
+                link_data.get("preserve_runner_result")
+                if isinstance(link_data.get("preserve_runner_result"), bool)
+                else prior.links.preserve_runner_result
+            ),
+        )
+        if "status" in data:
+            prior.status = JobStatus(data["status"])
+        if "message" in data:
+            prior.message = data["message"]
+        if "result_text" in data:
+            prior.result_text = data["result_text"]
+        if "result_meta" in data and isinstance(data["result_meta"], dict):
+            prior.result_meta = data["result_meta"]
+        if "result_payload" in data and isinstance(data["result_payload"], dict):
+            prior.result_payload = data["result_payload"]
+        if "error" in data:
+            prior.error = data["error"]
+        prior.updated_at = event.timestamp
+
+    prior.cursor = cursor
+    return prior

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -282,6 +282,7 @@ class TestMCPCommands:
             allowed_hosts=(),
             allowed_origins=(),
             workspace_roots=(),
+            idle_timeout_seconds=None,
         )
 
     def test_mcp_info(self) -> None:

--- a/tests/unit/cli/test_mcp_nested_guard.py
+++ b/tests/unit/cli/test_mcp_nested_guard.py
@@ -186,6 +186,7 @@ def test_serve_defaults_to_port_8080_when_port_omitted(monkeypatch):
         allowed_hosts=(),
         allowed_origins=(),
         workspace_roots=(),
+        idle_timeout_seconds=None,
     )
 
 
@@ -213,6 +214,7 @@ def test_public_claude_cli_runtime_selects_cli_worker(monkeypatch):
         allowed_hosts=(),
         allowed_origins=(),
         workspace_roots=(),
+        idle_timeout_seconds=None,
     )
 
 
@@ -240,6 +242,7 @@ def test_public_host_runtime_selects_host_dispatch(monkeypatch) -> None:
         allowed_hosts=(),
         allowed_origins=(),
         workspace_roots=(),
+        idle_timeout_seconds=None,
     )
 
 
@@ -267,6 +270,7 @@ def test_public_codex_runtime_remains_executable(monkeypatch):
         allowed_hosts=(),
         allowed_origins=(),
         workspace_roots=(),
+        idle_timeout_seconds=None,
     )
 
 
@@ -444,6 +448,7 @@ def test_bare_serve_allows_configured_cli_worker(monkeypatch, tmp_path) -> None:
         allowed_hosts=(),
         allowed_origins=(),
         workspace_roots=(),
+        idle_timeout_seconds=None,
     )
 
 

--- a/tests/unit/mcp/test_job_snapshot_fold.py
+++ b/tests/unit/mcp/test_job_snapshot_fold.py
@@ -1,0 +1,274 @@
+"""Resumable job-snapshot fold and network idle-shutdown lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from ouroboros.cli.commands.mcp import _effective_idle_timeout, _idle_shutdown_loop
+from ouroboros.events.base import BaseEvent
+from ouroboros.mcp.job_manager import JobManager, JobStatus
+from ouroboros.mcp.job_snapshot import fold_job_events
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.persistence.event_store import EventStore
+
+
+def _build_store(tmp_path) -> EventStore:
+    db_path = tmp_path / "jobs.db"
+    return EventStore(f"sqlite+aiosqlite:///{db_path}")
+
+
+async def _blocked_runner(release: asyncio.Event) -> MCPToolResult:
+    await release.wait()
+    return MCPToolResult(
+        content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
+        is_error=False,
+    )
+
+
+async def _drain_manager(manager: JobManager) -> None:
+    tasks = [
+        *manager._tasks.values(),
+        *manager._runner_tasks.values(),
+        *manager._monitors.values(),
+    ]
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+def _job_event(event_type: str, job_id: str, data: dict[str, Any], at: datetime) -> BaseEvent:
+    return BaseEvent(
+        type=event_type,
+        aggregate_type="job",
+        aggregate_id=job_id,
+        data=data,
+        timestamp=at,
+    )
+
+
+class TestFoldJobEvents:
+    def test_batched_fold_equals_single_fold(self) -> None:
+        base = datetime.now(UTC)
+        events = [
+            _job_event(
+                "mcp.job.started",
+                "job-1",
+                {
+                    "job_type": "execute",
+                    "status": "queued",
+                    "message": "queued",
+                    "links": {"session_id": "s-1"},
+                },
+                base,
+            ),
+            _job_event(
+                "mcp.job.updated",
+                "job-1",
+                {
+                    "status": "running",
+                    "message": "working",
+                    "links": {"execution_id": "e-1"},
+                },
+                base + timedelta(seconds=1),
+            ),
+            _job_event(
+                "mcp.job.completed",
+                "job-1",
+                {
+                    "status": "completed",
+                    "message": "done",
+                    "result_text": "all green",
+                    "result_meta": {"final_approved": True},
+                },
+                base + timedelta(seconds=2),
+            ),
+        ]
+
+        whole = fold_job_events(None, events, cursor=3).to_snapshot("job-1")
+        partial = fold_job_events(None, events[:1], cursor=1)
+        partial = fold_job_events(partial, events[1:2], cursor=2)
+        resumed = fold_job_events(partial, events[2:], cursor=3).to_snapshot("job-1")
+
+        assert resumed == whole
+        assert resumed.status is JobStatus.COMPLETED
+        assert resumed.links.session_id == "s-1"
+        assert resumed.links.execution_id == "e-1"
+        assert resumed.result_meta == {"final_approved": True}
+        assert resumed.cursor == 3
+
+    def test_empty_batch_preserves_state(self) -> None:
+        base = datetime.now(UTC)
+        events = [
+            _job_event("mcp.job.started", "job-1", {"job_type": "qa", "status": "running"}, base),
+        ]
+        fold = fold_job_events(None, events, cursor=1)
+        snapshot_before = fold.to_snapshot("job-1")
+        fold = fold_job_events(fold, [], cursor=1)
+        assert fold.to_snapshot("job-1") == snapshot_before
+
+
+class TestGetSnapshotTail:
+    async def test_tail_matches_full_replay_across_appends(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        fresh_reader = JobManager(store)
+        release = asyncio.Event()
+        try:
+            started = await manager.start_job(
+                job_type="execute",
+                initial_message="queued",
+                runner=_blocked_runner(release),
+            )
+            job_id = started.job_id
+            # Let the startup RUNNING append land so the stream is quiescent
+            # and both readers observe the same rows.
+            deadline = asyncio.get_running_loop().time() + 2.0
+            previous_cursor = -1
+            while asyncio.get_running_loop().time() < deadline:
+                current = await fresh_reader.get_snapshot(job_id)
+                if current.cursor == previous_cursor:
+                    break
+                previous_cursor = current.cursor
+                await asyncio.sleep(0.05)
+            for step in range(3):
+                await manager.update_status(job_id, JobStatus.RUNNING, f"step {step}")
+                tail = await manager._get_snapshot_tail(job_id)
+                # A manager with no fold cache performs the historical full
+                # replay; the resumable fold must agree with it exactly.
+                full = await fresh_reader.get_snapshot(job_id)
+                assert tail == full
+                assert tail.message == f"step {step}"
+        finally:
+            release.set()
+            await _drain_manager(manager)
+            await store.close()
+
+    async def test_tail_reads_only_rows_after_cursor(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        release = asyncio.Event()
+        seen_cursors: list[int] = []
+        original = store.get_events_after
+
+        async def spying_get_events_after(
+            aggregate_type: str, aggregate_id: str, last_row_id: int = 0, **kwargs: Any
+        ):
+            if aggregate_type == "job":
+                seen_cursors.append(last_row_id)
+            return await original(aggregate_type, aggregate_id, last_row_id, **kwargs)
+
+        try:
+            started = await manager.start_job(
+                job_type="execute",
+                initial_message="queued",
+                runner=_blocked_runner(release),
+            )
+            job_id = started.job_id
+            await manager._get_snapshot_tail(job_id)  # prime the fold cache
+            store.get_events_after = spying_get_events_after  # type: ignore[method-assign]
+            await manager.update_status(job_id, JobStatus.RUNNING, "later")
+            snapshot = await manager._get_snapshot_tail(job_id)
+            assert snapshot.message == "later"
+            assert seen_cursors, "tail read must hit the event store"
+            assert all(cursor > 0 for cursor in seen_cursors)
+        finally:
+            store.get_events_after = original  # type: ignore[method-assign]
+            release.set()
+            await _drain_manager(manager)
+            await store.close()
+
+    async def test_tail_without_cache_raises_for_unknown_job(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        try:
+            with pytest.raises(ValueError, match="Job not found"):
+                await manager._get_snapshot_tail("job-missing")
+        finally:
+            await store.close()
+
+    async def test_cleanup_drops_fold_cache_entry(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        try:
+            started = await manager.start_job(
+                job_type="execute",
+                initial_message="queued",
+                runner=_ok_result(),
+            )
+            job_id = started.job_id
+            deadline = asyncio.get_running_loop().time() + 2.0
+            while asyncio.get_running_loop().time() < deadline:
+                snapshot = await manager._get_snapshot_tail(job_id)
+                if snapshot.is_terminal:
+                    break
+                await asyncio.sleep(0.01)
+            assert job_id in manager._fold_cache
+            cleaned = await manager.cleanup_expired_jobs(ttl=timedelta(seconds=0))
+            assert cleaned >= 1
+            assert job_id not in manager._fold_cache
+        finally:
+            await _drain_manager(manager)
+            await store.close()
+
+
+async def _ok_result() -> MCPToolResult:
+    return MCPToolResult(
+        content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
+        is_error=False,
+    )
+
+
+class _FakeServer:
+    def __init__(self, idle_for: float) -> None:
+        self.seconds_since_last_tool_call = idle_for
+
+
+class TestIdleShutdown:
+    def test_effective_idle_timeout_defaults(self) -> None:
+        assert _effective_idle_timeout("stdio", None) == 0.0
+        assert _effective_idle_timeout("streamable-http", None) == 7200.0
+        assert _effective_idle_timeout("sse", None) == 7200.0
+        assert _effective_idle_timeout("streamable-http", 0.0) == 0.0
+        assert _effective_idle_timeout("stdio", 30.0) == 30.0
+
+    async def test_sets_stop_once_idle_threshold_is_crossed(self) -> None:
+        stop = asyncio.Event()
+        server = _FakeServer(idle_for=120.0)
+        await asyncio.wait_for(
+            _idle_shutdown_loop(stop, server, 60.0, poll_seconds=0.001),
+            timeout=1.0,
+        )
+        assert stop.is_set()
+
+    async def test_keeps_waiting_while_tool_calls_arrive(self) -> None:
+        stop = asyncio.Event()
+        server = _FakeServer(idle_for=1.0)
+        task = asyncio.create_task(_idle_shutdown_loop(stop, server, 60.0, poll_seconds=0.001))
+        await asyncio.sleep(0.05)
+        assert not stop.is_set()
+        assert not task.done()
+        server.seconds_since_last_tool_call = 999.0
+        await asyncio.wait_for(task, timeout=1.0)
+        assert stop.is_set()
+
+    async def test_exits_quietly_when_stop_already_set(self) -> None:
+        stop = asyncio.Event()
+        stop.set()
+        await asyncio.wait_for(
+            _idle_shutdown_loop(stop, _FakeServer(0.0), 60.0, poll_seconds=0.001),
+            timeout=1.0,
+        )
+
+    async def test_bows_out_when_server_lacks_idle_gauge(self) -> None:
+        stop = asyncio.Event()
+        await asyncio.wait_for(
+            _idle_shutdown_loop(stop, object(), 60.0, poll_seconds=0.001),
+            timeout=1.0,
+        )
+        assert not stop.is_set()


### PR DESCRIPTION
Refs #2325

## User problem

Two of the lifecycle defects behind the 2026-08-31 connection-pool incident:

1. A network-transport (`sse` / `streamable-http`) `ouroboros mcp serve` has no lifecycle tether once its spawner dies — the orphan watchdog deliberately stands down when `ppid == 1`. One such server ran **5 days at 40–80% CPU** (4,263 CPU-minutes), pinning the shared SQLite database.
2. The job polling loops replay a job's **entire event stream from row 0 on every tick** (`_monitor_job` every 1–5 s, `wait_for_change` every 0.5 s), so their cost grows linearly with the job's event count — sustained CPU burn and DB pressure for long-lived jobs.

## Supported inputs and execution conditions

- `ouroboros mcp serve` on any transport; the idle-shutdown bound activates only for network transports by default (`--idle-timeout` overrides; `0` disables; stdio default stays disabled/unbounded).
- Background job monitoring/waiting in the process that owns the job. Cross-process appends (e.g. `ouroboros_cancel_job` from a later MCP process) remain visible: the fold resumes from a SQLite rowid cursor, and SQLite's single-writer lock serializes rowid assignment, so cursor tailing cannot skip rows.

## Observable contract and invariants

- A network serve with no tool call for `--idle-timeout` seconds (default 7200) sets its stop event and runs the existing graceful-shutdown path (job drain, WAL truncate, PID-file cleanup). Explicit `--idle-timeout 0` keeps today's unbounded behavior.
- `get_snapshot` semantics are unchanged (still a full replay, still `ValueError` for unknown jobs); the new `_get_snapshot_tail` used by the polling loops produces **identical snapshots** while reading only rows after the cached cursor. Proven by `test_tail_matches_full_replay_across_appends` (fold vs. fresh-manager full replay, field-for-field) and `test_batched_fold_equals_single_fold`.
- The fold cache is process-local, refreshed by every full replay, and dropped by TTL cleanup with the other per-job registries. The event stream itself is append-only (cleanup prunes in-memory registries only), which is what makes the resumable fold sound.
- No event types added, renamed, or removed; write paths untouched.

## Changed subsystem, data/security boundary, owner

- `src/ouroboros/cli/commands/mcp.py`: serve idle lifecycle (new `--idle-timeout`, `_idle_shutdown_loop`, `_effective_idle_timeout`).
- `src/ouroboros/mcp/job_manager.py` + new `src/ouroboros/mcp/job_snapshot.py`: job snapshot read path. `JobStatus`/`JobLinks`/`JobSnapshot` moved verbatim into the new module (re-exported from `job_manager`, all existing imports unchanged) because the fold lives with the types and `job_manager` is grandfathered at 2950 lines (now 2875, was 2944).
- No data or security boundary changes. Owner: @Q00.

## Non-goals

- The stdio zombie exit path (`os.close(0)` no-op under mcp 2.0, shielded non-daemon stdin thread, dead-peer detection) — PR B on #2325.
- gjc worker-session reclamation — #2326.
- The reconcile steps' own reads of linked aggregates (they early-return for in-process-owned jobs, the polling loops' case).

## Evidence

- Incident: 119 serve processes / 54 DB holders on one machine; `QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00` × 714 in `~/.ouroboros/logs`; one launchd-orphaned http serve at 40–80% CPU for 5 days.
- Hot-loop cost before: `get_snapshot` → `get_events_after("job", id, last_row_id=0)` every tick; after: rows after cursor only (`test_tail_reads_only_rows_after_cursor` asserts every store read passes a positive cursor).
- New tests (11, all passing): fold identity, empty-batch stability, tail-vs-full equality across appends, cursor-only reads, unknown-job `ValueError`, TTL cache drop, idle-timeout defaults per transport, stop-on-threshold, no-fire-while-active, no-fire-when-stopped, graceful bow-out without the idle gauge.
- Gates: ruff clean, mypy clean (615 files), `check-module-size` OK, full `pytest` run attached in comments if requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDJPBa4pxVbUvcUcKeT5Ea
