### PR TITLE
fix(seed): preserve v1.0.4 semantic AC identity

### DIFF
--- a/src/ouroboros/cli/commands/workflow_ir.py
+++ b/src/ouroboros/cli/commands/workflow_ir.py
@@ -77,7 +77,7 @@ def _normalize_seed_payload(raw: dict[str, Any]) -> dict[str, Any]:
 def _normalize_criterion(item: Any) -> str | dict[str, Any]:
     if isinstance(item, dict):
         if isinstance(item.get("criterion"), str):
-            return item["criterion"]
+            return item
         if isinstance(item.get("description"), str) or isinstance(item.get("content"), str):
             return item
     if isinstance(item, str):

--- a/src/ouroboros/core/seed.py
+++ b/src/ouroboros/core/seed.py
@@ -375,6 +375,11 @@ here because ``ledger_seed`` imports this module. The two are pinned equal by a
 regression test.
 """
 
+_LEGACY_V104_VERSION = "1.0.4"
+_LEGACY_V104_GENERATION_MODE = "revised_after_qa"
+_LEGACY_V104_SEMANTIC_AC_KEY_RE = re.compile(r"^ac_[a-z][a-z0-9_]*$")
+_HASH_SHAPED_SEMANTIC_AC_KEY_RE = re.compile(r"^ac_[a-f0-9]+$")
+
 
 class SeedMetadata(BaseModel, frozen=True):
     """Metadata about the Seed generation.
@@ -765,6 +770,61 @@ def ac_texts(criteria: Any) -> tuple[str, ...]:
     return tuple(ac_text(criterion) for criterion in criteria)
 
 
+def _migrate_legacy_v104_seed_dict(data: dict[str, Any]) -> dict[str, Any]:
+    """Normalize only the persisted v1.0.4 ``revised_after_qa`` parser shape."""
+    metadata = data.get("metadata")
+    if not isinstance(metadata, dict) or (
+        metadata.get("version") != _LEGACY_V104_VERSION
+        or metadata.get("generation_mode") != _LEGACY_V104_GENERATION_MODE
+    ):
+        return data
+
+    normalized = dict(data)
+    criteria = data.get("acceptance_criteria")
+    if isinstance(criteria, list | tuple):
+        normalized_criteria: list[Any] = []
+        criteria_changed = False
+        for item in criteria:
+            semantic_ac_key = item.get("semantic_ac_key") if isinstance(item, dict) else None
+            if (
+                isinstance(semantic_ac_key, str)
+                and _LEGACY_V104_SEMANTIC_AC_KEY_RE.fullmatch(semantic_ac_key)
+                and not _HASH_SHAPED_SEMANTIC_AC_KEY_RE.fullmatch(semantic_ac_key)
+            ):
+                item = {**item, "semantic_ac_key": None}
+                criteria_changed = True
+            normalized_criteria.append(item)
+        if criteria_changed:
+            normalized["acceptance_criteria"] = (
+                tuple(normalized_criteria) if isinstance(criteria, tuple) else normalized_criteria
+            )
+
+    ontology_schema = data.get("ontology_schema")
+    if isinstance(ontology_schema, dict):
+        fields = ontology_schema.get("fields")
+        if isinstance(fields, list | tuple):
+            normalized_fields: list[Any] = []
+            fields_changed = False
+            for item in fields:
+                if (
+                    isinstance(item, dict)
+                    and "description" not in item
+                    and isinstance(item.get("name"), str)
+                    and item["name"].strip()
+                ):
+                    item = {**item, "description": item["name"]}
+                    fields_changed = True
+                normalized_fields.append(item)
+            if fields_changed:
+                normalized_schema = dict(ontology_schema)
+                normalized_schema["fields"] = (
+                    tuple(normalized_fields) if isinstance(fields, tuple) else normalized_fields
+                )
+                normalized["ontology_schema"] = normalized_schema
+
+    return normalized
+
+
 class Seed(BaseModel, frozen=True):
     """Immutable specification for workflow execution.
 
@@ -870,6 +930,13 @@ class Seed(BaseModel, frozen=True):
         ...,
         description="Generation metadata (version, timestamp, etc.)",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy_v104_parser_fields(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            return _migrate_legacy_v104_seed_dict(data)
+        return data
 
     @field_validator("task_type", mode="before")
     @classmethod

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -603,3 +603,72 @@ class TestWorkflowIRCommands:
         assert result.exit_code == 1
         assert "Workflow IR inspection failed" in result.output
         assert "acceptance_criteria.0.description" in result.output
+
+    def test_workflow_ir_inspect_preserves_v104_criterion_semantic_key(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from ouroboros.cli.commands.workflow_ir import _load_seed
+
+        seed_file = tmp_path / "legacy-seed.yaml"
+        seed_file.write_text(
+            "\n".join(
+                [
+                    "goal: Inspect legacy Workflow IR",
+                    "acceptance_criteria:",
+                    "  - criterion: A",
+                    "    semantic_ac_key: ac_a123456789abcdef",
+                    "ontology_schema:",
+                    "  name: Receipt",
+                    "  description: A reconciliation receipt",
+                    "  fields: []",
+                    "metadata:",
+                    "  seed_id: seed_cli_legacy_ir",
+                    "  version: 1.0.4",
+                    "  generation_mode: revised_after_qa",
+                    "  ambiguity_score: 0.1",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        loaded = _load_seed(seed_file)
+        result = runner.invoke(app, ["workflow-ir", "inspect", str(seed_file), "--json"])
+
+        assert loaded.acceptance_criteria[0].description == "A"
+        assert loaded.acceptance_criteria[0].semantic_ac_key == "ac_a123456789abcdef"
+        assert result.exit_code == 0
+        assert '"spec_id": "wfspec_seed_cli_legacy_ir"' in result.output
+        assert '"ok": true' in result.output
+
+    def test_workflow_ir_inspect_rejects_v104_hash_shaped_noncanonical_key(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        seed_file = tmp_path / "legacy-seed.yaml"
+        seed_file.write_text(
+            "\n".join(
+                [
+                    "goal: Inspect legacy Workflow IR",
+                    "acceptance_criteria:",
+                    "  - criterion: A",
+                    "    semantic_ac_key: ac_a123456789abcdef0",
+                    "ontology_schema:",
+                    "  name: Receipt",
+                    "  description: A reconciliation receipt",
+                    "  fields: []",
+                    "metadata:",
+                    "  seed_id: seed_cli_invalid_legacy_ir",
+                    "  version: 1.0.4",
+                    "  generation_mode: revised_after_qa",
+                    "  ambiguity_score: 0.1",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(app, ["workflow-ir", "inspect", str(seed_file), "--json"])
+
+        assert result.exit_code == 1
+        assert "Workflow IR inspection failed" in result.output
+        assert "semantic_ac_key" in result.output

--- a/tests/unit/core/test_seed.py
+++ b/tests/unit/core/test_seed.py
@@ -6,6 +6,7 @@ Tests the immutable Seed schema and related types.
 from datetime import UTC, datetime
 import json
 from pathlib import Path
+from typing import Any
 
 from pydantic import ValidationError as PydanticValidationError
 import pytest
@@ -37,6 +38,25 @@ def _multibyte_artifact_at_byte_budget(*, overflow_bytes: int = 0) -> str:
     path = "/".join(("😀" * 62, "a" * (6 + overflow_bytes)))
     assert len(path.encode("utf-8")) == MAX_AC_SUCCESS_CONTRACT_ARTIFACT_PATH_BYTES + overflow_bytes
     return path
+
+
+def _v104_revised_after_qa_seed(semantic_ac_key: str) -> dict[str, Any]:
+    """Return the persisted v1.0.4 shape that needs compatibility loading."""
+    return {
+        "goal": "Reconcile a campaign",
+        "acceptance_criteria": [
+            {
+                "description": "A deterministic receipt is written",
+                "semantic_ac_key": semantic_ac_key,
+            },
+        ],
+        "ontology_schema": {
+            "name": "Receipt",
+            "description": "A reconciliation receipt",
+            "fields": [{"name": "manifest_id", "type": "string", "required": True}],
+        },
+        "metadata": {"version": "1.0.4", "generation_mode": "revised_after_qa"},
+    }
 
 
 class TestSeedMetadata:
@@ -1071,6 +1091,45 @@ class TestSeed:
         assert (
             reconstructed.exit_conditions[0].evaluation_criteria == "All invariant tests are green"
         )
+
+    @pytest.mark.parametrize("loader", (Seed.from_dict, Seed.model_validate))
+    @pytest.mark.parametrize(
+        "semantic_ac_key",
+        ("ac_a123456789abcdef0", "ac_deadbeef"),
+    )
+    def test_v104_migration_rejects_hash_shaped_noncanonical_semantic_keys(
+        self,
+        loader: Any,
+        semantic_ac_key: str,
+    ) -> None:
+        """All-hex noncanonical keys stay strict validation errors, never legacy labels."""
+        with pytest.raises(PydanticValidationError, match="semantic_ac_key"):
+            loader(_v104_revised_after_qa_seed(semantic_ac_key))
+
+    @pytest.mark.parametrize("loader", (Seed.from_dict, Seed.model_validate))
+    def test_v104_migration_preserves_exact_canonical_semantic_key(self, loader: Any) -> None:
+        """Both direct Seed loaders retain a canonical persisted identity verbatim."""
+        canonical_key = "ac_a123456789abcdef"
+
+        seed = loader(_v104_revised_after_qa_seed(canonical_key))
+
+        assert seed.acceptance_criteria[0].semantic_ac_key == canonical_key
+        assert seed.ontology_schema.fields[0].description == "manifest_id"
+
+    def test_v104_migration_rehashes_descriptive_legacy_key_and_fills_ontology_description(
+        self,
+    ) -> None:
+        """The exact legacy envelope still repairs only its descriptive parser fields."""
+        seed_dict = _v104_revised_after_qa_seed("ac_manifest_exact_frozen")
+
+        seed = Seed.from_dict(seed_dict)
+        criterion = seed.acceptance_criteria[0]
+
+        assert criterion.semantic_ac_key == derive_semantic_ac_key(criterion)
+        assert criterion.semantic_ac_key != "ac_manifest_exact_frozen"
+        assert seed.ontology_schema.fields[0].description == "manifest_id"
+        assert seed_dict["acceptance_criteria"][0]["semantic_ac_key"] == "ac_manifest_exact_frozen"
+        assert "description" not in seed_dict["ontology_schema"]["fields"][0]
 
     def test_seed_roundtrip_serialization(self, full_seed: Seed) -> None:
         """Seed can roundtrip through dict serialization."""


### PR DESCRIPTION
## User problem
Persisted v1.0.4 `revised_after_qa` Seeds must remain loadable without rewriting explicit AC identity or accepting malformed hash-shaped keys.

## Promised contract
- Only exact v1.0.4 / `revised_after_qa` gets compatibility normalization.
- Human-readable legacy labels deterministically materialize canonical hashes.
- Exact `ac_[a-f0-9]{16}` values preserve byte-for-byte.
- all-hex noncanonical-length values fail existing strict validation.
- `workflow-ir inspect` preserves `{criterion, semantic_ac_key}` through Seed.
- nonblank ontology names fill missing descriptions deterministically.

## Implementation boundary
- core Seed migration, Workflow IR normalization, focused core/CLI tests.

## Non-goals
- no runtime worker policy / orchestration behavior
- no parser/dependency/adapter abstraction or WorkflowSpec semantic-key projection
- no compatibility outside exact envelope
- no docs source change: narrow persisted-input compatibility only; stop/report if current docs assert contrary behavior.

## Evidence
- RED: the focused new-regression command produced 5 failures and 4 passes before source changes.
- GREEN: the same focused regressions passed (9 passed).
- Affected Seed and CLI unit modules passed (192 passed).
- Ruff check and format check passed on all four changed files; `mypy src/ouroboros` passed (617 source files).
- Full unit attempt under the approved base profile stopped at 3 collection errors because optional `mcp` is not installed; CI readback follows.

Refs #2338
Supersedes #2283
