### PR TITLE
fix(codex): exempt main-repo-root automatic trust from config drift for worktree cwds

### DIFF
--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -361,6 +361,7 @@ class CodexCliRuntime:
             self._profile_resolution_fingerprint = self._fingerprint_profile_resolution_config()
             self._codex_profile_v2_names = self._codex_profile_v2_names_from_ouroboros_config()
             self._codex_project_trust_baseline = self._read_codex_project_trust_levels()
+            self._codex_trust_exempt_keys_cache: frozenset[str] | None = None
             self._codex_config_fingerprint = self._fingerprint_codex_config_files()
             self._skill_dispatch_registry_fingerprint = self._fingerprint_skill_dispatch_registry()
             self._builtin_mcp_handler_registry_fingerprint = (
@@ -379,6 +380,7 @@ class CodexCliRuntime:
             self._codex_config_fingerprint = None
             self._codex_profile_v2_names = set()
             self._codex_project_trust_baseline = None
+            self._codex_trust_exempt_keys_cache = None
             self._skill_dispatch_registry_fingerprint = None
             self._builtin_mcp_handler_registry_fingerprint = None
             self._runtime_handle_profile_fingerprints = {}
@@ -810,6 +812,68 @@ class CodexCliRuntime:
             if isinstance(settings, dict) and "trust_level" in settings
         }
 
+    def _codex_trust_exempt_project_keys(self) -> frozenset[str]:
+        """Project keys whose automatic first-use trust entry is not drift.
+
+        Codex records first-use trust against the git MAIN repository root, so
+        a task running inside a linked worktree (the orchestrator's normal
+        layout) writes ``projects.<main-root>.trust_level`` — not an entry for
+        the worktree path this runtime was initialized with. Both keys describe
+        the same benign mutation for the same execution and neither can
+        retarget a model/profile; every other project's trust remains
+        authority-bearing drift.
+        """
+        cached = self._codex_trust_exempt_keys_cache
+        if cached is not None:
+            return cached
+        keys: set[str] = set()
+        if self._cwd is not None:
+            keys.add(self._cwd)
+            main_root = self._git_main_repository_root(self._cwd)
+            if main_root is not None:
+                keys.add(main_root)
+        resolved = frozenset(keys)
+        self._codex_trust_exempt_keys_cache = resolved
+        return resolved
+
+    def _git_main_repository_root(self, cwd: str) -> str | None:
+        """Resolve the main repository root for a linked-worktree cwd.
+
+        Pure file inspection (no subprocess): a linked worktree carries a
+        ``.git`` FILE containing ``gitdir: <main>/.git/worktrees/<name>``.
+        Returns None when cwd is not a linked worktree or the layout is
+        unrecognized — exemption then falls back to the cwd key alone.
+        """
+        try:
+            current = Path(cwd).expanduser().resolve(strict=False)
+        except (OSError, RuntimeError, ValueError):
+            return None
+        for candidate in (current, *current.parents):
+            gitfile = candidate / ".git"
+            try:
+                if gitfile.is_dir():
+                    return str(candidate) if candidate != current else None
+                if not gitfile.is_file():
+                    continue
+                content = gitfile.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                return None
+            for line in content.splitlines():
+                if not line.startswith("gitdir:"):
+                    continue
+                gitdir = Path(line[len("gitdir:") :].strip()).expanduser()
+                if not gitdir.is_absolute():
+                    gitdir = candidate / gitdir
+                # <main>/.git/worktrees/<name> -> <main>
+                if gitdir.parent.parent.name == ".git":
+                    try:
+                        return str(gitdir.parent.parent.parent.resolve(strict=False))
+                    except (OSError, RuntimeError, ValueError):
+                        return None
+                return None
+            return None
+        return None
+
     @staticmethod
     def _canonical_codex_project_path(project_path: str) -> str:
         """Match Codex project keys to the canonical cwd without weakening drift."""
@@ -952,8 +1016,7 @@ class CodexCliRuntime:
                 canonical_project_key = self._canonical_codex_project_path(project_key)
                 automatic_current_cwd_trust = (
                     self._codex_project_trust_baseline is not None
-                    and self._cwd is not None
-                    and canonical_project_key == self._cwd
+                    and canonical_project_key in self._codex_trust_exempt_project_keys()
                     and canonical_project_key not in self._codex_project_trust_baseline
                     and raw_settings.get("trust_level") == "trusted"
                 )

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -839,10 +839,9 @@ class CodexCliRuntime:
     def _git_main_repository_root(self, cwd: str) -> str | None:
         """Resolve the main repository root for a linked-worktree cwd.
 
-        Pure file inspection (no subprocess): a linked worktree carries a
-        ``.git`` FILE containing ``gitdir: <main>/.git/worktrees/<name>``.
-        Returns None when cwd is not a linked worktree or the layout is
-        unrecognized — exemption then falls back to the cwd key alone.
+        Pure file inspection (no subprocess): only an existing linked-worktree
+        ``.git`` FILE (``gitdir: <main>/.git/worktrees/<name>``) may mint the
+        extra exempt key; None otherwise — exemption then covers cwd alone.
         """
         try:
             current = Path(cwd).expanduser().resolve(strict=False)
@@ -852,7 +851,7 @@ class CodexCliRuntime:
             gitfile = candidate / ".git"
             try:
                 if gitfile.is_dir():
-                    return str(candidate) if candidate != current else None
+                    return None
                 if not gitfile.is_file():
                     continue
                 content = gitfile.read_text(encoding="utf-8", errors="replace")
@@ -864,13 +863,15 @@ class CodexCliRuntime:
                 gitdir = Path(line[len("gitdir:") :].strip()).expanduser()
                 if not gitdir.is_absolute():
                     gitdir = candidate / gitdir
-                # <main>/.git/worktrees/<name> -> <main>
-                if gitdir.parent.parent.name == ".git":
-                    try:
-                        return str(gitdir.parent.parent.parent.resolve(strict=False))
-                    except (OSError, RuntimeError, ValueError):
+                main_git_dir = gitdir.parent.parent
+                if gitdir.parent.name != "worktrees" or main_git_dir.name != ".git":
+                    return None
+                try:
+                    if not gitdir.is_dir() or not main_git_dir.is_dir():
                         return None
-                return None
+                    return str(main_git_dir.parent.resolve(strict=False))
+                except (OSError, RuntimeError, ValueError):
+                    return None
             return None
         return None
 
@@ -937,7 +938,12 @@ class CodexCliRuntime:
             try:
                 stat_result = path.lstat()
             except FileNotFoundError:
-                digest.update(b"missing\0")
+                # Missing config ≡ only the exempt first-use trust entry.
+                digest.update(
+                    self._stable_global_codex_config_bytes(b"") + b"\0"
+                    if name == "config.toml"
+                    else b"missing\0"
+                )
                 continue
             except OSError as exc:
                 raise RuntimeError("Cannot inspect Codex profile configuration") from exc

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -111,6 +111,109 @@ def test_codex_config_fingerprint_ignores_main_root_trust_for_worktree_cwd(
     runtime._assert_codex_config_files_unchanged()
 
 
+def test_codex_config_fingerprint_exempts_first_use_trust_when_config_absent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex may CREATE config.toml during initialization with only the trust entry.
+
+    The absent-file baseline and a file holding nothing but the exempt
+    first-use trust entry both mean "no non-exempt global settings" and must
+    fingerprint identically; a non-exempt entry in that new file still drifts.
+    """
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    project_key = str(project_dir.resolve(strict=False))
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    runtime = CodexCliRuntime(cli_path="codex", cwd=project_key)
+    original = runtime._codex_config_fingerprint
+
+    config_path = codex_home / "config.toml"
+    config_path.write_text(
+        f'[projects.{json.dumps(project_key)}]\ntrust_level = "trusted"\n',
+        encoding="utf-8",
+    )
+
+    assert runtime._fingerprint_codex_config_files() == original
+    runtime._assert_codex_config_files_unchanged()
+
+    config_path.write_text(
+        f'model = "gpt-other"\n\n[projects.{json.dumps(project_key)}]\ntrust_level = "trusted"\n',
+        encoding="utf-8",
+    )
+    assert runtime._fingerprint_codex_config_files() != original
+
+
+def test_ordinary_checkout_does_not_mint_a_main_root_exempt_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``.git`` DIRECTORY ancestor is the main repo itself, not a linked worktree."""
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    subdir = repo / "src"
+    subdir.mkdir()
+    repo_key = str(repo.resolve(strict=False))
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    (codex_home / "config.toml").write_text('model = "gpt-test"\n', encoding="utf-8")
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    runtime = CodexCliRuntime(cli_path="codex", cwd=str(subdir.resolve(strict=False)))
+
+    assert runtime._git_main_repository_root(str(subdir)) is None
+    original = runtime._codex_config_fingerprint
+    (codex_home / "config.toml").write_text(
+        f'model = "gpt-test"\n\n[projects.{json.dumps(repo_key)}]\ntrust_level = "trusted"\n',
+        encoding="utf-8",
+    )
+    assert runtime._fingerprint_codex_config_files() != original
+
+
+def test_malformed_gitdir_layouts_do_not_resolve_a_main_root(
+    tmp_path: Path,
+) -> None:
+    """Only an existing ``<main>/.git/worktrees/<name>`` target is recognized."""
+    main_repo = tmp_path / "main-repo"
+    (main_repo / ".git" / "worktrees" / "wt").mkdir(parents=True)
+    (main_repo / ".git" / "not-worktrees" / "wt").mkdir(parents=True)
+    runtime = CodexCliRuntime(cli_path="codex", cwd=str(tmp_path))
+
+    def worktree_with_gitdir(name: str, target: Path) -> str:
+        worktree = tmp_path / name
+        worktree.mkdir()
+        (worktree / ".git").write_text(f"gitdir: {target}\n", encoding="utf-8")
+        return str(worktree)
+
+    # Grandparent named .git but not the worktrees layout.
+    assert (
+        runtime._git_main_repository_root(
+            worktree_with_gitdir("wt-not", main_repo / ".git" / "not-worktrees" / "wt")
+        )
+        is None
+    )
+    # Correct shape but nonexistent target.
+    assert (
+        runtime._git_main_repository_root(
+            worktree_with_gitdir("wt-absent", main_repo / ".git" / "worktrees" / "absent")
+        )
+        is None
+    )
+    # Submodule-style gitdir (.git/modules/<name>).
+    (main_repo / ".git" / "modules" / "sub").mkdir(parents=True)
+    assert (
+        runtime._git_main_repository_root(
+            worktree_with_gitdir("wt-module", main_repo / ".git" / "modules" / "sub")
+        )
+        is None
+    )
+    # The valid layout still resolves.
+    assert runtime._git_main_repository_root(
+        worktree_with_gitdir("wt-ok", main_repo / ".git" / "worktrees" / "wt")
+    ) == str(main_repo.resolve(strict=False))
+
+
 def test_codex_config_fingerprint_tracks_other_project_trust(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -76,6 +76,41 @@ def test_codex_config_fingerprint_ignores_automatic_project_trust(
     assert runtime._fingerprint_codex_config_files() == original
 
 
+def test_codex_config_fingerprint_ignores_main_root_trust_for_worktree_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex records first-use trust against the git MAIN repo root.
+
+    A task running in a linked worktree must not have that benign entry
+    treated as authority-bearing drift (observed live: every AC after the
+    first failed instantly with "configuration changed").
+    """
+    main_repo = tmp_path / "main-repo"
+    (main_repo / ".git" / "worktrees" / "wt").mkdir(parents=True)
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    (worktree / ".git").write_text(
+        f"gitdir: {main_repo / '.git' / 'worktrees' / 'wt'}\n", encoding="utf-8"
+    )
+    main_key = str(main_repo.resolve(strict=False))
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    config_path = codex_home / "config.toml"
+    config_path.write_text('model = "gpt-test"\n', encoding="utf-8")
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    runtime = CodexCliRuntime(cli_path="codex", cwd=str(worktree.resolve(strict=False)))
+    original = runtime._codex_config_fingerprint
+
+    config_path.write_text(
+        f'model = "gpt-test"\n\n[projects.{json.dumps(main_key)}]\ntrust_level = "trusted"\n',
+        encoding="utf-8",
+    )
+
+    assert runtime._fingerprint_codex_config_files() == original
+    runtime._assert_codex_config_files_unchanged()
+
+
 def test_codex_config_fingerprint_tracks_other_project_trust(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Refs #2311

## User problem
Every codex `ooo run` AC after the first completed task fails instantly (0.16s) with `Failed to prepare Codex CLI: Codex configuration changed after runtime initialization; start a new execution session`. Measured live: canonical cli-todo, 10/10 runs affected — codex could never finish a multi-AC seed.

## Root cause
Codex records first-use project trust against the **git main repository root**, while orchestrator tasks run inside a linked worktree. The drift guard's exemption only covered `self._cwd` (the worktree path), so codex's own benign `projects.<main-root>.trust_level = "trusted"` write permanently poisoned the config fingerprint.

## Supported inputs / execution conditions
codex runtime backend, tasks dispatched in linked git worktrees (the orchestrator's normal layout) or plain directories. No behavior change for non-codex backends.

## Observable contract / invariants
- The automatic first-use trust entry is exempt for exactly two keys: the runtime cwd and, when the cwd is inside a linked worktree, the main repository root resolved via the worktree's `.git` gitfile (pure file inspection, no subprocess).
- Every other project's trust entry — and any other config key — remains authority-bearing drift and still fails closed.
- Unrecognized `.git` layouts resolve to no extra key (fail-closed to today's behavior).

## Changed subsystem / boundary
`src/ouroboros/orchestrator/codex_cli_runtime.py` only (+ its unit tests). No data/security boundary change: the exemption is narrower than the existing cwd exemption's intent (same benign mutation, correct key).

## Non-goals
Verifier/evidence changes (separate stacked PR), other runtimes' attestation, trust entries the user edits manually.

## Evidence
- Live before/after: codex cli-todo instant-death retries eliminated; with the verify stack on top, 10-run success went 0/10 → 10/10 (#2311 comment).
- New regression test `test_codex_config_fingerprint_ignores_main_root_trust_for_worktree_cwd`; existing drift tests unchanged and passing (226 codex runtime tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145uCSmu29DhCtDR5yGkLQd