### PR TITLE
fix(cli): persist Codex setup telemetry opt-out

### DIFF
--- a/src/ouroboros/cli/codex_mcp_telemetry.py
+++ b/src/ouroboros/cli/codex_mcp_telemetry.py
@@ -1,0 +1,69 @@
+"""Codex MCP env helpers for setup-owned telemetry opt-out."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+
+from ouroboros.config.telemetry_opt_out import telemetry_opt_out_environ
+
+MCP_SECTION_TEMPLATE = """# Ouroboros MCP hookup for Codex CLI.
+# Keep Ouroboros runtime settings and per-role model overrides in
+# ~/.ouroboros/config.yaml (for example: clarification.default_model,
+# llm.qa_model, evaluation.semantic_model, consensus.*).
+# This file is only for the Codex MCP/env registration block.
+
+[mcp_servers.ouroboros]
+{command_lines}
+
+[mcp_servers.ouroboros.env]
+{env_lines}
+"""
+
+TELEMETRY_OPT_OUT_ENV_KEYS = frozenset({"DO_NOT_TRACK", "OUROBOROS_TELEMETRY"})
+TELEMETRY_OPT_OUT_TRUTHY = frozenset({"1", "true", "on", "yes"})
+TELEMETRY_OPT_OUT_FALSY = frozenset({"0", "false", "off", "no"})
+
+
+def base_env(env: Mapping[str, object]) -> dict[str, object]:
+    """Return Codex MCP env without telemetry opt-out keys."""
+    return {key: value for key, value in env.items() if key not in TELEMETRY_OPT_OUT_ENV_KEYS}
+
+
+def env_is_setup_owned(
+    env: object,
+    *,
+    managed_env: Mapping[str, str],
+    host_env: Mapping[str, str],
+) -> bool:
+    """Return whether Codex MCP env is still setup-owned, including opt-out keys."""
+    if env is None:
+        return True
+    if not isinstance(env, dict):
+        return False
+    extra_keys = set(env) - set(managed_env) - set(host_env)
+    if extra_keys - TELEMETRY_OPT_OUT_ENV_KEYS:
+        return False
+    base = base_env(env)
+    if base != dict(managed_env) and base != dict(host_env):
+        return False
+    do_not_track = env.get("DO_NOT_TRACK")
+    if do_not_track is not None and str(do_not_track).strip().lower() not in (
+        TELEMETRY_OPT_OUT_TRUTHY
+    ):
+        return False
+    telemetry_flag = env.get("OUROBOROS_TELEMETRY")
+    return telemetry_flag is None or str(telemetry_flag).strip().lower() in (
+        TELEMETRY_OPT_OUT_FALSY
+    )
+
+
+def registration_env(base: Mapping[str, str]) -> dict[str, str]:
+    """Merge setup-owned Codex MCP env with the current process opt-out."""
+    return {**base, **telemetry_opt_out_environ()}
+
+
+def render_env_lines(base: Mapping[str, str], toml_string: Callable[[str], str]) -> str:
+    """Render the Codex MCP env table body for a setup-owned registration."""
+    return "\n".join(
+        f"{key} = {toml_string(value)}" for key, value in registration_env(base).items()
+    )

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -433,8 +433,7 @@ _CODEX_MCP_SECTION_TEMPLATE = """# Ouroboros MCP hookup for Codex CLI.
 {command_lines}
 
 [mcp_servers.ouroboros.env]
-OUROBOROS_AGENT_RUNTIME = "codex"
-OUROBOROS_LLM_BACKEND = "codex"
+{env_lines}
 """
 _CODEX_MCP_COMMENT_LINES = (
     "# Ouroboros MCP hookup for Codex CLI.",
@@ -470,6 +469,9 @@ _CODEX_HOST_MCP_ENV = {
     "OUROBOROS_AGENT_RUNTIME": "host",
     "OUROBOROS_LLM_BACKEND": "codex",
 }
+_CODEX_TELEMETRY_OPT_OUT_ENV_KEYS = frozenset({"DO_NOT_TRACK", "OUROBOROS_TELEMETRY"})
+_CODEX_TELEMETRY_OPT_OUT_TRUTHY = frozenset({"1", "true", "on", "yes"})
+_CODEX_TELEMETRY_OPT_OUT_FALSY = frozenset({"0", "false", "off", "no"})
 _CODEX_HOST_DIRECT_MCP_ARGS = [
     "mcp",
     "serve",
@@ -649,6 +651,50 @@ def _toml_string(value: str) -> str:
     return json.dumps(value, ensure_ascii=False)
 
 
+def _codex_mcp_base_env(env: dict[str, object]) -> dict[str, object]:
+    """Return Codex MCP env without telemetry opt-out keys."""
+    return {
+        key: value for key, value in env.items() if key not in _CODEX_TELEMETRY_OPT_OUT_ENV_KEYS
+    }
+
+
+def _codex_mcp_env_is_setup_owned(env: object) -> bool:
+    """Return whether Codex MCP env is still setup-owned, including opt-out keys."""
+    if env is None:
+        return True
+    if not isinstance(env, dict):
+        return False
+    extra_keys = set(env) - set(_CODEX_MANAGED_MCP_ENV) - set(_CODEX_HOST_MCP_ENV)
+    if extra_keys - _CODEX_TELEMETRY_OPT_OUT_ENV_KEYS:
+        return False
+    base = _codex_mcp_base_env(env)
+    if base != _CODEX_MANAGED_MCP_ENV and base != _CODEX_HOST_MCP_ENV:
+        return False
+    do_not_track = env.get("DO_NOT_TRACK")
+    if do_not_track is not None and str(do_not_track).strip().lower() not in (
+        _CODEX_TELEMETRY_OPT_OUT_TRUTHY
+    ):
+        return False
+    telemetry_flag = env.get("OUROBOROS_TELEMETRY")
+    return telemetry_flag is None or str(telemetry_flag).strip().lower() in (
+        _CODEX_TELEMETRY_OPT_OUT_FALSY
+    )
+
+
+def _codex_mcp_registration_env(base: dict[str, str]) -> dict[str, str]:
+    """Merge setup-owned Codex MCP env with the current process opt-out."""
+    from ouroboros.config.loader import telemetry_opt_out_environ
+
+    return {**base, **telemetry_opt_out_environ()}
+
+
+def _render_codex_mcp_env_lines(base: dict[str, str]) -> str:
+    """Render the Codex MCP env table body for a setup-owned registration."""
+    return "\n".join(
+        f"{key} = {_toml_string(value)}" for key, value in _codex_mcp_registration_env(base).items()
+    )
+
+
 def _codex_release_mcp_launcher() -> tuple[str, list[str]] | None:
     """Resolve a launchable release MCP command for the current machine."""
     uvx_path = shutil.which("uvx")
@@ -708,7 +754,10 @@ def _render_codex_mcp_section() -> str | None:
             "args = [" + ", ".join(_toml_string(arg) for arg in args) + "]",
         )
     )
-    return _CODEX_MCP_SECTION_TEMPLATE.format(command_lines=command_lines)
+    return _CODEX_MCP_SECTION_TEMPLATE.format(
+        command_lines=command_lines,
+        env_lines=_render_codex_mcp_env_lines(_CODEX_MANAGED_MCP_ENV),
+    )
 
 
 def _has_managed_codex_mcp_comment(raw: str) -> bool:
@@ -742,7 +791,7 @@ def _is_setup_managed_codex_mcp_entry(
         return False
 
     env = entry.get("env")
-    if env is not None and env != _CODEX_MANAGED_MCP_ENV and env != _CODEX_HOST_MCP_ENV:
+    if env is not None and not _codex_mcp_env_is_setup_owned(env):
         return False
     if set(entry) - {"command", "args", "env"}:
         return False
@@ -753,9 +802,10 @@ def _is_setup_managed_codex_mcp_entry(
         args_tuple = tuple(str(arg) for arg in args)
         if has_managed_comment:
             return args_tuple in _CODEX_LEGACY_DIRECT_MCP_ARGS
+        base_env = _codex_mcp_base_env(env) if isinstance(env, dict) else env
         return (
             args_tuple == _CODEX_DIRECT_MCP_BASE_ARGS
-            and env == _CODEX_MANAGED_MCP_ENV
+            and base_env == _CODEX_MANAGED_MCP_ENV
             and _command_matches_path_program(command, "ouroboros")
         )
     if not has_managed_comment:

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -38,6 +38,10 @@ import yaml
 
 from ouroboros import package_profiles
 from ouroboros.bigbang.brownfield import scan_and_register, set_default_repo
+from ouroboros.cli.codex_mcp_telemetry import MCP_SECTION_TEMPLATE as _CODEX_MCP_SECTION_TEMPLATE
+from ouroboros.cli.codex_mcp_telemetry import base_env as _codex_mcp_base_env
+from ouroboros.cli.codex_mcp_telemetry import env_is_setup_owned as _codex_mcp_env_is_setup_owned
+from ouroboros.cli.codex_mcp_telemetry import render_env_lines as _render_codex_mcp_env_lines
 from ouroboros.cli.commands.claude_setup import (
     setup_claude as _setup_claude,
 )
@@ -423,18 +427,6 @@ def _detect_runtimes() -> dict[str, str | None]:
     return runtimes
 
 
-_CODEX_MCP_SECTION_TEMPLATE = """# Ouroboros MCP hookup for Codex CLI.
-# Keep Ouroboros runtime settings and per-role model overrides in
-# ~/.ouroboros/config.yaml (for example: clarification.default_model,
-# llm.qa_model, evaluation.semantic_model, consensus.*).
-# This file is only for the Codex MCP/env registration block.
-
-[mcp_servers.ouroboros]
-{command_lines}
-
-[mcp_servers.ouroboros.env]
-{env_lines}
-"""
 _CODEX_MCP_COMMENT_LINES = (
     "# Ouroboros MCP hookup for Codex CLI.",
     "# Keep Ouroboros runtime settings and per-role model overrides in",
@@ -469,9 +461,6 @@ _CODEX_HOST_MCP_ENV = {
     "OUROBOROS_AGENT_RUNTIME": "host",
     "OUROBOROS_LLM_BACKEND": "codex",
 }
-_CODEX_TELEMETRY_OPT_OUT_ENV_KEYS = frozenset({"DO_NOT_TRACK", "OUROBOROS_TELEMETRY"})
-_CODEX_TELEMETRY_OPT_OUT_TRUTHY = frozenset({"1", "true", "on", "yes"})
-_CODEX_TELEMETRY_OPT_OUT_FALSY = frozenset({"0", "false", "off", "no"})
 _CODEX_HOST_DIRECT_MCP_ARGS = [
     "mcp",
     "serve",
@@ -651,50 +640,6 @@ def _toml_string(value: str) -> str:
     return json.dumps(value, ensure_ascii=False)
 
 
-def _codex_mcp_base_env(env: dict[str, object]) -> dict[str, object]:
-    """Return Codex MCP env without telemetry opt-out keys."""
-    return {
-        key: value for key, value in env.items() if key not in _CODEX_TELEMETRY_OPT_OUT_ENV_KEYS
-    }
-
-
-def _codex_mcp_env_is_setup_owned(env: object) -> bool:
-    """Return whether Codex MCP env is still setup-owned, including opt-out keys."""
-    if env is None:
-        return True
-    if not isinstance(env, dict):
-        return False
-    extra_keys = set(env) - set(_CODEX_MANAGED_MCP_ENV) - set(_CODEX_HOST_MCP_ENV)
-    if extra_keys - _CODEX_TELEMETRY_OPT_OUT_ENV_KEYS:
-        return False
-    base = _codex_mcp_base_env(env)
-    if base != _CODEX_MANAGED_MCP_ENV and base != _CODEX_HOST_MCP_ENV:
-        return False
-    do_not_track = env.get("DO_NOT_TRACK")
-    if do_not_track is not None and str(do_not_track).strip().lower() not in (
-        _CODEX_TELEMETRY_OPT_OUT_TRUTHY
-    ):
-        return False
-    telemetry_flag = env.get("OUROBOROS_TELEMETRY")
-    return telemetry_flag is None or str(telemetry_flag).strip().lower() in (
-        _CODEX_TELEMETRY_OPT_OUT_FALSY
-    )
-
-
-def _codex_mcp_registration_env(base: dict[str, str]) -> dict[str, str]:
-    """Merge setup-owned Codex MCP env with the current process opt-out."""
-    from ouroboros.config.loader import telemetry_opt_out_environ
-
-    return {**base, **telemetry_opt_out_environ()}
-
-
-def _render_codex_mcp_env_lines(base: dict[str, str]) -> str:
-    """Render the Codex MCP env table body for a setup-owned registration."""
-    return "\n".join(
-        f"{key} = {_toml_string(value)}" for key, value in _codex_mcp_registration_env(base).items()
-    )
-
-
 def _codex_release_mcp_launcher() -> tuple[str, list[str]] | None:
     """Resolve a launchable release MCP command for the current machine."""
     uvx_path = shutil.which("uvx")
@@ -756,7 +701,7 @@ def _render_codex_mcp_section() -> str | None:
     )
     return _CODEX_MCP_SECTION_TEMPLATE.format(
         command_lines=command_lines,
-        env_lines=_render_codex_mcp_env_lines(_CODEX_MANAGED_MCP_ENV),
+        env_lines=_render_codex_mcp_env_lines(_CODEX_MANAGED_MCP_ENV, _toml_string),
     )
 
 
@@ -791,7 +736,9 @@ def _is_setup_managed_codex_mcp_entry(
         return False
 
     env = entry.get("env")
-    if env is not None and not _codex_mcp_env_is_setup_owned(env):
+    if env is not None and not _codex_mcp_env_is_setup_owned(
+        env, managed_env=_CODEX_MANAGED_MCP_ENV, host_env=_CODEX_HOST_MCP_ENV
+    ):
         return False
     if set(entry) - {"command", "args", "env"}:
         return False

--- a/src/ouroboros/config/__init__.py
+++ b/src/ouroboros/config/__init__.py
@@ -86,7 +86,6 @@ from ouroboros.config.loader import (
     get_zcode_cli_path,
     load_config,
     load_credentials,
-    telemetry_opt_out_environ,
 )
 from ouroboros.config.models import (
     ClarificationConfig,
@@ -115,6 +114,7 @@ from ouroboros.config.models import (
     get_default_config,
     get_default_credentials,
 )
+from ouroboros.config.telemetry_opt_out import telemetry_opt_out_environ
 
 __all__ = [
     # Models

--- a/src/ouroboros/config/__init__.py
+++ b/src/ouroboros/config/__init__.py
@@ -86,6 +86,7 @@ from ouroboros.config.loader import (
     get_zcode_cli_path,
     load_config,
     load_credentials,
+    telemetry_opt_out_environ,
 )
 from ouroboros.config.models import (
     ClarificationConfig,
@@ -200,6 +201,7 @@ __all__ = [
     "get_runtime_profile",
     "get_semantic_model",
     "get_telemetry_enabled",
+    "telemetry_opt_out_environ",
     "get_usage_limit_pause_seconds",
     "MAX_USAGE_LIMIT_PAUSE_SECONDS",
     "get_wonder_model",

--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -57,11 +57,11 @@ from ouroboros.config.models import (  # noqa: E402
     CredentialsConfig,
     OuroborosConfig,
     RuntimeControlsConfig,
-    TelemetryConfig,
     get_config_dir,
     get_default_config,
     get_default_credentials,
 )
+from ouroboros.config.telemetry_opt_out import with_process_telemetry_opt_out
 from ouroboros.config.untrusted_env import is_untrusted_env_denied_key
 from ouroboros.core.errors import ConfigError  # noqa: E402
 from ouroboros.orchestrator_stage import (  # noqa: E402
@@ -342,11 +342,7 @@ def create_default_config(
             )
 
     # Create config.yaml
-    default_config = get_default_config()
-    if telemetry_opt_out_environ():
-        default_config = default_config.model_copy(
-            update={"telemetry": TelemetryConfig(enabled=False)}
-        )
+    default_config = with_process_telemetry_opt_out(get_default_config())
     config_dict = _model_to_yaml_dict(default_config)
     with config_path.open("w", encoding="utf-8") as f:
         yaml.dump(
@@ -1532,26 +1528,6 @@ def get_opencode_mode() -> str | None:
         return config.orchestrator.opencode_mode
     except ConfigError:
         return None
-
-
-def telemetry_opt_out_environ() -> dict[str, str]:
-    """Return normalized process-level telemetry opt-out variables.
-
-    Only environment signals are included. A persisted
-    ``telemetry.enabled: false`` is not copied into the mapping: that
-    file-level preference already applies in this process, and MCP child
-    environments should not invent keys the operator did not set.
-
-    Values are normalized to ``DO_NOT_TRACK=1`` and ``OUROBOROS_TELEMETRY=0``
-    so Codex MCP registrations inherit a stable opt-out regardless of the
-    original spelling (``true``/``yes``/``off``/``no``).
-    """
-    env: dict[str, str] = {}
-    if os.environ.get("DO_NOT_TRACK", "").strip().lower() in ("1", "true", "on", "yes"):
-        env["DO_NOT_TRACK"] = "1"
-    if _env_flag("OUROBOROS_TELEMETRY") is False:
-        env["OUROBOROS_TELEMETRY"] = "0"
-    return env
 
 
 def get_telemetry_enabled() -> bool:

--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -57,6 +57,7 @@ from ouroboros.config.models import (  # noqa: E402
     CredentialsConfig,
     OuroborosConfig,
     RuntimeControlsConfig,
+    TelemetryConfig,
     get_config_dir,
     get_default_config,
     get_default_credentials,
@@ -342,6 +343,10 @@ def create_default_config(
 
     # Create config.yaml
     default_config = get_default_config()
+    if telemetry_opt_out_environ():
+        default_config = default_config.model_copy(
+            update={"telemetry": TelemetryConfig(enabled=False)}
+        )
     config_dict = _model_to_yaml_dict(default_config)
     with config_path.open("w", encoding="utf-8") as f:
         yaml.dump(
@@ -1527,6 +1532,26 @@ def get_opencode_mode() -> str | None:
         return config.orchestrator.opencode_mode
     except ConfigError:
         return None
+
+
+def telemetry_opt_out_environ() -> dict[str, str]:
+    """Return normalized process-level telemetry opt-out variables.
+
+    Only environment signals are included. A persisted
+    ``telemetry.enabled: false`` is not copied into the mapping: that
+    file-level preference already applies in this process, and MCP child
+    environments should not invent keys the operator did not set.
+
+    Values are normalized to ``DO_NOT_TRACK=1`` and ``OUROBOROS_TELEMETRY=0``
+    so Codex MCP registrations inherit a stable opt-out regardless of the
+    original spelling (``true``/``yes``/``off``/``no``).
+    """
+    env: dict[str, str] = {}
+    if os.environ.get("DO_NOT_TRACK", "").strip().lower() in ("1", "true", "on", "yes"):
+        env["DO_NOT_TRACK"] = "1"
+    if _env_flag("OUROBOROS_TELEMETRY") is False:
+        env["OUROBOROS_TELEMETRY"] = "0"
+    return env
 
 
 def get_telemetry_enabled() -> bool:

--- a/src/ouroboros/config/telemetry_opt_out.py
+++ b/src/ouroboros/config/telemetry_opt_out.py
@@ -1,0 +1,40 @@
+"""Process-level telemetry opt-out helpers.
+
+Kept out of ``config.loader`` so grandfathered modules do not grow when
+setup persists ``DO_NOT_TRACK`` / ``OUROBOROS_TELEMETRY``.
+"""
+
+from __future__ import annotations
+
+import os
+
+from ouroboros.config.models import OuroborosConfig, TelemetryConfig
+
+
+def telemetry_opt_out_environ() -> dict[str, str]:
+    """Return normalized process-level telemetry opt-out variables.
+
+    Only environment signals are included. A persisted
+    ``telemetry.enabled: false`` is not copied into the mapping: that
+    file-level preference already applies in this process, and MCP child
+    environments should not invent keys the operator did not set.
+
+    Values are normalized to ``DO_NOT_TRACK=1`` and ``OUROBOROS_TELEMETRY=0``
+    so Codex MCP registrations inherit a stable opt-out regardless of the
+    original spelling (``true``/``yes``/``off``/``no``).
+    """
+    env: dict[str, str] = {}
+    raw_do_not_track = os.environ.get("DO_NOT_TRACK", "").strip().lower()
+    if raw_do_not_track in ("1", "true", "on", "yes"):
+        env["DO_NOT_TRACK"] = "1"
+    raw_telemetry = os.environ.get("OUROBOROS_TELEMETRY", "").strip().lower()
+    if raw_telemetry in ("0", "false", "off", "no"):
+        env["OUROBOROS_TELEMETRY"] = "0"
+    return env
+
+
+def with_process_telemetry_opt_out(config: OuroborosConfig) -> OuroborosConfig:
+    """Persist an active process opt-out onto a freshly generated config."""
+    if not telemetry_opt_out_environ():
+        return config
+    return config.model_copy(update={"telemetry": TelemetryConfig(enabled=False)})

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -1374,9 +1374,13 @@ class TestCodexDoctor:
         assert rendered is not None
         parsed = tomllib.loads(rendered)
         entry = parsed["mcp_servers"]["ouroboros"]
-        assert entry["env"] == {
-            "OUROBOROS_AGENT_RUNTIME": "codex",
-            "OUROBOROS_LLM_BACKEND": "codex",
+        assert entry["env"]["OUROBOROS_AGENT_RUNTIME"] == "codex"
+        assert entry["env"]["OUROBOROS_LLM_BACKEND"] == "codex"
+        assert set(entry["env"]) <= {
+            "OUROBOROS_AGENT_RUNTIME",
+            "OUROBOROS_LLM_BACKEND",
+            "DO_NOT_TRACK",
+            "OUROBOROS_TELEMETRY",
         }
         (codex_dir / "config.toml").write_text(rendered, encoding="utf-8")
         assert _check_auto_dispatch_surface(codex_dir) == []

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -342,6 +342,116 @@ class TestCodexSetup:
             '"ouroboros", "mcp", "serve"]' in contents
         )
 
+    def test_register_codex_mcp_server_inherits_telemetry_opt_out(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fresh Codex MCP env must carry the setup process telemetry opt-out."""
+        monkeypatch.setenv("DO_NOT_TRACK", "true")
+        monkeypatch.setenv("OUROBOROS_TELEMETRY", "off")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.is_native_windows", return_value=False),
+            patch(
+                "ouroboros.cli.commands.setup._is_source_tree_ouroboros_build", return_value=False
+            ),
+            patch("ouroboros.cli.commands.setup.importlib_metadata.version", return_value="0.38.2"),
+            patch("ouroboros.cli.commands.setup.shutil.which", return_value="/usr/local/bin/uvx"),
+        ):
+            assert setup_cmd._register_codex_mcp_server()
+
+        contents = (tmp_path / ".codex" / "config.toml").read_text(encoding="utf-8")
+        parsed = tomllib.loads(contents)
+        env = parsed["mcp_servers"]["ouroboros"]["env"]
+        assert env["OUROBOROS_AGENT_RUNTIME"] == "codex"
+        assert env["OUROBOROS_LLM_BACKEND"] == "codex"
+        assert env["DO_NOT_TRACK"] == "1"
+        assert env["OUROBOROS_TELEMETRY"] == "0"
+
+    def test_register_codex_mcp_server_refreshes_managed_entry_with_opt_out(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Setup-owned Codex MCP env should pick up a later process opt-out."""
+        monkeypatch.setenv("DO_NOT_TRACK", "1")
+        monkeypatch.delenv("OUROBOROS_TELEMETRY", raising=False)
+        codex_config = tmp_path / ".codex" / "config.toml"
+        codex_config.parent.mkdir(parents=True)
+        codex_config.write_text(
+            "\n".join(
+                [
+                    "# Ouroboros MCP hookup for Codex CLI.",
+                    "# Keep Ouroboros runtime settings and per-role model overrides in",
+                    "# ~/.ouroboros/config.yaml (for example: clarification.default_model,",
+                    "# llm.qa_model, evaluation.semantic_model, consensus.*).",
+                    "# This file is only for the Codex MCP/env registration block.",
+                    "",
+                    "[mcp_servers.ouroboros]",
+                    'command = "/usr/local/bin/uvx"',
+                    'args = ["--isolated", "--python", ">=3.12", "--from", "ouroboros-ai[mcp]", '
+                    '"ouroboros", "mcp", "serve"]',
+                    "",
+                    "[mcp_servers.ouroboros.env]",
+                    'OUROBOROS_AGENT_RUNTIME = "codex"',
+                    'OUROBOROS_LLM_BACKEND = "codex"',
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.is_native_windows", return_value=False),
+            patch(
+                "ouroboros.cli.commands.setup._is_source_tree_ouroboros_build", return_value=False
+            ),
+            patch("ouroboros.cli.commands.setup.importlib_metadata.version", return_value="0.38.2"),
+            patch("ouroboros.cli.commands.setup.shutil.which", return_value="/usr/local/bin/uvx"),
+        ):
+            assert setup_cmd._register_codex_mcp_server()
+
+        env = tomllib.loads(codex_config.read_text(encoding="utf-8"))["mcp_servers"]["ouroboros"][
+            "env"
+        ]
+        assert env["DO_NOT_TRACK"] == "1"
+        assert "OUROBOROS_TELEMETRY" not in env
+
+    def test_register_codex_mcp_server_preserves_custom_env_without_opt_out(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """User-owned MCP env must not be rewritten to inject telemetry opt-out."""
+        monkeypatch.setenv("DO_NOT_TRACK", "1")
+        selected = tmp_path / "bin" / "ouroboros"
+        selected.parent.mkdir()
+        selected.touch()
+        codex_config = tmp_path / ".codex" / "config.toml"
+        codex_config.parent.mkdir(parents=True)
+        original = (
+            "[mcp_servers.ouroboros]\n"
+            f"command = {json.dumps(str(selected))}\n"
+            'args = ["mcp", "serve"]\n'
+            "[mcp_servers.ouroboros.env]\n"
+            'OUROBOROS_AGENT_RUNTIME = "claude"\n'
+            'OUROBOROS_LLM_BACKEND = "codex"\n'
+        )
+        codex_config.write_text(original, encoding="utf-8")
+
+        def which(command: str) -> str | None:
+            return str(selected) if command in {"ouroboros", str(selected)} else None
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.is_native_windows", return_value=False),
+            patch("ouroboros.cli.commands.setup.shutil.which", side_effect=which),
+            patch(
+                "ouroboros.cli.commands.setup._render_codex_mcp_section",
+                return_value='[mcp_servers.ouroboros]\ncommand = "uvx"\nargs = []\n',
+            ),
+        ):
+            assert setup_cmd._register_codex_mcp_server()
+
+        assert codex_config.read_text(encoding="utf-8") == original
+
     def test_register_codex_mcp_server_uses_direct_executable_for_dev_build(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -9958,9 +9958,7 @@ class TestHostRuntimeSetup:
                     'args = ["mcp", "serve", "--runtime", "codex", '
                     '"--llm-backend", "codex"]'
                 ),
-                env_lines=(
-                    'OUROBOROS_AGENT_RUNTIME = "codex"\nOUROBOROS_LLM_BACKEND = "codex"'
-                ),
+                env_lines=('OUROBOROS_AGENT_RUNTIME = "codex"\nOUROBOROS_LLM_BACKEND = "codex"'),
             ),
             encoding="utf-8",
         )

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -9957,7 +9957,10 @@ class TestHostRuntimeSetup:
                     'command = "ouroboros"\n'
                     'args = ["mcp", "serve", "--runtime", "codex", '
                     '"--llm-backend", "codex"]'
-                )
+                ),
+                env_lines=(
+                    'OUROBOROS_AGENT_RUNTIME = "codex"\nOUROBOROS_LLM_BACKEND = "codex"'
+                ),
             ),
             encoding="utf-8",
         )

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -233,6 +233,34 @@ class TestCreateDefaultConfig:
         assert (config_dir / "data").exists()
         assert (config_dir / "logs").exists()
 
+    def test_create_default_config_persists_env_telemetry_opt_out(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fresh config must persist an active process-level telemetry opt-out."""
+        monkeypatch.setenv("DO_NOT_TRACK", "1")
+        monkeypatch.setenv("OUROBOROS_TELEMETRY", "0")
+        config_dir = tmp_path / ".ouroboros"
+
+        config_path, _ = create_default_config(config_dir)
+
+        with config_path.open(encoding="utf-8") as handle:
+            config_dict = yaml.safe_load(handle)
+        assert config_dict["telemetry"]["enabled"] is False
+
+    def test_create_default_config_keeps_telemetry_on_without_env_opt_out(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Absent process opt-out, a fresh config keeps the default-on contract."""
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+        monkeypatch.delenv("OUROBOROS_TELEMETRY", raising=False)
+        config_dir = tmp_path / ".ouroboros"
+
+        config_path, _ = create_default_config(config_dir)
+
+        with config_path.open(encoding="utf-8") as handle:
+            config_dict = yaml.safe_load(handle)
+        assert config_dict["telemetry"]["enabled"] is True
+
 
 class TestLoadConfig:
     """Test load_config function."""


### PR DESCRIPTION
## User problem

`ouroboros setup --runtime codex --non-interactive` run with `DO_NOT_TRACK=1` and `OUROBOROS_TELEMETRY=0` still wrote `telemetry.enabled: true` and a Codex MCP env without those opt-out variables. Later Codex MCP launches could therefore enable telemetry.

## Promised contract

- Supported inputs: process env `DO_NOT_TRACK` in `{1,true,on,yes}` and/or `OUROBOROS_TELEMETRY` in `{0,false,off,no}` during fresh `create_default_config` and setup-managed Codex MCP registration.
- Preconditions: Codex MCP auto-registration path that writes `~/.codex/config.toml` (not native-Windows auto skip).
- Observable behavior:
  - Fresh config persists `telemetry.enabled: false` when a process opt-out is active.
  - Setup-managed Codex MCP env inherits normalized `DO_NOT_TRACK=1` and/or `OUROBOROS_TELEMETRY=0`.
  - Refresh of a setup-owned Codex MCP entry picks up a later process opt-out.
  - User-owned MCP env (foreign runtime or extra keys) is left unchanged.
  - Absent process opt-out, fresh config keeps the default-on contract.
- Invariants: file-level `telemetry.enabled: false` is not copied into MCP env; only process-level opt-out keys are injected.

## Implementation boundary

- `src/ouroboros/config/loader.py` (`create_default_config`, `telemetry_opt_out_environ`)
- `src/ouroboros/cli/commands/setup.py` (Codex MCP env render + setup-owned env matching)
- Tests in `tests/unit/config/test_loader.py` and `tests/unit/cli/test_setup.py`
- Owner: existing config/setup CLI maintainers

## Non-goals

- Changing native-Windows Codex auto mode, which still skips persistent MCP registration.
- Rewriting an existing `config.yaml` `telemetry.enabled` on refresh.
- Hermes/Copilot MCP env, install.sh telemetry, or PostHog transport.
- Pinning `ouroboros-ai[mcp]` versions (separate issue #2280).

## Evidence

```
uv run ruff format <changed files>
uv run ruff check <changed files>
uv run pytest tests/unit/config/test_loader.py::TestCreateDefaultConfig::test_create_default_config_persists_env_telemetry_opt_out tests/unit/config/test_loader.py::TestCreateDefaultConfig::test_create_default_config_keeps_telemetry_on_without_env_opt_out tests/unit/cli/test_setup.py::TestCodexSetup::test_register_codex_mcp_server_inherits_telemetry_opt_out tests/unit/cli/test_setup.py::TestCodexSetup::test_register_codex_mcp_server_refreshes_managed_entry_with_opt_out tests/unit/cli/test_setup.py::TestCodexSetup::test_register_codex_mcp_server_preserves_custom_env_without_opt_out tests/unit/cli/test_setup.py::TestCodexSetup::test_register_codex_mcp_server_preserves_path_direct_with_mismatched_env
```

6 targeted tests passed. Pre-existing Windows chmod/symlink and native-Windows MCP auto-skip failures were not introduced by this change.

Refs #2281
