### PR TITLE
fix(mcp): hard-exit backstop and stdin dead-peer watchdog for immortal serve zombies

### DIFF
--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -6,6 +6,7 @@ Start and manage the MCP (Model Context Protocol) server.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 import contextlib
 from enum import Enum
 import json
@@ -13,6 +14,7 @@ import os
 from pathlib import Path
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import time
@@ -554,6 +556,121 @@ def _resolve_client_identity(orig_ppid: int) -> tuple[int, float | None] | None:
     return None
 
 
+def _make_stdin_peer_probe(stdin_fd: int = 0) -> Callable[[], bool] | None:
+    """Build a dead-peer probe for a socket stdin, or None when inapplicable.
+
+    Some MCP clients hand this server a unix socketpair as stdin. When such a
+    client dies without an orderly close, the socket never delivers a readline
+    EOF — the fd lingers with a gone peer (lsof shows ``->(none)``) and the
+    serve loop blocks forever: the immortal-zombie incident of 2026-08-31.
+
+    The MCP SDK (mcp>=2.0) diverts fd 0 away from the wire while serving, so
+    the probe duplicates the descriptor *now*, before the serve loop starts,
+    and watches the duplicate. ``MSG_PEEK`` keeps protocol bytes in the queue,
+    making the probe non-destructive.
+
+    Returns None on Windows and when stdin is not a socket — a pipe or tty
+    stdin already delivers EOF when the client dies, so no probe is needed.
+    """
+    if sys.platform == "win32":
+        return None
+    try:
+        wire_fd = os.dup(stdin_fd)
+    except OSError:
+        return None
+    try:
+        wire = socket.socket(fileno=wire_fd)
+    except OSError:
+        # Not a socket (ENOTSOCK): socket() does not take ownership on
+        # failure, so release the duplicate ourselves.
+        with contextlib.suppress(OSError):
+            os.close(wire_fd)
+        return None
+    try:
+        wire.setblocking(False)
+    except OSError:
+        wire.close()
+        return None
+
+    def _peer_is_dead() -> bool:
+        try:
+            data = wire.recv(1, socket.MSG_PEEK)
+        except BlockingIOError:
+            return False  # live peer, nothing queued
+        except OSError:
+            return True  # ECONNRESET-class: peer is gone
+        return len(data) == 0  # b"" is an orderly peer close
+
+    return _peer_is_dead
+
+
+async def _orphan_watchdog_loop(
+    *,
+    stop: asyncio.Event,
+    orig_ppid: int,
+    client_identity: tuple[int, float | None] | None,
+    stdin_peer_dead: Callable[[], bool] | None,
+    poll_seconds: float = 5.0,
+) -> None:
+    """Stop the server once the client that owns it is provably gone.
+
+    Three complementary checks, polled every ``poll_seconds``:
+
+    - getppid() vs the original parent (covers direct-parent death; under the
+      shipped ``client -> uvx -> python`` topology the uv wrapper survives the
+      client, so this alone can never fire there),
+    - a stdin socket dead-peer probe (covers a socketpair stdin whose peer
+      vanished without EOF — the state fd-0 lsof reports as ``->(none)``),
+    - the resolved client identity (nearest non-wrapper ancestor, pid + start
+      marker; immune to subreapers and pid recycling).
+
+    A server that starts already detached (``orig_ppid == 1``) with no stdio
+    wire to watch has no tether and must never self-terminate (a real
+    launchd/systemd service). streamable-http idle shutdown is tracked
+    separately (#2325).
+    """
+    if orig_ppid == 1 and stdin_peer_dead is None:
+        return
+    while not stop.is_set():
+        if orig_ppid != 1 and os.getppid() != orig_ppid:
+            _stderr_console.print("[yellow]Parent client gone — orphan exit[/yellow]")
+            stop.set()
+            return
+        if stdin_peer_dead is not None and stdin_peer_dead():
+            _stderr_console.print("[yellow]stdin peer closed — orphan exit[/yellow]")
+            stop.set()
+            return
+        if client_identity is not None:
+            client_pid, client_start = client_identity
+            alive = await asyncio.to_thread(_client_is_alive, client_pid, client_start)
+            if not alive:
+                _stderr_console.print(
+                    f"[yellow]MCP client (pid {client_pid}) gone — orphan exit[/yellow]"
+                )
+                stop.set()
+                return
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(stop.wait(), timeout=poll_seconds)
+
+
+def _flush_and_hard_exit(code: int) -> None:
+    """Terminate the process when graceful teardown is impossible.
+
+    Reached only after the shutdown grace expired with the serve loop still
+    parked on the MCP SDK's stdin reader, and after every cleanup in
+    ``_run_mcp_server``'s finally block (job drain, store close, pid-record
+    removal) has already run. That reader is a shielded, non-daemon anyio
+    worker thread: returning normally instead would leave asyncio.run() and
+    interpreter teardown blocked forever joining it — the immortal-zombie
+    symptom this backstop exists to end.
+    """
+    with contextlib.suppress(Exception):
+        sys.stdout.flush()
+    with contextlib.suppress(Exception):
+        sys.stderr.flush()
+    os._exit(code)
+
+
 app = typer.Typer(
     name="mcp",
     help="MCP (Model Context Protocol) server commands.",
@@ -894,51 +1011,20 @@ async def _run_mcp_server(
                 loop.add_signal_handler(_sig, _request_stop, _sig.name)
 
         # Client-death watchdog: when the MCP client that spawned us dies, exit
-        # instead of pinning the SQLite database forever (streamable-http has no
-        # stdin EOF to rely on; for stdio, EOF stays the primary defense). Two
-        # complementary checks, polled every 5s:
-        #  - getppid() vs the original parent: catches death of whatever spawned
-        #    us directly. Under the shipped `client -> uvx -> python` topology the
-        #    direct parent is the uv wrapper, which blocks on waitpid() and
-        #    survives the client's death — this check alone can never fire there
-        #    (the orphaned wrapper is reparented; our own ppid never changes).
-        #  - the resolved *client* identity (nearest non-wrapper ancestor at
-        #    startup, pid + start time): catches the real client dying behind the
-        #    wrapper. Polling an absolute pid identity is immune to subreapers
-        #    (systemd --user, tini) and to pid recycling. OUROBOROS_CLIENT_PID
-        #    overrides the ancestor walk for spawners that want to pin the
-        #    watched process explicitly.
-        # Skipped when launched already-detached on purpose (orig_ppid == 1,
-        # e.g. a real launchd/systemd service — such servers must never
-        # self-terminate). Not effective on Windows (no POSIX ps, no
-        # reparent-on-death model); SIGINT/stdin EOF cover the common cases
-        # there.
+        # instead of pinning the SQLite database forever (streamable-http has
+        # no stdin EOF to rely on; a socketpair stdin may never deliver one).
+        # Checks and their rationale live on _orphan_watchdog_loop. Not
+        # effective on Windows (no POSIX ps, no reparent-on-death model);
+        # SIGINT/stdin EOF cover the common cases there.
         orig_ppid = os.getppid()
         client_identity: tuple[int, float | None] | None = None
         if orig_ppid != 1:
             # ps lookups can block up to their subprocess timeout — resolve off
             # the event loop so a slow ps never stalls the MCP handshake.
             client_identity = await asyncio.to_thread(_resolve_client_identity, orig_ppid)
-
-        async def _orphan_watchdog() -> None:
-            if orig_ppid == 1:
-                return
-            while not stop.is_set():
-                if os.getppid() != orig_ppid:
-                    _console_out.print("[yellow]Parent client gone — orphan exit[/yellow]")
-                    stop.set()
-                    return
-                if client_identity is not None:
-                    client_pid, client_start = client_identity
-                    alive = await asyncio.to_thread(_client_is_alive, client_pid, client_start)
-                    if not alive:
-                        _console_out.print(
-                            f"[yellow]MCP client (pid {client_pid}) gone — orphan exit[/yellow]"
-                        )
-                        stop.set()
-                        return
-                with contextlib.suppress(asyncio.TimeoutError):
-                    await asyncio.wait_for(stop.wait(), timeout=5.0)
+        # Duplicate the stdin descriptor before the SDK's serve loop diverts
+        # fd 0 (mcp>=2.0), so the probe watches the real wire.
+        stdin_peer_dead = _make_stdin_peer_probe() if transport == "stdio" else None
 
         effective_idle_timeout = _effective_idle_timeout(transport, idle_timeout_seconds)
 
@@ -972,7 +1058,15 @@ async def _run_mcp_server(
             name="ouroboros-mcp-serve",
         )
         stop_task = asyncio.create_task(stop.wait(), name="ouroboros-mcp-stop")
-        watchdog_task = asyncio.create_task(_orphan_watchdog(), name="ouroboros-mcp-watchdog")
+        watchdog_task = asyncio.create_task(
+            _orphan_watchdog_loop(
+                stop=stop,
+                orig_ppid=orig_ppid,
+                client_identity=client_identity,
+                stdin_peer_dead=stdin_peer_dead,
+            ),
+            name="ouroboros-mcp-watchdog",
+        )
         idle_checkpoint_task = asyncio.create_task(
             _idle_wal_checkpoint(), name="ouroboros-mcp-idle-checkpoint"
         )
@@ -1021,28 +1115,34 @@ async def _run_mcp_server(
         if serve_task is not None and not serve_task.done():
             serve_task.cancel()
         # Bound the serve drain: the MCP SDK's stdio session reads stdin via a
-        # shielded worker thread (anyio readline, abandon_on_cancel=False), so an
-        # unbounded ``await serve_task`` hangs forever when shutdown was requested
-        # by a signal or the watchdog while the client is alive but quiescent —
-        # the exact "server survives kill" symptom. After the grace, closing fd 0
-        # EOFs the blocked readline (verified empirically on macOS, the primary
-        # fleet; best-effort elsewhere — a second bounded wait below means a
-        # non-waking platform still proceeds to cleanup). os._exit is
-        # deliberately NOT used anywhere here: every exit must run the store
-        # cleanup below.
+        # shielded worker thread (anyio readline, abandon_on_cancel=False), so
+        # an unbounded ``await serve_task`` hangs forever when shutdown was
+        # requested by a signal or the watchdog while the client is alive but
+        # quiescent. No descriptor this function can close will EOF that read:
+        # mcp>=2.0 serves the wire from a private duplicate of fd 0 (fd 0
+        # itself is diverted to /dev/null), so the closing-fd-0 trick of
+        # earlier releases is a no-op. The reader thread is also non-daemon —
+        # if the serve task is still pending after the graces, returning
+        # normally would leave asyncio.run() and interpreter teardown blocked
+        # forever joining it (the immortal-zombie incident). The only working
+        # exit is _flush_and_hard_exit at the END of this finally block: a
+        # hard exit is permitted strictly as the last resort, after the job
+        # drain, store close and pid-record cleanup below have all run.
+        hard_exit_required = False
         pending: set[asyncio.Task[Any]] = {
             t for t in (serve_task, *helper_tasks) if t is not None and not t.done()
         }
         if pending:
+            # Two consecutive graces preserve the historical total budget and
+            # give a slow-but-cooperative unwind time to finish on its own.
             _, pending = await asyncio.wait(pending, timeout=_SHUTDOWN_DRAIN_GRACE_SECONDS)
-            if serve_task is not None and serve_task in pending and transport == "stdio":
-                with contextlib.suppress(OSError):
-                    os.close(0)
+            if pending:
                 _, pending = await asyncio.wait(pending, timeout=_SHUTDOWN_DRAIN_GRACE_SECONDS)
             if pending:
+                hard_exit_required = True
                 _console_out.print(
                     "[yellow]Serve loop did not stop within the shutdown grace; "
-                    "continuing cleanup[/yellow]"
+                    "cleaning up and forcing exit[/yellow]"
                 )
         # Retrieve parked results so completed tasks never log
         # "exception was never retrieved" during interpreter teardown.
@@ -1103,6 +1203,10 @@ async def _run_mcp_server(
         # (SIGTERM/orphan-exit/stdin EOF) and propagates nothing.
         if serve_task is not None and serve_task.done() and not serve_task.cancelled():
             serve_exc = serve_task.exception()
+        if hard_exit_required and serve_exc is None:
+            # Every cleanup above has run; only the unjoinable stdin reader
+            # keeps this process alive. See _flush_and_hard_exit.
+            _flush_and_hard_exit(0)
 
     # Surface a serve-loop failure only after cleanup has collapsed the WAL and
     # released the stores. This preserves the error-propagation contract of the

--- a/tests/unit/cli/test_mcp_shutdown_drain.py
+++ b/tests/unit/cli/test_mcp_shutdown_drain.py
@@ -4,8 +4,8 @@ The MCP SDK's stdio session reads stdin via a shielded anyio worker thread
 (``abandon_on_cancel=False``), so an unbounded ``await serve_task`` in the
 shutdown path hangs forever whenever a stop was requested by a signal or the
 watchdog while the client is alive but quiescent — the "server survives kill"
-symptom. The drain is bounded; after the grace, fd 0 is closed (stdio only)
-to EOF the blocked readline so the normal cleanup path completes.
+symptom. The drain is bounded; a serve task that outlives the graces forces a
+hard exit, but only after every cleanup in the finally block has run.
 """
 
 from __future__ import annotations
@@ -95,30 +95,35 @@ async def test_watchdog_dead_client_stops_server(monkeypatch) -> None:
     mock_server.shutdown.assert_awaited_once()
 
 
+class _HardExitCalled(BaseException):
+    """Sentinel the test raises in place of ``os._exit``."""
+
+
 @pytest.mark.asyncio
-async def test_stuck_serve_loop_is_bounded_and_unblocked_by_fd0_close(monkeypatch) -> None:
-    """A serve loop that swallows cancellation must not hang shutdown."""
+async def test_stuck_serve_loop_hard_exits_after_cleanup(monkeypatch) -> None:
+    """A serve loop that swallows cancellation must force a hard exit.
+
+    Under mcp>=2.0 no descriptor close can EOF the SDK's stdin reader (the
+    wire is a private duplicate of fd 0) and the reader thread is non-daemon,
+    so returning normally would hang interpreter teardown forever. The drain
+    must therefore invoke the hard-exit backstop — but only AFTER the finally
+    block's cleanup (server shutdown among it) has run.
+    """
     mock_es, mock_repo, mock_server = _make_mocks()
-    monkeypatch.setattr(mcp_module, "_SHUTDOWN_DRAIN_GRACE_SECONDS", 0.2)
+    monkeypatch.setattr(mcp_module, "_SHUTDOWN_DRAIN_GRACE_SECONDS", 0.1)
 
-    closed_fds: list[int] = []
     release = asyncio.Event()
-    real_close = mcp_module.os.close
+    hard_exit_codes: list[int] = []
 
-    def fake_close(fd: int) -> None:
-        # Intercept only fd 0 (the drain's EOF escalation); everything else
-        # must really close or subprocess plumbing (ps lookups) deadlocks.
-        if fd == 0:
-            closed_fds.append(fd)
-            release.set()
-            return
-        real_close(fd)
+    def fake_hard_exit(code: int) -> None:
+        hard_exit_codes.append(code)
+        release.set()  # let the stuck task finish so the loop tears down clean
+        raise _HardExitCalled
 
-    monkeypatch.setattr(mcp_module.os, "close", fake_close)
+    monkeypatch.setattr(mcp_module, "_flush_and_hard_exit", fake_hard_exit)
 
     async def stuck_serve(*args, **kwargs):
-        # Emulates the shielded stdin readline: swallows cancellation and only
-        # returns once fd 0 is closed (EOF reaches the worker thread).
+        # Emulates the shielded stdin readline: swallows cancellation forever.
         while True:
             try:
                 await release.wait()
@@ -133,31 +138,27 @@ async def test_stuck_serve_loop_is_bounded_and_unblocked_by_fd0_close(monkeypatc
     monkeypatch.setattr(mcp_module, "_client_is_alive", lambda _pid, _start_marker=None: False)
 
     es_patch, repo_patch, server_patch = _patches(mock_es, mock_repo, mock_server)
-    with es_patch, repo_patch, server_patch:
+    with es_patch, repo_patch, server_patch, pytest.raises(_HardExitCalled):
         await asyncio.wait_for(
             mcp_module._run_mcp_server("localhost", 8080, "stdio"),
             timeout=10.0,
         )
 
-    assert 0 in closed_fds, "the drain must EOF fd 0 after the grace expired"
+    assert hard_exit_codes == [0]
+    # Cleanup must have completed BEFORE the hard exit fired.
     mock_server.shutdown.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_non_stdio_transport_never_closes_fd0(monkeypatch) -> None:
+async def test_slow_cooperative_unwind_does_not_hard_exit(monkeypatch) -> None:
+    """An unwind that finishes within the graces must exit gracefully."""
     mock_es, mock_repo, mock_server = _make_mocks()
-    monkeypatch.setattr(mcp_module, "_SHUTDOWN_DRAIN_GRACE_SECONDS", 0.1)
+    monkeypatch.setattr(mcp_module, "_SHUTDOWN_DRAIN_GRACE_SECONDS", 0.3)
 
-    closed_fds: list[int] = []
-    real_close = mcp_module.os.close
-
-    def fake_close(fd: int) -> None:
-        if fd == 0:
-            closed_fds.append(fd)
-            return
-        real_close(fd)
-
-    monkeypatch.setattr(mcp_module.os, "close", fake_close)
+    hard_exit_codes: list[int] = []
+    monkeypatch.setattr(
+        mcp_module, "_flush_and_hard_exit", lambda code: hard_exit_codes.append(code)
+    )
 
     stop_probe = asyncio.Event()
 
@@ -167,7 +168,7 @@ async def test_non_stdio_transport_never_closes_fd0(monkeypatch) -> None:
         except asyncio.CancelledError:
             # One slow unwind beyond the first grace window, then exit.
             stop_probe.set()
-            await asyncio.sleep(0.3)
+            await asyncio.sleep(0.4)
             raise
 
     mock_server.serve.side_effect = slow_then_cooperative_serve
@@ -183,7 +184,8 @@ async def test_non_stdio_transport_never_closes_fd0(monkeypatch) -> None:
         )
 
     assert stop_probe.is_set()
-    assert closed_fds == [], "fd 0 belongs to the console on network transports"
+    assert hard_exit_codes == [], "a cooperative unwind must never hard-exit"
+    mock_server.shutdown.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/test_mcp_stdin_peer_probe.py
+++ b/tests/unit/cli/test_mcp_stdin_peer_probe.py
@@ -1,0 +1,193 @@
+"""Tests for the stdin dead-peer probe and the extracted orphan watchdog loop.
+
+Production zombies (2026-08-31) held a socketpair stdin whose peer was gone
+(lsof ``->(none)``) without ever delivering a readline EOF, so the serve loop
+outlived its client indefinitely. The probe detects exactly that state; the
+watchdog loop turns it — and parent-death signals — into a stop request.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import sys
+
+import pytest
+
+from ouroboros.cli.commands import mcp as mcp_module
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="the probe is POSIX-only by design")
+
+
+class TestMakeStdinPeerProbe:
+    def test_live_peer_reports_alive(self) -> None:
+        ours, theirs = socket.socketpair()
+        try:
+            probe = mcp_module._make_stdin_peer_probe(ours.fileno())
+            assert probe is not None
+            assert probe() is False
+        finally:
+            ours.close()
+            theirs.close()
+
+    def test_dead_peer_is_detected(self) -> None:
+        ours, theirs = socket.socketpair()
+        try:
+            probe = mcp_module._make_stdin_peer_probe(ours.fileno())
+            assert probe is not None
+            theirs.close()
+            assert probe() is True
+        finally:
+            ours.close()
+
+    def test_peek_does_not_consume_protocol_bytes(self) -> None:
+        ours, theirs = socket.socketpair()
+        try:
+            probe = mcp_module._make_stdin_peer_probe(ours.fileno())
+            assert probe is not None
+            theirs.sendall(b"x")
+            assert probe() is False, "queued bytes mean the peer was alive to send them"
+            assert ours.recv(1) == b"x", "MSG_PEEK must leave the byte in the queue"
+        finally:
+            ours.close()
+            theirs.close()
+
+    def test_probe_survives_fd_diversion(self) -> None:
+        """The probe watches a duplicate, immune to later dup2 games on the fd.
+
+        mcp>=2.0 diverts fd 0 to /dev/null while serving; the probe must keep
+        watching the original wire regardless.
+        """
+        ours, theirs = socket.socketpair()
+        devnull = os.open(os.devnull, os.O_RDONLY)
+        # Sacrifice a duplicate as the "fd 0" stand-in so real stdin is safe.
+        stand_in = os.dup(ours.fileno())
+        try:
+            probe = mcp_module._make_stdin_peer_probe(stand_in)
+            assert probe is not None
+            os.dup2(devnull, stand_in)  # the SDK's diversion
+            assert probe() is False
+            theirs.close()
+            assert probe() is True
+        finally:
+            os.close(stand_in)
+            os.close(devnull)
+            ours.close()
+
+    def test_non_socket_stdin_returns_none(self, tmp_path) -> None:
+        read_fd, write_fd = os.pipe()
+        try:
+            assert mcp_module._make_stdin_peer_probe(read_fd) is None
+        finally:
+            os.close(read_fd)
+            os.close(write_fd)
+        plain = os.open(tmp_path / "plain", os.O_CREAT | os.O_RDWR)
+        try:
+            assert mcp_module._make_stdin_peer_probe(plain) is None
+        finally:
+            os.close(plain)
+
+    def test_invalid_fd_returns_none(self) -> None:
+        assert mcp_module._make_stdin_peer_probe(999_999) is None
+
+
+class TestOrphanWatchdogLoop:
+    @pytest.mark.asyncio
+    async def test_reparented_to_init_stops_server(self, monkeypatch) -> None:
+        """getppid() drifting to 1 (parent died) must request a stop."""
+        monkeypatch.setattr(mcp_module.os, "getppid", lambda: 1)
+        stop = asyncio.Event()
+        await asyncio.wait_for(
+            mcp_module._orphan_watchdog_loop(
+                stop=stop,
+                orig_ppid=4242,
+                client_identity=None,
+                stdin_peer_dead=None,
+                poll_seconds=0.05,
+            ),
+            timeout=5.0,
+        )
+        assert stop.is_set()
+
+    @pytest.mark.asyncio
+    async def test_dead_stdin_peer_stops_server(self, monkeypatch) -> None:
+        current_ppid = os.getppid()
+        monkeypatch.setattr(mcp_module.os, "getppid", lambda: current_ppid)
+        stop = asyncio.Event()
+        await asyncio.wait_for(
+            mcp_module._orphan_watchdog_loop(
+                stop=stop,
+                orig_ppid=current_ppid,
+                client_identity=None,
+                stdin_peer_dead=lambda: True,
+                poll_seconds=0.05,
+            ),
+            timeout=5.0,
+        )
+        assert stop.is_set()
+
+    @pytest.mark.asyncio
+    async def test_detached_start_with_probe_is_still_watched(self) -> None:
+        """orig_ppid == 1 no longer disables the watchdog when a wire exists.
+
+        A stdio server spawned already-detached (the launchd-orphan zombie
+        case) still has its stdin socket to watch; a dead peer must stop it.
+        """
+        stop = asyncio.Event()
+        await asyncio.wait_for(
+            mcp_module._orphan_watchdog_loop(
+                stop=stop,
+                orig_ppid=1,
+                client_identity=None,
+                stdin_peer_dead=lambda: True,
+                poll_seconds=0.05,
+            ),
+            timeout=5.0,
+        )
+        assert stop.is_set()
+
+    @pytest.mark.asyncio
+    async def test_detached_start_without_probe_never_self_terminates(self) -> None:
+        """A deliberate service (ppid 1, no stdio wire) keeps no tether."""
+        stop = asyncio.Event()
+        await asyncio.wait_for(
+            mcp_module._orphan_watchdog_loop(
+                stop=stop,
+                orig_ppid=1,
+                client_identity=None,
+                stdin_peer_dead=None,
+                poll_seconds=0.05,
+            ),
+            timeout=5.0,
+        )
+        assert not stop.is_set()
+
+    @pytest.mark.asyncio
+    async def test_live_peer_keeps_polling_until_stop(self, monkeypatch) -> None:
+        current_ppid = os.getppid()
+        monkeypatch.setattr(mcp_module.os, "getppid", lambda: current_ppid)
+        stop = asyncio.Event()
+        task = asyncio.create_task(
+            mcp_module._orphan_watchdog_loop(
+                stop=stop,
+                orig_ppid=current_ppid,
+                client_identity=None,
+                stdin_peer_dead=lambda: False,
+                poll_seconds=0.05,
+            )
+        )
+        await asyncio.sleep(0.2)
+        assert not task.done()
+        stop.set()
+        await asyncio.wait_for(task, timeout=5.0)
+
+
+class TestFlushAndHardExit:
+    def test_flushes_before_exit(self, monkeypatch) -> None:
+        calls: list[tuple[str, int | None]] = []
+        monkeypatch.setattr(mcp_module.sys.stdout, "flush", lambda: calls.append(("flush", None)))
+        monkeypatch.setattr(mcp_module.os, "_exit", lambda code: calls.append(("exit", code)))
+        mcp_module._flush_and_hard_exit(0)
+        assert ("exit", 0) in calls
+        assert calls.index(("flush", None)) < calls.index(("exit", 0))


### PR DESCRIPTION
Refs #2325

## User problem

`ouroboros mcp serve` processes outlive their dead MCP clients indefinitely and pin the shared SQLite database. On 2026-08-31 one machine accumulated 119 serve processes (54 holding `~/.ouroboros/data/ouroboros.db`), driving the `QueuePool limit of size 5 overflow 10 reached` pool-exhaustion incident (714 log occurrences). The zombies' fd 0 was a unix socket whose peer was gone (`->(none)` in lsof) — no readline EOF ever arrived, and the existing watchdog (shipped since 0.51.17) fired but could not make the process exit.

## Why the existing defense fails

- The shutdown path's `os.close(0)` EOF poke targets the wrong descriptor under mcp==2.0.0: the SDK diverts fd 0 to /dev/null and serves the wire from a private duplicate, so closing fd 0 is a no-op.
- The SDK's stdin readline runs in a shielded (`abandon_on_cancel=False`), **non-daemon** anyio worker thread: even after the serve coroutine returns, interpreter teardown blocks forever joining it. The old comment forbade `os._exit`, leaving no working exit at all.
- `_orphan_watchdog` disabled itself entirely when `orig_ppid == 1`, so an already-detached stdio server had no tether.

## Change

All in `src/ouroboros/cli/commands/mcp.py`:

1. **Hard-exit backstop**: when the serve task is still pending after two shutdown graces, the finally block now completes *all* cleanup (job drain, store close, WAL collapse, pid-record removal) and then calls `_flush_and_hard_exit(0)` — `os._exit` strictly as the last resort, never a shortcut past cleanup. The forbidding comment is rewritten to state the new invariant.
2. **Dead-peer probe**: `_make_stdin_peer_probe()` duplicates the stdin descriptor *before* the SDK diverts fd 0 and detects a vanished socket peer via non-destructive `MSG_PEEK` (`b""` = orderly close, `ECONNRESET`-class = dead, `BlockingIOError` = alive). Returns None for pipe/tty stdin (EOF already works there) and on Windows.
3. **Watchdog**: extracted to module-level `_orphan_watchdog_loop` and wired with the probe. `orig_ppid == 1` now disables the watchdog only when there is also no stdio wire to watch (a deliberate launchd/systemd service); a detached stdio server with a dead peer is reaped.
4. The ineffective `os.close(0)` poke is removed (its second grace window is kept, preserving the historical drain budget).

## Supported inputs / execution conditions

POSIX (macOS/Linux) stdio serve; probe inert on Windows and non-socket stdin. streamable-http keeps its current lifecycle except that the drain backstop applies to any transport whose serve task survives the graces.

## Observable contract / invariants

- A stdio serve whose client is provably gone (reparented, dead client identity, or dead stdin socket peer) stops within one watchdog poll (5s) plus the bounded drain.
- Cleanup (job drain → store close → pid record) ALWAYS runs before any hard exit; a serve-loop exception still propagates and is never masked by the backstop.
- A deliberately detached server with no stdio wire never self-terminates (unchanged).
- MSG_PEEK never consumes protocol bytes.

## Changed subsystem / boundary / owner

CLI serve lifecycle (`cli/commands/mcp.py`) only. No changes to the MCP SDK usage surface, job manager, stores, or any runtime adapter. Owner: @Q00.

## Non-goals

- streamable-http idle shutdown and the job-monitor CPU runaway (follow-up PR, same issue #2325).
- gjc worker-session reclamation (#2326).
- Upstream anyio/mcp SDK behavior.

## Evidence

- Incident forensics: 29 zombies from one night, all with dead-socket fd 0; the watchdog code present since 0.51.17 did not prevent them; a launchd-orphaned http serve ran 5 days at 40–80% CPU.
- New tests: `tests/unit/cli/test_mcp_stdin_peer_probe.py` (probe alive/dead/peek-non-destructive/diversion-immunity/non-socket/invalid-fd; watchdog reparent/dead-peer/detached-with-wire/detached-service/live-poll; hard-exit flush ordering) and updated `tests/unit/cli/test_mcp_shutdown_drain.py` (stuck serve → hard exit AFTER cleanup; slow cooperative unwind → no hard exit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDJPBa4pxVbUvcUcKeT5Ea
