### PR TITLE
chore(release): v0.53.0

### DIFF
--- a/.claude-plugin/.mcp.json
+++ b/.claude-plugin/.mcp.json
@@ -7,7 +7,7 @@
         "--python",
         ">=3.12",
         "--from",
-        "ouroboros-ai[mcp]==0.52.0",
+        "ouroboros-ai[mcp]==0.53.0",
         "ouroboros",
         "mcp",
         "serve",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "ouroboros",
       "description": "Sits in front of Claude Code and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
-      "version": "0.52.0",
+      "version": "0.53.0",
       "author": {
         "name": "Q00",
         "email": "jqyu.lee@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "Sits in front of Claude Code and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
   "author": {
     "name": "Q00",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "Sits in front of Codex CLI and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
   "author": {
     "name": "Q00",

--- a/.mcp.codex.json
+++ b/.mcp.codex.json
@@ -7,7 +7,7 @@
         "--python",
         ">=3.12",
         "--from",
-        "ouroboros-ai[mcp]==0.52.0",
+        "ouroboros-ai[mcp]==0.53.0",
         "ouroboros",
         "mcp",
         "serve",

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -296,7 +296,7 @@ A backup will be created: CLAUDE.md.bak
 **If "Preview first", show:**
 ````markdown
 <!-- ooo:START -->
-<!-- ooo:VERSION:0.52.0 -->
+<!-- ooo:VERSION:0.53.0 -->
 # Ouroboros — Specification-First AI Development
 
 > Before telling AI what to build, define what should be built.


### PR DESCRIPTION
## One user problem

Cut the v0.53.0 stable release: plugin metadata must carry the release version before the tag is created on the merged `main` commit.

## Scope

Mechanical version sync only — `scripts/sync-plugin-version.py --write --version 0.53.0`:

- `.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`
- `.claude-plugin/.mcp.json`
- `.codex-plugin/plugin.json`
- `.mcp.codex.json`
- `skills/setup/SKILL.md`

No source, behavior, or dependency changes. `uv lock` was a no-op.

## Non-goals

Any functional change. The release content is the 17 commits already merged since `v0.52.0`.

## Evidence

```
uv run ruff format src/ tests/   # 1408 files left unchanged
uv run ruff check src/ tests/ --fix   # All checks passed!
uv run mypy src/ouroboros   # Success: no issues found in 617 source files
uv run pytest   # running locally; CI is the authoritative gate
python3 scripts/sync-plugin-version.py  # no drift at 0.53.0
```

Version itself is derived by `hatch-vcs` from the `v0.53.0` tag, which is created on the squash-merge commit of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwzsmprTfPVjoWRDynyufG