### PR TITLE
feat(evidence): admit transcript-proven functional verification under verify-gate authority

### DIFF
--- a/src/ouroboros/orchestrator/evidence/harness_observation.py
+++ b/src/ouroboros/orchestrator/evidence/harness_observation.py
@@ -235,6 +235,27 @@ def observation_from_message(message: AgentMessage) -> WorkspaceObservation | No
     return None
 
 
+def observations_confirm_unmutated_workspace(
+    messages: tuple[AgentMessage, ...],
+) -> bool:
+    """Return True when harness observations prove the leaf mutated nothing.
+
+    Requires at least one observation and every observation to report a
+    complete (non-truncated) snapshot diff with zero changed paths. This is the
+    harness's own unforgeable witness that a run was pure verification — the
+    basis for accepting an honestly-empty ``files_touched`` and for letting a
+    verification command execute a pre-existing artifact.
+    """
+    observations = [
+        observation
+        for observation in (observation_from_message(message) for message in messages)
+        if observation is not None
+    ]
+    return bool(observations) and all(
+        not observation.changed_paths and not observation.truncated for observation in observations
+    )
+
+
 def is_harness_observation_message(message: AgentMessage) -> bool:
     """Return True for a genuine harness observation message."""
     return observation_from_message(message) is not None

--- a/src/ouroboros/orchestrator/evidence/harness_observation.py
+++ b/src/ouroboros/orchestrator/evidence/harness_observation.py
@@ -98,13 +98,15 @@ class WorkspaceObservation:
     """What the harness itself observed around one leaf run.
 
     ``changed_paths`` are workspace-relative paths that appeared or changed
-    between the pre- and post-leaf snapshots. ``command_runs`` are commands the
-    harness re-executed in the workspace, with their real exit status.
+    between the pre- and post-leaf snapshots; ``deleted_paths`` are paths the
+    complete post-snapshot no longer contains. ``command_runs`` are commands
+    the harness re-executed in the workspace, with their real exit status.
     """
 
     changed_paths: frozenset[str]
     truncated: bool = False
     command_runs: tuple[CommandObservation, ...] = ()
+    deleted_paths: frozenset[str] = frozenset()
 
     def supports_file_claim(self, claim: str) -> bool:
         """Return True when the claimed workspace-relative path changed."""
@@ -201,9 +203,17 @@ def diff_workspace_snapshots(
             # that the leaf created it during this window.
             continue
         changed.add(path)
+    deleted: set[str] = set()
+    if not after.truncated:
+        # A path the complete post-snapshot no longer contains was removed
+        # during the window. Under a truncated post-snapshot its absence is
+        # only budget uncertainty, and ``truncated`` already withholds the
+        # zero-mutation waiver.
+        deleted = {path for path in before.fingerprints if path not in after.fingerprints}
     return WorkspaceObservation(
         changed_paths=frozenset(changed),
         truncated=before.truncated or after.truncated,
+        deleted_paths=frozenset(deleted),
     )
 
 
@@ -241,7 +251,8 @@ def observations_confirm_unmutated_workspace(
     """Return True when harness observations prove the leaf mutated nothing.
 
     Requires at least one observation and every observation to report a
-    complete (non-truncated) snapshot diff with zero changed paths. This is the
+    complete (non-truncated) snapshot diff with zero changed and zero deleted
+    paths. This is the
     harness's own unforgeable witness that a run was pure verification — the
     basis for accepting an honestly-empty ``files_touched`` and for letting a
     verification command execute a pre-existing artifact.
@@ -252,7 +263,10 @@ def observations_confirm_unmutated_workspace(
         if observation is not None
     ]
     return bool(observations) and all(
-        not observation.changed_paths and not observation.truncated for observation in observations
+        not observation.changed_paths
+        and not observation.deleted_paths
+        and not observation.truncated
+        for observation in observations
     )
 
 

--- a/src/ouroboros/orchestrator/evidence/test_detection.py
+++ b/src/ouroboros/orchestrator/evidence/test_detection.py
@@ -15,7 +15,10 @@ from ouroboros.orchestrator.evidence.claims import (
     _runtime_messages_support_file_claim,
 )
 from ouroboros.orchestrator.evidence.common import _normalized_evidence_text
-from ouroboros.orchestrator.evidence.harness_observation import observation_from_message
+from ouroboros.orchestrator.evidence.harness_observation import (
+    observation_from_message,
+    observations_confirm_unmutated_workspace,
+)
 from ouroboros.orchestrator.evidence.shell_parsing import (
     _has_trailing_output_filter_pipeline,
     _is_python_executable,
@@ -483,7 +486,11 @@ def _functional_command_supports_test_claim(
     if not any(
         _runtime_messages_support_file_claim(invoked, messages, task_cwd=task_cwd)
         for invoked in invoked_files
-    ):
+    ) and not observations_confirm_unmutated_workspace(messages):
+        # The invoked artifact must be this run's own work — unless the
+        # harness witnessed a pure-verification run (zero mutation), where the
+        # artifact necessarily pre-exists and the verify gate stays the
+        # behavioral authority.
         return False
     for index, message in enumerate(messages):
         if message.tool_name != "Bash":

--- a/src/ouroboros/orchestrator/evidence/test_detection.py
+++ b/src/ouroboros/orchestrator/evidence/test_detection.py
@@ -9,6 +9,7 @@ from ouroboros.orchestrator.evidence.claims import (
     _runtime_message_command_values,
     _runtime_message_has_conflicting_tool_call_ids,
     _runtime_message_has_success_evidence,
+    _runtime_message_is_tool_completion,
     _runtime_message_supports_command_claim,
     _runtime_message_tool_call_id,
     _runtime_messages_support_file_claim,
@@ -419,6 +420,81 @@ def _runtime_messages_support_test_claim(
             )
             for command in matching_commands
         ):
+            return True
+    return False
+
+
+_FUNCTIONAL_INTERPRETER_NAMES = frozenset(
+    {"python", "python3", "node", "bash", "sh", "zsh", "ruby", "perl", "php", "deno", "bun"}
+)
+
+
+def _functional_command_invoked_files(command: str) -> tuple[str, ...]:
+    """Return workspace file tokens a command directly executes.
+
+    Only direct invocations count: an interpreter followed by a file argument
+    (``python3 tool.py``) or a ``./script`` execution. Files that are merely
+    mentioned (copied, grepped, cat-ed) are not "invoked" and cannot anchor the
+    functional-verification tier.
+    """
+    tokens = [token.strip("'\"") for token in command.split()]
+    invoked: list[str] = []
+    for index, token in enumerate(tokens):
+        base = token.rsplit("/", 1)[-1]
+        if base in _FUNCTIONAL_INTERPRETER_NAMES:
+            for candidate in tokens[index + 1 :]:
+                if candidate.startswith("-"):
+                    continue
+                if "." in candidate.rsplit("/", 1)[-1]:
+                    invoked.append(candidate)
+                break
+        elif token.startswith("./") and len(token) > 2:
+            invoked.append(token[2:])
+    return tuple(dict.fromkeys(invoked))
+
+
+def _functional_command_supports_test_claim(
+    *,
+    value: str,
+    messages: tuple[AgentMessage, ...],
+    task_cwd: str | None,
+) -> bool:
+    """Return True when a ``tests_passed`` claim is itself a transcript-backed
+    functional verification command.
+
+    Some leafs (Codex in particular) verify behavior by executing the built
+    artifact directly — ``python3 tool.py add x && python3 tool.py list`` —
+    and cite that exact command under ``tests_passed`` instead of a test-runner
+    invocation. That is honest, transcript-provable work, not fabrication, so
+    it must not be rejected as FABRICATION_SUSPECTED. This tier never trusts
+    leaf narration: the claim must match a recorded Bash invocation, the
+    correlated completion must carry a machine-readable success signal, and the
+    command must directly execute a workspace file whose mutation this run
+    already proved (a stale artifact cannot be claimed). Test-runner-shaped
+    claims never enter this tier — they keep the stricter test-output proof.
+    The caller additionally restricts this tier to ACs where a hidden verify
+    gate remains the behavioral authority.
+    """
+    if _looks_like_test_command(value):
+        return False
+    invoked_files = _functional_command_invoked_files(value)
+    if not invoked_files:
+        return False
+    if not any(
+        _runtime_messages_support_file_claim(invoked, messages, task_cwd=task_cwd)
+        for invoked in invoked_files
+    ):
+        return False
+    for index, message in enumerate(messages):
+        if message.tool_name != "Bash":
+            continue
+        if _runtime_message_is_tool_completion(message):
+            continue
+        if _runtime_message_has_conflicting_tool_call_ids(message):
+            continue
+        if not _runtime_message_supports_command_claim(value, message):
+            continue
+        if _runtime_message_has_success_evidence(message, messages=messages, index=index):
             return True
     return False
 

--- a/src/ouroboros/orchestrator/evidence/test_detection.py
+++ b/src/ouroboros/orchestrator/evidence/test_detection.py
@@ -432,27 +432,34 @@ _FUNCTIONAL_INTERPRETER_NAMES = frozenset(
 )
 
 
-def _functional_command_invoked_files(command: str) -> tuple[str, ...]:
-    """Return workspace file tokens a command directly executes.
+_FILE_TOKEN_RE = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_./-]*\.[A-Za-z0-9_]+")
 
-    Only direct invocations count: an interpreter followed by a file argument
-    (``python3 tool.py``) or a ``./script`` execution. Files that are merely
-    mentioned (copied, grepped, cat-ed) are not "invoked" and cannot anchor the
-    functional-verification tier.
+
+def _functional_command_invoked_files(command: str) -> tuple[str, ...]:
+    """Return workspace file tokens a verification command exercises.
+
+    The anchor is not the token itself but the backing requirement layered on
+    top: at least one referenced file must be proven authored by this run (or
+    the harness must have witnessed a pure-verification run). An interpreter
+    invocation (``python3 tool.py``), a ``./script`` execution, and a heredoc
+    driver that names the artifact inside its body (``python3 - <<'PY' ...
+    subprocess.run([..., 'tool.py', ...])``) all reference the artifact the
+    same way; a command that names no file at all (``echo ok``) stays outside
+    the tier entirely.
     """
     tokens = [token.strip("'\"") for token in command.split()]
-    invoked: list[str] = []
-    for index, token in enumerate(tokens):
-        base = token.rsplit("/", 1)[-1]
-        if base in _FUNCTIONAL_INTERPRETER_NAMES:
-            for candidate in tokens[index + 1 :]:
-                if candidate.startswith("-"):
-                    continue
-                if "." in candidate.rsplit("/", 1)[-1]:
-                    invoked.append(candidate)
-                break
-        elif token.startswith("./") and len(token) > 2:
-            invoked.append(token[2:])
+    has_interpreter = any(
+        token.rsplit("/", 1)[-1] in _FUNCTIONAL_INTERPRETER_NAMES or token.startswith("./")
+        for token in tokens
+    )
+    if not has_interpreter:
+        return ()
+    invoked = [
+        match.group(0)
+        for match in _FILE_TOKEN_RE.finditer(command)
+        # Skip pure version-ish tokens such as ``2.0`` (no letter anywhere).
+        if any(ch.isalpha() for ch in match.group(0))
+    ]
     return tuple(dict.fromkeys(invoked))
 
 

--- a/src/ouroboros/orchestrator/evidence/test_detection.py
+++ b/src/ouroboros/orchestrator/evidence/test_detection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 import re
 
 from ouroboros.orchestrator.adapter import AgentMessage
@@ -13,6 +14,7 @@ from ouroboros.orchestrator.evidence.claims import (
     _runtime_message_supports_command_claim,
     _runtime_message_tool_call_id,
     _runtime_messages_support_file_claim,
+    _workspace_relative_file_claim,
 )
 from ouroboros.orchestrator.evidence.common import _normalized_evidence_text
 from ouroboros.orchestrator.evidence.harness_observation import (
@@ -493,12 +495,19 @@ def _functional_command_supports_test_claim(
     if not any(
         _runtime_messages_support_file_claim(invoked, messages, task_cwd=task_cwd)
         for invoked in invoked_files
-    ) and not observations_confirm_unmutated_workspace(messages):
+    ):
         # The invoked artifact must be this run's own work — unless the
-        # harness witnessed a pure-verification run (zero mutation), where the
-        # artifact necessarily pre-exists and the verify gate stays the
-        # behavioral authority.
-        return False
+        # harness witnessed a pure-verification run (zero mutation, zero
+        # deletion, complete snapshots), where the cited artifact must still
+        # be a real workspace file: existence now proves existence throughout
+        # the leaf's window, so a ghost path in a comment stays rejected.
+        if not observations_confirm_unmutated_workspace(messages):
+            return False
+        if not any(
+            _invoked_file_is_existing_workspace_file(invoked, task_cwd=task_cwd)
+            for invoked in invoked_files
+        ):
+            return False
     for index, message in enumerate(messages):
         if message.tool_name != "Bash":
             continue
@@ -508,8 +517,69 @@ def _functional_command_supports_test_claim(
             continue
         if not _runtime_message_supports_command_claim(value, message):
             continue
-        if _runtime_message_has_success_evidence(message, messages=messages, index=index):
+        if _runtime_message_has_success_evidence(
+            message, messages=messages, index=index
+        ) and _functional_command_has_authoritative_zero_exit(messages, index=index):
             return True
+    return False
+
+
+def _invoked_file_is_existing_workspace_file(invoked: str, *, task_cwd: str | None) -> bool:
+    """Return True when a cited path is an existing regular file in the workspace."""
+    if task_cwd is None:
+        return False
+    relative = _workspace_relative_file_claim(invoked, task_cwd=task_cwd)
+    if relative is None:
+        return False
+    try:
+        return (Path(task_cwd).resolve() / relative).is_file()
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def _message_carries_zero_exit(message: AgentMessage) -> bool:
+    """Return True when a message carries an authoritative integer zero exit."""
+    containers: list[dict[str, object]] = [message.data]
+    tool_result = message.data.get("tool_result")
+    if isinstance(tool_result, dict):
+        containers.append(tool_result)
+    for container in containers:
+        exit_code = container.get("exit_code")
+        if isinstance(exit_code, int) and not isinstance(exit_code, bool) and exit_code == 0:
+            return True
+    return False
+
+
+def _functional_command_has_authoritative_zero_exit(
+    messages: tuple[AgentMessage, ...],
+    *,
+    index: int,
+) -> bool:
+    """Require a real exit verdict for the functional-verification tier.
+
+    ``_runtime_message_has_success_evidence`` accepts lifecycle-only success
+    (``status="completed"``, ``*.completed`` events), but Codex marks
+    command_execution items completed even on non-zero exits. A checking
+    command that vouches for behavior needs the authoritative zero exit
+    itself — on the call, its correlated completion, or (for id-less legacy
+    streams) the immediately following completion.
+    """
+    call = messages[index]
+    if _message_carries_zero_exit(call):
+        return True
+    call_id = _runtime_message_tool_call_id(call)
+    if call_id is not None:
+        return any(
+            _runtime_message_is_tool_completion(candidate)
+            and _runtime_message_tool_call_id(candidate) == call_id
+            and _message_carries_zero_exit(candidate)
+            for candidate in messages
+        )
+    for candidate in messages[index + 1 :]:
+        if candidate.tool_name is not None and not _runtime_message_is_tool_completion(candidate):
+            break
+        if _runtime_message_is_tool_completion(candidate):
+            return _message_carries_zero_exit(candidate)
     return False
 
 

--- a/src/ouroboros/orchestrator/evidence/verification.py
+++ b/src/ouroboros/orchestrator/evidence/verification.py
@@ -15,6 +15,7 @@ from ouroboros.orchestrator.evidence.common import _flatten_evidence_values
 from ouroboros.orchestrator.evidence.harness_observation import (
     is_harness_observation_message,
     observation_from_message,
+    observations_confirm_unmutated_workspace,
 )
 from ouroboros.orchestrator.evidence.test_detection import (
     _functional_command_supports_test_claim,
@@ -110,6 +111,18 @@ def _verify_atomic_evidence_against_runtime_messages(
         values = tuple(_flatten_evidence_values(typed_evidence.get(field_name)))
         if not values:
             if field_name in required_fields:
+                # A pure-verification run may honestly have nothing to touch:
+                # when the AC's hidden verify gate stays the behavioral
+                # authority and the harness's own snapshot diff witnessed zero
+                # workspace mutation, an empty files_touched is corroborated
+                # truth, not withheld evidence.
+                if (
+                    field_name == "files_touched"
+                    and has_success_contract
+                    and verify_gate_active
+                    and observations_confirm_unmutated_workspace(support_messages)
+                ):
+                    continue
                 unsupported.append(f"{field_name}: no concrete claim values")
             continue
         field_messages = _runtime_support_messages_for_field(field_name, support_messages)

--- a/src/ouroboros/orchestrator/evidence/verification.py
+++ b/src/ouroboros/orchestrator/evidence/verification.py
@@ -17,6 +17,7 @@ from ouroboros.orchestrator.evidence.harness_observation import (
     observation_from_message,
 )
 from ouroboros.orchestrator.evidence.test_detection import (
+    _functional_command_supports_test_claim,
     _runtime_messages_have_masked_test_command_for_test_claim,
     _runtime_messages_support_test_claim,
 )
@@ -142,6 +143,21 @@ def _verify_atomic_evidence_against_runtime_messages(
                     backed_commands=backed_commands,
                     messages=support_messages,
                     task_cwd=workspace_cwd,
+                ):
+                    continue
+                # Functional-verification tier: only when a hidden verify gate
+                # stays the behavioral authority for this AC, a non-test claim
+                # that IS a transcript-backed successful execution of an
+                # artifact this run produced is honest evidence, not
+                # fabrication.
+                if (
+                    has_success_contract
+                    and verify_gate_active
+                    and _functional_command_supports_test_claim(
+                        value=value,
+                        messages=support_messages,
+                        task_cwd=workspace_cwd,
+                    )
                 ):
                     continue
                 if _runtime_messages_have_masked_test_command_for_test_claim(

--- a/tests/unit/orchestrator/evidence/test_functional_command_tier.py
+++ b/tests/unit/orchestrator/evidence/test_functional_command_tier.py
@@ -76,13 +76,29 @@ def _edit_pair(path: str) -> tuple[AgentMessage, AgentMessage]:
     return start, result
 
 
-def test_invoked_files_only_cover_direct_executions() -> None:
-    assert _functional_command_invoked_files(CLAIM) == ("habit_tracker.py",)
-    # Mentioned-but-not-invoked files and test runners do not anchor the tier.
+def test_invoked_files_require_an_interpreter_and_a_file_token() -> None:
+    assert "habit_tracker.py" in _functional_command_invoked_files(CLAIM)
+    # Commands with no interpreter or no file token never enter the tier.
     assert _functional_command_invoked_files("cp habit_tracker.py /tmp/") == ()
     assert _functional_command_invoked_files("echo ok") == ()
-    assert _functional_command_invoked_files("python3 -m pytest test_app.py") == ()
     assert _functional_command_invoked_files("./run.sh") == ("run.sh",)
+    # Heredoc drivers reference the artifact inside their body.
+    heredoc = (
+        "python3 - <<'PY'\nimport subprocess, sys\n"
+        "subprocess.run([sys.executable, 'habit_tracker.py', 'add', 'x'], check=True)\nPY"
+    )
+    assert "habit_tracker.py" in _functional_command_invoked_files(heredoc)
+
+
+def test_test_runner_claims_stay_outside_the_functional_tier() -> None:
+    start, result = _codex_bash_pair("python3 -m pytest test_app.py")
+    messages = (*_edit_pair("test_app.py"), start, result)
+    assert (
+        _functional_command_supports_test_claim(
+            value="python3 -m pytest test_app.py", messages=messages, task_cwd=None
+        )
+        is False
+    )
 
 
 def test_codex_wrapped_functional_command_supports_claim() -> None:

--- a/tests/unit/orchestrator/evidence/test_functional_command_tier.py
+++ b/tests/unit/orchestrator/evidence/test_functional_command_tier.py
@@ -170,14 +170,23 @@ def test_verifier_settles_functional_claim_only_under_verify_gate_authority() ->
     assert any("tests_passed" in reason for reason in gated_off.reasons)
 
 
-def _observation_message(*, changed: tuple[str, ...] = (), truncated: bool = False) -> AgentMessage:
+def _observation_message(
+    *,
+    changed: tuple[str, ...] = (),
+    deleted: tuple[str, ...] = (),
+    truncated: bool = False,
+) -> AgentMessage:
     from ouroboros.orchestrator.evidence.harness_observation import (
         WorkspaceObservation,
         build_observation_message,
     )
 
     return build_observation_message(
-        WorkspaceObservation(changed_paths=frozenset(changed), truncated=truncated)
+        WorkspaceObservation(
+            changed_paths=frozenset(changed),
+            deleted_paths=frozenset(deleted),
+            truncated=truncated,
+        )
     )
 
 
@@ -187,38 +196,89 @@ VALIDATION_CLAIM = (
 )
 
 
-def test_zero_mutation_witness_admits_preexisting_artifact_execution() -> None:
+def test_zero_mutation_witness_admits_preexisting_artifact_execution(tmp_path) -> None:
+    (tmp_path / "habit_tracker.py").write_text("print('hi')\n", encoding="utf-8")
+    task_cwd = str(tmp_path)
     start, result = _codex_bash_pair(VALIDATION_CLAIM)
-    # No Edit evidence: the artifact pre-exists. The harness witnessed zero
-    # workspace mutation, so this is a pure-verification run.
+    # No Edit evidence: the artifact pre-exists as a real workspace file. The
+    # harness witnessed zero workspace mutation, so this is pure verification.
     messages = (start, result, _observation_message())
     assert (
         _functional_command_supports_test_claim(
-            value=VALIDATION_CLAIM, messages=messages, task_cwd=None
+            value=VALIDATION_CLAIM, messages=messages, task_cwd=task_cwd
         )
         is True
     )
-    # A mutated or truncated observation withdraws the waiver.
+    # A mutated, deleting, or truncated observation withdraws the waiver.
     for witness in (
         _observation_message(changed=("habits.json",)),
+        _observation_message(deleted=("removed.py",)),
         _observation_message(truncated=True),
     ):
         assert (
             _functional_command_supports_test_claim(
-                value=VALIDATION_CLAIM, messages=(start, result, witness), task_cwd=None
+                value=VALIDATION_CLAIM, messages=(start, result, witness), task_cwd=task_cwd
             )
             is False
         )
     # And with no observation at all, the stale-artifact guard still holds.
     assert (
         _functional_command_supports_test_claim(
-            value=VALIDATION_CLAIM, messages=(start, result), task_cwd=None
+            value=VALIDATION_CLAIM, messages=(start, result), task_cwd=task_cwd
         )
         is False
     )
 
 
-def test_verifier_accepts_empty_files_touched_only_with_zero_mutation_witness() -> None:
+def test_zero_mutation_waiver_requires_the_cited_file_to_exist(tmp_path) -> None:
+    """A ghost path mentioned in the command must not settle through the waiver."""
+    ghost_claim = "python3 ghost.py check  # verifies ghost.py behavior"
+    start, result = _codex_bash_pair(ghost_claim)
+    messages = (start, result, _observation_message())
+    # ghost.py does not exist in the workspace, and with no workspace at all
+    # existence cannot be proven either.
+    for cwd in (str(tmp_path), None):
+        assert (
+            _functional_command_supports_test_claim(
+                value=ghost_claim, messages=messages, task_cwd=cwd
+            )
+            is False
+        )
+
+
+def test_functional_tier_requires_an_authoritative_zero_exit(tmp_path) -> None:
+    """Lifecycle-only completion (status=completed, no exit code) is not success."""
+    (tmp_path / "habit_tracker.py").write_text("print('hi')\n", encoding="utf-8")
+    import shlex as _shlex
+
+    wrapped = "/bin/zsh -lc " + _shlex.quote(VALIDATION_CLAIM)
+    start = AgentMessage(
+        type="assistant",
+        content=f"Calling tool: Bash: {wrapped}",
+        tool_name="Bash",
+        data={"tool_input": {"command": wrapped}, "tool_call_id": "item_9"},
+    )
+    lifecycle_only = AgentMessage(
+        type="tool_result",
+        content="Traceback: command failed",
+        data={
+            "tool_call_id": "item_9",
+            "status": "completed",
+            "tool_result": {"text_content": "Traceback: command failed"},
+        },
+    )
+    assert (
+        _functional_command_supports_test_claim(
+            value=VALIDATION_CLAIM,
+            messages=(start, lifecycle_only, _observation_message()),
+            task_cwd=str(tmp_path),
+        )
+        is False
+    )
+
+
+def test_verifier_accepts_empty_files_touched_only_with_zero_mutation_witness(tmp_path) -> None:
+    (tmp_path / "habit_tracker.py").write_text("print('hi')\n", encoding="utf-8")
     start, result = _codex_bash_pair(VALIDATION_CLAIM)
 
     def verdict(extra: tuple[AgentMessage, ...]):
@@ -233,8 +293,8 @@ def test_verifier_accepts_empty_files_touched_only_with_zero_mutation_witness() 
             ),
             ac_content="An unknown subcommand prints a usage error and exits with status 2",
             execution_profile=load_profile("code"),
-            task_cwd=None,
-            adapter_working_directory=None,
+            task_cwd=str(tmp_path),
+            adapter_working_directory=str(tmp_path),
             has_success_contract=True,
             verify_gate_active=True,
         )

--- a/tests/unit/orchestrator/evidence/test_functional_command_tier.py
+++ b/tests/unit/orchestrator/evidence/test_functional_command_tier.py
@@ -152,3 +152,78 @@ def test_verifier_settles_functional_claim_only_under_verify_gate_authority() ->
     gated_off = _verdict(verify_gate_active=False)
     assert gated_off.passed is False
     assert any("tests_passed" in reason for reason in gated_off.reasons)
+
+
+def _observation_message(*, changed: tuple[str, ...] = (), truncated: bool = False) -> AgentMessage:
+    from ouroboros.orchestrator.evidence.harness_observation import (
+        WorkspaceObservation,
+        build_observation_message,
+    )
+
+    return build_observation_message(
+        WorkspaceObservation(changed_paths=frozenset(changed), truncated=truncated)
+    )
+
+
+VALIDATION_CLAIM = (
+    't=$(mktemp -d) && cp habit_tracker.py "$t"/ && cd "$t" && '
+    "python3 habit_tracker.py unknown-command; test $? -eq 2 && echo EXIT_TWO_OK"
+)
+
+
+def test_zero_mutation_witness_admits_preexisting_artifact_execution() -> None:
+    start, result = _codex_bash_pair(VALIDATION_CLAIM)
+    # No Edit evidence: the artifact pre-exists. The harness witnessed zero
+    # workspace mutation, so this is a pure-verification run.
+    messages = (start, result, _observation_message())
+    assert (
+        _functional_command_supports_test_claim(
+            value=VALIDATION_CLAIM, messages=messages, task_cwd=None
+        )
+        is True
+    )
+    # A mutated or truncated observation withdraws the waiver.
+    for witness in (
+        _observation_message(changed=("habits.json",)),
+        _observation_message(truncated=True),
+    ):
+        assert (
+            _functional_command_supports_test_claim(
+                value=VALIDATION_CLAIM, messages=(start, result, witness), task_cwd=None
+            )
+            is False
+        )
+    # And with no observation at all, the stale-artifact guard still holds.
+    assert (
+        _functional_command_supports_test_claim(
+            value=VALIDATION_CLAIM, messages=(start, result), task_cwd=None
+        )
+        is False
+    )
+
+
+def test_verifier_accepts_empty_files_touched_only_with_zero_mutation_witness() -> None:
+    start, result = _codex_bash_pair(VALIDATION_CLAIM)
+
+    def verdict(extra: tuple[AgentMessage, ...]):
+        return _verify_atomic_evidence_against_runtime_messages(
+            messages=(start, result, *extra, AgentMessage(type="result", content="done")),
+            typed_evidence=EvidenceRecord(
+                data={
+                    "files_touched": [],
+                    "commands_run": [VALIDATION_CLAIM],
+                    "tests_passed": [VALIDATION_CLAIM],
+                }
+            ),
+            ac_content="An unknown subcommand prints a usage error and exits with status 2",
+            execution_profile=load_profile("code"),
+            task_cwd=None,
+            adapter_working_directory=None,
+            has_success_contract=True,
+            verify_gate_active=True,
+        )
+
+    assert verdict((_observation_message(),)).passed is True
+    without_witness = verdict(())
+    assert without_witness.passed is False
+    assert any("files_touched" in reason for reason in without_witness.reasons)

--- a/tests/unit/orchestrator/evidence/test_functional_command_tier.py
+++ b/tests/unit/orchestrator/evidence/test_functional_command_tier.py
@@ -1,0 +1,154 @@
+"""Functional-verification tier for ``tests_passed`` claims.
+
+A leaf that verifies behavior by executing the built artifact directly
+(``python3 tool.py add x``) and cites that command as ``tests_passed`` did
+honest, transcript-provable work. With a hidden verify gate as the behavioral
+authority, that claim must settle through transcript + structured success
+evidence instead of being rejected as FABRICATION_SUSPECTED (observed on every
+Codex cli-todo run). The tier stays fail-closed: no transcript match, no
+structured success, no invoked artifact backed by this run, or no active
+verify gate each keep the current rejection.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+from ouroboros.orchestrator.adapter import AgentMessage
+from ouroboros.orchestrator.evidence.test_detection import (
+    _functional_command_invoked_files,
+    _functional_command_supports_test_claim,
+)
+from ouroboros.orchestrator.evidence.verification import (
+    _verify_atomic_evidence_against_runtime_messages,
+)
+from ouroboros.orchestrator.evidence_schema import EvidenceRecord
+from ouroboros.orchestrator.profile_loader import load_profile
+
+CLAIM = (
+    't=$(mktemp -d) && cp habit_tracker.py "$t"/ && cd "$t" && '
+    "python3 habit_tracker.py add 'drink water' && python3 habit_tracker.py list"
+)
+
+
+def _codex_bash_pair(command: str, *, exit_code: int = 0) -> tuple[AgentMessage, AgentMessage]:
+    """Codex-shaped Bash start/result pair: zsh -lc wrapped, correlated by id."""
+    wrapped = "/bin/zsh -lc " + shlex.quote(command)
+    start = AgentMessage(
+        type="assistant",
+        content=f"Calling tool: Bash: {wrapped}",
+        tool_name="Bash",
+        data={"tool_input": {"command": wrapped}, "tool_call_id": "item_7"},
+    )
+    result = AgentMessage(
+        type="tool_result",
+        content="drink water",
+        data={
+            "tool_call_id": "item_7",
+            "exit_code": exit_code,
+            "tool_result": {
+                "is_error": exit_code != 0,
+                "text_content": "drink water",
+                "meta": {"tool_call_id": "item_7", "exit_status": exit_code},
+            },
+        },
+    )
+    return start, result
+
+
+def _edit_pair(path: str) -> tuple[AgentMessage, AgentMessage]:
+    """Codex-shaped file_change start/result pair (Edit with success result)."""
+    call_id = f"edit:{path}"
+    start = AgentMessage(
+        type="assistant",
+        content=f"Calling tool: Edit: {path}",
+        tool_name="Edit",
+        data={"tool_input": {"file_path": path}, "tool_call_id": call_id},
+    )
+    result = AgentMessage(
+        type="tool_result",
+        content="",
+        data={
+            "tool_call_id": call_id,
+            "tool_result": {"is_error": False, "meta": {"tool_call_id": call_id}},
+        },
+    )
+    return start, result
+
+
+def test_invoked_files_only_cover_direct_executions() -> None:
+    assert _functional_command_invoked_files(CLAIM) == ("habit_tracker.py",)
+    # Mentioned-but-not-invoked files and test runners do not anchor the tier.
+    assert _functional_command_invoked_files("cp habit_tracker.py /tmp/") == ()
+    assert _functional_command_invoked_files("echo ok") == ()
+    assert _functional_command_invoked_files("python3 -m pytest test_app.py") == ()
+    assert _functional_command_invoked_files("./run.sh") == ("run.sh",)
+
+
+def test_codex_wrapped_functional_command_supports_claim() -> None:
+    start, result = _codex_bash_pair(CLAIM)
+    messages = (*_edit_pair("habit_tracker.py"), start, result)
+    assert (
+        _functional_command_supports_test_claim(value=CLAIM, messages=messages, task_cwd=None)
+        is True
+    )
+
+
+def test_failed_execution_does_not_support_claim() -> None:
+    start, result = _codex_bash_pair(CLAIM, exit_code=1)
+    messages = (*_edit_pair("habit_tracker.py"), start, result)
+    assert (
+        _functional_command_supports_test_claim(value=CLAIM, messages=messages, task_cwd=None)
+        is False
+    )
+
+
+def test_unbacked_artifact_does_not_support_claim() -> None:
+    # No Edit/Write evidence for habit_tracker.py: a stale artifact in the
+    # workspace must not be claimable.
+    messages = _codex_bash_pair(CLAIM)
+    assert (
+        _functional_command_supports_test_claim(value=CLAIM, messages=messages, task_cwd=None)
+        is False
+    )
+
+
+def test_claim_without_transcript_execution_does_not_support() -> None:
+    start, result = _codex_bash_pair("python3 habit_tracker.py list")
+    messages = (*_edit_pair("habit_tracker.py"), start, result)
+    assert (
+        _functional_command_supports_test_claim(value=CLAIM, messages=messages, task_cwd=None)
+        is False
+    )
+
+
+def _verdict(*, verify_gate_active: bool):
+    start, result = _codex_bash_pair(CLAIM)
+    return _verify_atomic_evidence_against_runtime_messages(
+        messages=(
+            *_edit_pair("habit_tracker.py"),
+            start,
+            result,
+            AgentMessage(type="result", content="done"),
+        ),
+        typed_evidence=EvidenceRecord(
+            data={
+                "files_touched": ["habit_tracker.py"],
+                "commands_run": [CLAIM],
+                "tests_passed": [CLAIM],
+            }
+        ),
+        ac_content="habit_tracker.py supports `add <name>` and `list`",
+        execution_profile=load_profile("code"),
+        task_cwd=None,
+        adapter_working_directory=None,
+        has_success_contract=verify_gate_active,
+        verify_gate_active=verify_gate_active,
+    )
+
+
+def test_verifier_settles_functional_claim_only_under_verify_gate_authority() -> None:
+    assert _verdict(verify_gate_active=True).passed is True
+    gated_off = _verdict(verify_gate_active=False)
+    assert gated_off.passed is False
+    assert any("tests_passed" in reason for reason in gated_off.reasons)

--- a/tests/unit/orchestrator/evidence/test_harness_observation.py
+++ b/tests/unit/orchestrator/evidence/test_harness_observation.py
@@ -25,6 +25,7 @@ from ouroboros.orchestrator.evidence.harness_observation import (
     insert_observation_message,
     is_harness_observation_message,
     observation_from_message,
+    observations_confirm_unmutated_workspace,
     snapshot_workspace,
 )
 from ouroboros.orchestrator.evidence.verification import (
@@ -147,6 +148,38 @@ class TestSnapshotDiff:
         assert observation.changed_paths == frozenset({"seen.py"})
         assert observation.supports_file_claim("seen.py")
         assert not observation.supports_file_claim("unseen.py")
+
+    def test_deletion_is_observed_and_withdraws_the_zero_mutation_waiver(
+        self, tmp_path: Path
+    ) -> None:
+        """Removing a file is a mutation: the diff must see it symmetrically."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        (workspace / "kept.py").write_text("x\n", encoding="utf-8")
+        doomed = workspace / "doomed.py"
+        doomed.write_text("y\n", encoding="utf-8")
+        before = snapshot_workspace(workspace)
+
+        doomed.unlink()
+        observation = diff_workspace_snapshots(before, snapshot_workspace(workspace))
+
+        assert observation is not None
+        assert observation.changed_paths == frozenset()
+        assert observation.deleted_paths == frozenset({"doomed.py"})
+        assert not observations_confirm_unmutated_workspace(
+            (build_observation_message(observation),)
+        )
+
+    def test_truncated_post_snapshot_claims_no_deletions(self) -> None:
+        """Absence from a truncated post-snapshot is budget uncertainty."""
+        before = WorkspaceSnapshot(root="/ws", fingerprints={"a.py": (1, 1), "b.py": (2, 2)})
+        after = WorkspaceSnapshot(root="/ws", fingerprints={"a.py": (1, 1)}, truncated=True)
+
+        observation = diff_workspace_snapshots(before, after)
+
+        assert observation is not None
+        assert observation.deleted_paths == frozenset()
+        assert observation.truncated is True
 
     def test_missing_or_mismatched_roots_yield_no_observation(self, tmp_path: Path) -> None:
         assert snapshot_workspace(None) is None


### PR DESCRIPTION
Refs #2311

Stacked on #2314 (base `feat/run-success-settlement-replay`); restack onto main after the stack merges.

## User problem
A codex leaf that does honest, transcript-provable work is rejected as FABRICATION_SUSPECTED on every canonical cli-todo run (0/10). Three concrete false-negative classes, all reproduced live with `--debug`:
1. The leaf verifies behavior by executing the built artifact (`python3 habit_tracker.py add x && … list`) and cites that exact command as `tests_passed`; only test-runner-shaped proof was accepted.
2. A dependent AC already satisfied by earlier work leaves the leaf nothing to touch; its honestly-empty `files_touched` fails as "no concrete claim values".
3. Codex varies claim shape run to run (direct invocation, heredoc python driver, inline `-c`), so a fixed invocation grammar keeps missing honest claims.

## Supported inputs / execution conditions
Fat-harness verification with a hidden verify gate active for the AC (`has_success_contract and verify_gate_active`) — the new tiers never fire otherwise. Provider-agnostic: the tiers read only normalized `AgentMessage`s; no per-runtime verification paths.

## Observable contract / invariants
- **Functional tier (fail-closed, all four required)**: verify-gate authority for the AC; the claim matches a recorded Bash invocation (structured `tool_input.command`, never narration); its correlated completion carries a machine-readable success signal; the command references a workspace file this run authored (or see witness below). Test-runner-shaped claims keep the stricter existing test-output tier.
- **Zero-mutation witness**: only the harness's own snapshot diff (unforgeable `WorkspaceObservation`, complete and non-truncated, zero changed paths, at least one observation) lets an empty `files_touched` pass and lets a verification command exercise a pre-existing artifact. Any mutation or truncation withdraws the waiver; with no observation both stale-artifact guards hold unchanged.
- Withhold-only invariant preserved: nothing new can flip a FAIL to PASS on narration; every acceptance is anchored to runtime-authored structure (tool completions, snapshot diffs).

## Changed subsystem / boundary
`src/ouroboros/orchestrator/evidence/` (test_detection, verification, harness_observation) + new test module. No security boundary change: no shell execution added, `safe_test_argv` and argv-only re-execution untouched.

## Non-goals
Codex config-drift fix (#2332, independent), retry-attempt evidence continuity (a retried leaf claiming files authored by its previous attempt still fails — known variance, follow-up candidate), prompt-side claim-form guidance.

## Evidence
- Live E2E trajectory on codex cli-todo as each tier landed: 0/4 → 1/4 → 2/4 → 4/4.
- 10-run before/after (family proxy, seed v2): **0/10 → 10/10**, every run independently smoke-verified 4/4 by hand (add/list, done marker, unknown-cmd exit 2, pytest suite green) — table in #2311.
- claude-cli 10/10 stack result unchanged (evidence suites: 811 tests passing; ruff/mypy clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145uCSmu29DhCtDR5yGkLQd