### PR TITLE
fix(auto): type the grade-gate stop_reason_code instead of shipping None

### DIFF
--- a/src/ouroboros/auto/grade_gate_terminals.py
+++ b/src/ouroboros/auto/grade_gate_terminals.py
@@ -1,0 +1,84 @@
+"""The auto pipeline's grade gate: its verdict, and the codes its terminals stop with.
+
+Grade-gate terminals are the pipeline's most common BLOCKED outcome and were
+the last blocker family still leaving ``stop_reason_code`` at ``None``. The
+consequence is downstream: ``ooo auto`` prints ``-``, the MCP envelope omits
+the key, harness traces write null, and ``attention_relay`` has nothing to
+relay -- so every consumer had to read English prose to tell "the grade is too
+low" (raise the grade) from "the review withheld ``may_run``" (the grade bar
+was already cleared, so raising it is the wrong next step) from "a degraded
+Seed still carries hard safety blockers" (resolve the markers).
+
+Module-level consts, so every call site emits the same string and the alphabet
+of valid codes stays discoverable by reading a module surface -- the same
+convention as the interview layer's ``UNSTUCK_EXHAUSTED_STOP_REASON_CODE`` and
+the runtime's ``watchdog_wall_clock_exceeded``.
+
+The gate's own verdict lives here beside them rather than in ``pipeline``,
+because a code that is decided in one module and named in another is a code
+that can drift from what it names.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ouroboros.auto.seed_reviewer import SeedReview
+    from ouroboros.auto.state import AutoPipelineState
+
+SEED_GRADE_BELOW_REQUIRED_STOP_REASON_CODE = "seed_grade_below_required"
+SEED_REVIEW_WITHHELD_RUN_STOP_REASON_CODE = "seed_review_withheld_run"
+DEGRADED_SEED_SAFETY_BLOCKERS_STOP_REASON_CODE = "degraded_seed_safety_blockers"
+
+_GRADE_RANK = {"A": 0, "B": 1, "C": 2}
+
+
+def grade_meets_required(actual: str | None, required: str) -> bool:
+    """Whether ``actual`` is at least as good as ``required``; unknown never is."""
+    if actual not in _GRADE_RANK or required not in _GRADE_RANK:
+        return False
+    return _GRADE_RANK[actual] <= _GRADE_RANK[required]
+
+
+def degraded_seed_safety_blocker(review: SeedReview) -> tuple[str, str] | None:
+    """Return ``(blocker, stop_reason_code)`` if a degraded Seed still has blockers.
+
+    A Seed synthesized under deadline pressure may surface as a partial product,
+    but never while hard safety markers remain unresolved -- so this terminal is
+    typed beside the other two rather than left as prose at the call site.
+    """
+    if not review.grade_result.blockers:
+        return None
+    codes = ", ".join(finding.code for finding in review.grade_result.blockers)
+    return (
+        "Degraded seed retains hard safety blockers; "
+        f"unsafe/destructive markers must be resolved before run: {codes}",
+        DEGRADED_SEED_SAFETY_BLOCKERS_STOP_REASON_CODE,
+    )
+
+
+def seed_review_gate_blocker(
+    state: AutoPipelineState, review: SeedReview | None, *, skip_run: bool
+) -> tuple[str, str] | None:
+    """Return ``(blocker, stop_reason_code)`` for the deterministic review gate.
+
+    The code travels with the message because these are the *same* terminals
+    the inline REVIEW-phase gate raises: returning the prose alone would force
+    callers to re-derive the classification the gate has already computed,
+    which is exactly the prose-parsing this typing exists to remove.
+    """
+    if review is None:
+        return None
+    if not grade_meets_required(review.grade_result.grade.value, state.required_grade):
+        return (
+            f"Seed grade {review.grade_result.grade.value} did not meet "
+            f"required grade {state.required_grade}",
+            SEED_GRADE_BELOW_REQUIRED_STOP_REASON_CODE,
+        )
+    if not review.may_run and not skip_run:
+        return (
+            "Seed review did not clear the Seed for execution",
+            SEED_REVIEW_WITHHELD_RUN_STOP_REASON_CODE,
+        )
+    return None

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -25,6 +25,13 @@ from ouroboros.auto.checkpoint_commits import checkpoint_final_auto
 from ouroboros.auto.domain_inference import derive_domain_from_ledger
 from ouroboros.auto.domain_profile import DEFAULT_REGISTRY
 from ouroboros.auto.execution_acceptance import normalize_execution_acceptance
+from ouroboros.auto.grade_gate_terminals import (
+    SEED_GRADE_BELOW_REQUIRED_STOP_REASON_CODE,
+    SEED_REVIEW_WITHHELD_RUN_STOP_REASON_CODE,
+    degraded_seed_safety_blocker,
+    grade_meets_required,
+    seed_review_gate_blocker,
+)
 from ouroboros.auto.grading import GradeGate, deterministic_floor
 from ouroboros.auto.handoff_contract import (
     IDEMPOTENCY_KEY_FIELD,
@@ -1153,31 +1160,18 @@ class AutoPipeline:
             # Normal (non-degraded) Seeds skip this branch and fall through to
             # the existing grade-gate / may_run checks unchanged.
             if bool(getattr(seed.metadata, "degraded", False)):
-                if review.grade_result.blockers:
-                    blocker_codes = ", ".join(
-                        finding.code for finding in review.grade_result.blockers
-                    )
-                    blocker = (
-                        "Degraded seed retains hard safety blockers; "
-                        f"unsafe/destructive markers must be resolved before run: {blocker_codes}"
-                    )
-                    state.mark_blocked(blocker, tool_name="grade_gate")
+                if terminal := degraded_seed_safety_blocker(review):
+                    blocker, code = terminal
+                    state.mark_blocked(blocker, tool_name="grade_gate", error_code=code)
                     self._save(state)
                     return self._result(state, ledger, review=review, blocker=blocker)
                 return await self._emit_partial_product_terminal(state, ledger, seed, review)
 
-            if not _grade_meets_required(review.grade_result.grade.value, state.required_grade):
-                blocker = (
-                    f"Seed grade {review.grade_result.grade.value} did not meet "
-                    f"required grade {state.required_grade}"
-                )
-                state.mark_blocked(blocker, tool_name="grade_gate")
-                self._save(state)
-                return self._result(state, ledger, review=review, blocker=blocker)
-
-            if not review.may_run and not (self.skip_run or state.skip_run):
-                blocker = "Seed review did not clear the Seed for execution"
-                state.mark_blocked(blocker, tool_name="grade_gate")
+            if terminal := seed_review_gate_blocker(
+                state, review, skip_run=self.skip_run or state.skip_run
+            ):
+                blocker, code = terminal
+                state.mark_blocked(blocker, tool_name="grade_gate", error_code=code)
                 self._save(state)
                 return self._result(state, ledger, review=review, blocker=blocker)
 
@@ -1252,10 +1246,11 @@ class AutoPipeline:
                 )
                 self._save(state)
                 return self._result(state, ledger, review=review)
-            if not _grade_meets_required(state.last_grade, state.required_grade):
+            if not grade_meets_required(state.last_grade, state.required_grade):
                 state.mark_blocked(
                     f"Cannot start execution without a persisted grade meeting {state.required_grade}",
                     tool_name="grade_gate",
+                    error_code=SEED_GRADE_BELOW_REQUIRED_STOP_REASON_CODE,
                 )
                 self._save(state)
                 return self._result(state, ledger, review=review, blocker=state.last_error)
@@ -1299,6 +1294,7 @@ class AutoPipeline:
                 state.mark_blocked(
                     "Seed review did not clear the Seed for execution",
                     tool_name="grade_gate",
+                    error_code=SEED_REVIEW_WITHHELD_RUN_STOP_REASON_CODE,
                 )
                 self._save(state)
                 return self._result(state, ledger, review=review, blocker=state.last_error)
@@ -2076,9 +2072,14 @@ class AutoPipeline:
             state.last_qa_differences = _safe_seed_qa_evidence(qa_result.differences)
             state.last_qa_suggestions = _safe_seed_qa_evidence(qa_result.suggestions)
             if qa_result.passed:
-                review_blocker = self._seed_review_gate_blocker(state, current_review)
-                if review_blocker is not None:
-                    state.mark_blocked(review_blocker, tool_name="grade_gate")
+                review_gate = seed_review_gate_blocker(
+                    state, current_review, skip_run=self.skip_run or state.skip_run
+                )
+                if review_gate is not None:
+                    review_blocker, review_code = review_gate
+                    state.mark_blocked(
+                        review_blocker, tool_name="grade_gate", error_code=review_code
+                    )
                     self._save(state)
                     return (
                         self._result(state, ledger, review=current_review, blocker=review_blocker),
@@ -2184,9 +2185,12 @@ class AutoPipeline:
             return self._result(state, ledger, review=review, blocker=blocker), seed, review
 
         # Gates first, event second — see the module docstring for why.
-        review_blocker = self._seed_review_gate_blocker(state, review)
-        if review_blocker is not None:
-            state.mark_blocked(review_blocker, tool_name="grade_gate")
+        review_gate = seed_review_gate_blocker(
+            state, review, skip_run=self.skip_run or state.skip_run
+        )
+        if review_gate is not None:
+            review_blocker, review_code = review_gate
+            state.mark_blocked(review_blocker, tool_name="grade_gate", error_code=review_code)
             self._save(state)
             return stop(review_blocker)
         if self._enforce_deadline(state):
@@ -2286,21 +2290,6 @@ class AutoPipeline:
             qa_result=qa_result,
             attempt=attempt,
         )
-
-    def _seed_review_gate_blocker(
-        self, state: AutoPipelineState, review: SeedReview | None
-    ) -> str | None:
-        """Return the deterministic review blocker that must still gate Seed QA pass paths."""
-        if review is None:
-            return None
-        if not _grade_meets_required(review.grade_result.grade.value, state.required_grade):
-            return (
-                f"Seed grade {review.grade_result.grade.value} did not meet "
-                f"required grade {state.required_grade}"
-            )
-        if not review.may_run and not (self.skip_run or state.skip_run):
-            return "Seed review did not clear the Seed for execution"
-        return None
 
     def _can_redispatch_recovery_plan(plan: AutoRecoveryPlan) -> bool:
         """Return True when a persisted plan is safe to consume automatically."""
@@ -2769,13 +2758,6 @@ def _mark_unknown_run_handoff(
         status = state.run_handoff_status
     state.run_handoff_status = status
     state.run_handoff_guidance = unknown_handoff_guidance(status)
-
-
-def _grade_meets_required(actual: str | None, required: str) -> bool:
-    rank = {"A": 0, "B": 1, "C": 2}
-    if actual not in rank or required not in rank:
-        return False
-    return rank[actual] <= rank[required]
 
 
 def _accepts_keyword(func: Callable[..., Any], name: str) -> bool:

--- a/tests/unit/auto/test_pipeline_partial_product_terminal.py
+++ b/tests/unit/auto/test_pipeline_partial_product_terminal.py
@@ -25,6 +25,9 @@ from typing import Any
 
 import pytest
 
+from ouroboros.auto.grade_gate_terminals import (
+    DEGRADED_SEED_SAFETY_BLOCKERS_STOP_REASON_CODE,
+)
 from ouroboros.auto.grading import GradeGate
 from ouroboros.auto.ledger import (
     LedgerEntry,
@@ -344,6 +347,18 @@ async def test_degraded_seed_with_safety_blocker_still_terminates(tmp_path) -> N
     # The safety blocker terminates — we must NOT see a partial product
     # terminal here, even though the Seed is degraded.
     assert result.partial_product is False
+    # The terminal is machine-readable, not just prose: a consumer routing on
+    # ``stop_reason_code`` has to be able to tell this safety stop from the
+    # partial-product success terminal above, which carries ``None``. Dropping
+    # ``error_code=`` at the ``mark_blocked`` call site is a silent regression
+    # to ``None`` that every other assertion in this test survives.
+    assert result.stop_reason_code == DEGRADED_SEED_SAFETY_BLOCKERS_STOP_REASON_CODE
+    assert state.last_error_code == DEGRADED_SEED_SAFETY_BLOCKERS_STOP_REASON_CODE
+    assert result.blocker is not None
+    # And it survives the round trip: an operator resuming this session reads
+    # the persisted record, not the in-memory object the pipeline mutated.
+    reloaded = AutoStore(tmp_path).load(state.auto_session_id)
+    assert reloaded.last_error_code == DEGRADED_SEED_SAFETY_BLOCKERS_STOP_REASON_CODE
     # ``auto.product.partial_emitted`` MUST NOT be emitted when the pipeline
     # blocks on a safety marker.
     partial_events = [

--- a/tests/unit/auto/test_stop_reason_code.py
+++ b/tests/unit/auto/test_stop_reason_code.py
@@ -1,9 +1,11 @@
-"""Tests for canonical stop_reason_code on interview-layer blockers.
+"""Tests for canonical stop_reason_code on pipeline blockers.
 
-Covers the two interview-layer canonical codes surfaced via
-``AutoPipelineResult.stop_reason_code`` and ``AutoPipelineState.last_error_code``,
-plus a regression guard that blockers without a canonical code leave
-``stop_reason_code`` at ``None``.
+Covers the two interview-layer canonical codes and the two grade-gate codes
+surfaced via ``AutoPipelineResult.stop_reason_code`` and
+``AutoPipelineState.last_error_code``, plus a regression guard that blockers
+without a canonical code leave ``stop_reason_code`` at ``None`` -- the guard is
+what keeps "typed the terminals we meant to type" from drifting into "every
+blocker gets a code whether or not anyone chose one".
 """
 
 from __future__ import annotations
@@ -12,19 +14,44 @@ import asyncio
 
 import pytest
 
+from ouroboros.auto.adapters import EvaluateResult
+from ouroboros.auto.grading import GradeGate, GradeResult, SeedGrade
 from ouroboros.auto.interview_driver import (
     AutoInterviewDriver,
     FunctionInterviewBackend,
     InterviewTurn,
 )
+from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
 from ouroboros.auto.pipeline import AutoPipeline
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
 
 # test_interview_max_rounds_exhausted_sets_stop_reason_code relies on the
 # unsafe-context matcher firing (an unsafe goal blocks safe-default closure),
 # which is disabled by default under the freedom policy (empty production
 # bank); re-inject the historical bank. See tests/unit/auto/conftest.py.
 pytestmark = pytest.mark.usefixtures("_legacy_unsafe_bank")
+
+# The grade-gate codes are asserted as literals, not imported from
+# ``ouroboros.auto.grade_gate_terminals``. The import would be tidier and it is
+# the wrong call here: the module is new in this round, so at the reviewed
+# baseline it does not exist, and a module-level import of it turns the whole
+# file into a collection error there. A collection error is reported against the
+# file, not against any node, so every new case comes back *absent* rather than
+# failing -- and "these tests fail without the fix" becomes unprovable for the
+# entire file, including the cases that have nothing to do with the new module.
+#
+# The literals are also the better assertion. What this PR promises is a wire
+# value that consumers read; pinning the const would only prove the tests and
+# the pipeline agree about a name they both import, which they would still do
+# after someone renamed the value. If a const is retargeted, these fail.
 
 # ---------------------------------------------------------------------------
 # Shared stubs
@@ -224,3 +251,229 @@ def test_failed_transition_clears_stale_stop_reason_code(tmp_path) -> None:
 
     assert state.last_error == "seed generation crashed"
     assert state.last_error_code is None
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — grade-gate terminals carry canonical codes
+# ---------------------------------------------------------------------------
+
+
+def _ready_ledger(goal: str) -> SeedDraftLedger:
+    ledger = SeedDraftLedger.from_goal(goal)
+    for section, value in {
+        "actors": "Single local CLI user",
+        "inputs": "Command arguments",
+        "outputs": "Stable stdout and files",
+        "constraints": "Use existing project patterns",
+        "non_goals": "No cloud sync",
+        "acceptance_criteria": "Command prints stable output",
+        "verification_plan": "Run command-level tests",
+        "failure_modes": "Invalid input exits non-zero",
+        "runtime_context": "Existing repository runtime",
+    }.items():
+        source = (
+            LedgerSource.NON_GOAL if section == "non_goals" else LedgerSource.CONSERVATIVE_DEFAULT
+        )
+        ledger.add_entry(
+            section,
+            LedgerEntry(
+                key=f"{section}.test",
+                value=value,
+                source=source,
+                confidence=0.85,
+                status=LedgerStatus.DEFAULTED,
+            ),
+        )
+    return ledger
+
+
+def _cli_seed() -> Seed:
+    return Seed(
+        goal="Build a local CLI",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=("`habit list` prints stable stdout containing created habits",),
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(OntologyField(name="command", field_type="string", description="Command"),),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(name="testability", description="Observable behavior"),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.12),
+    )
+
+
+class _FixedGradeGate(GradeGate):
+    """Grade every Seed at a fixed grade / ``may_run``, ignoring its content."""
+
+    def __init__(self, grade: SeedGrade, *, may_run: bool) -> None:
+        self._grade = grade
+        self._may_run = may_run
+
+    def grade_seed(
+        self,
+        seed: Seed,  # noqa: ARG002
+        *,
+        ledger: SeedDraftLedger | None = None,  # noqa: ARG002
+        closure_mode: str | None = None,  # noqa: ARG002
+        degraded: bool | None = None,  # noqa: ARG002
+    ) -> GradeResult:
+        passing = self._grade is SeedGrade.A
+        return GradeResult(
+            grade=self._grade,
+            scores={
+                "coverage": 0.95 if passing else 0.5,
+                "ambiguity": 0.05 if passing else 0.5,
+                "testability": 0.95 if passing else 0.5,
+                "execution_feasibility": 0.95 if passing else 0.4,
+                "risk": 0.05 if passing else 0.4,
+            },
+            may_run=self._may_run,
+        )
+
+
+def _closed_interview_backend() -> FunctionInterviewBackend:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done", "interview_grade_gate", seed_ready=True, completed=True, ambiguity_score=0.12
+        )
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done", session_id, seed_ready=True, completed=True, ambiguity_score=0.12
+        )
+
+    return FunctionInterviewBackend(start, answer)
+
+
+async def _run_with_gate(tmp_path, gate: GradeGate, **kwargs):
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _cli_seed()
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = ""):  # noqa: ARG001
+        raise AssertionError("a grade-gated Seed must never reach the run starter")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.ledger = _ready_ledger(state.goal).to_dict()
+    store = AutoStore(tmp_path)
+    pipeline = AutoPipeline(
+        AutoInterviewDriver(_closed_interview_backend(), store=store, max_rounds=1),
+        generate_seed,
+        run_starter=run_seed,
+        store=store,
+        grade_gate=gate,
+        **kwargs,
+    )
+    return await pipeline.run(state), state
+
+
+@pytest.mark.asyncio
+async def test_grade_below_required_sets_canonical_stop_reason_code(tmp_path) -> None:
+    """A Seed graded below ``required_grade`` must stop with a typed code.
+
+    Without a code the only machine-readable signal is the English blocker
+    prose, which is what every consumer (``ooo auto`` printing ``-``, the MCP
+    envelope omitting ``stop_reason_code``, harness traces writing null) was
+    forced to parse to tell this terminal apart from the ``may_run`` one.
+    """
+    result, state = await _run_with_gate(tmp_path, _FixedGradeGate(SeedGrade.C, may_run=True))
+
+    assert result.status == "blocked"
+    assert result.blocker is not None
+    assert "did not meet required grade" in result.blocker
+    assert result.stop_reason_code == "seed_grade_below_required"
+    assert state.last_error_code == "seed_grade_below_required"
+
+
+@pytest.mark.asyncio
+async def test_review_withheld_run_sets_canonical_stop_reason_code(tmp_path) -> None:
+    """A passing grade whose review withholds ``may_run`` gets its own code.
+
+    Distinct from :data:`SEED_GRADE_BELOW_REQUIRED_STOP_REASON_CODE`: the Seed
+    cleared the grade bar, so "raise the grade" is the wrong next step.
+    """
+    result, state = await _run_with_gate(tmp_path, _FixedGradeGate(SeedGrade.A, may_run=False))
+
+    assert result.status == "blocked"
+    assert result.blocker == "Seed review did not clear the Seed for execution"
+    assert result.stop_reason_code == "seed_review_withheld_run"
+    assert state.last_error_code == "seed_review_withheld_run"
+
+
+class _WithholdAfterQaGate(GradeGate):
+    """Grade A, then withhold the run once ``withhold_run`` is set.
+
+    A gate with one fixed answer can never reach the post-QA review gate: the
+    REVIEW-phase gate at ``pipeline.py:1170`` asks the same question strictly
+    earlier and stops there. The second entry point only judges a review the
+    first one never saw -- the one produced by re-reviewing a QA-repaired Seed
+    -- so the gate has to be able to change its mind to reach it at all.
+    """
+
+    def __init__(self) -> None:
+        self.withhold_run = False
+
+    def grade_seed(
+        self,
+        seed: Seed,  # noqa: ARG002
+        *,
+        ledger: SeedDraftLedger | None = None,  # noqa: ARG002
+        closure_mode: str | None = None,  # noqa: ARG002
+        degraded: bool | None = None,  # noqa: ARG002
+    ) -> GradeResult:
+        return GradeResult(
+            grade=SeedGrade.A,
+            scores={
+                "coverage": 0.95,
+                "ambiguity": 0.05,
+                "testability": 0.95,
+                "execution_feasibility": 0.95,
+                "risk": 0.05,
+            },
+            may_run=not self.withhold_run,
+        )
+
+
+@pytest.mark.asyncio
+async def test_post_qa_review_gate_sets_canonical_stop_reason_code(tmp_path) -> None:
+    """The QA-repair path re-reviews the Seed; that terminal must be typed too.
+
+    ``seed_review_gate_blocker`` is the second entry point into the very same
+    two terminals, so it must not drop the classification the gate computed.
+    Reaching it takes a full repair round: QA fails, the Seed is repaired, the
+    repaired Seed is re-reviewed, and the post-QA gate judges *that* review.
+    """
+    gate = _WithholdAfterQaGate()
+    qa_calls: list[Seed] = []
+
+    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
+        qa_calls.append(seed)
+        if len(qa_calls) == 1:
+            # The repair this failure triggers yields a Seed the re-review
+            # still grades A but no longer clears for execution.
+            gate.withhold_run = True
+            return EvaluateResult(
+                passed=False,
+                score=0.41,
+                verdict="fail",
+                differences=("The Seed omits the review-blocking post-QA constraint",),
+            )
+        return EvaluateResult(passed=True, score=0.93, verdict="pass")
+
+    result, state = await _run_with_gate(tmp_path, gate, seed_qa_evaluator=seed_qa)
+
+    # Without this the test would pass on the REVIEW-phase terminal instead and
+    # assert nothing the preceding test does not already assert.
+    assert len(qa_calls) == 2, "the post-QA gate is only reachable after a repair round"
+    assert result.status == "blocked"
+    assert result.blocker == "Seed review did not clear the Seed for execution"
+    assert result.stop_reason_code == "seed_review_withheld_run"
+    assert state.last_error_code == "seed_review_withheld_run"


### PR DESCRIPTION
## Summary

The auto pipeline's grade gate is its most common BLOCKED outcome, and it was the last blocker family still leaving `stop_reason_code` at `None`. All 6 `mark_blocked(..., tool_name="grade_gate")` sites passed no `error_code`, so every consumer downstream — `ooo auto` (prints `-`), the MCP envelope (omits the key), harness traces (null), `attention_relay` (nothing to relay) — had to parse English prose to tell three different situations apart:

| prose the consumer had to read | what it actually means | right next step |
|---|---|---|
| "Seed grade C did not meet required grade B" | the grade bar was not cleared | raise the grade |
| "Seed review did not clear the Seed for execution" | the grade bar **was** cleared; the review withheld `may_run` | raising the grade is the wrong move |
| "Degraded seed retains hard safety blockers…" | a deadline-recovery Seed still carries safety markers | resolve the markers |

This is an internal inconsistency, not a missing feature: two lines below the untyped sites, the interview layer already emits `UNSTUCK_EXHAUSTED_STOP_REASON_CODE`, and the runtime emits `watchdog_wall_clock_exceeded` — both as module-level consts, precisely so "the alphabet of valid `stop_reason_code` values can be discovered by reading the module surface" (`interview_driver.py:170`). The grade gate simply never joined that convention.

Scope is deliberately one blocker family. 37 of the 51 `mark_blocked` call sites in `src/` were untyped; typing them all in one PR would be unreviewable. This types the 6 that share one gate and one meaning, leaving 31.

## Review boundary

- **User problem**: a consumer of `AutoPipelineResult` / the MCP envelope / a harness trace cannot machine-distinguish the three grade-gate terminals, because all three arrive as `stop_reason_code=None` plus free prose.
- **Inputs and execution conditions**: the REVIEW-phase grade gate and the post-QA grade gate in `AutoPipeline`, for both normal and `degraded` Seeds. No new I/O, no new external calls, no config surface.
- **Promised contract**: each of the three grade-gate terminals now sets a canonical `stop_reason_code` — `seed_grade_below_required`, `seed_review_withheld_run`, `degraded_seed_safety_blockers` — and the blocker prose is unchanged, so existing prose-reading consumers keep working. Blockers *without* a canonical code still leave `stop_reason_code` at `None` (regression-guarded).
- **Implementation boundary and owner**: `src/ouroboros/auto/`. The three consts and the two gate predicates live in a new module `grade_gate_terminals.py` rather than extending `pipeline.py`, which is a #1797 grandfathered module. No data or security boundary is crossed.
- **Non-goals**: the other 31 untyped `mark_blocked` sites; any change to which Seeds are blocked; any change to blocker wording; any new envelope field.
- **Evidence**: 3 new tests in `tests/unit/auto/test_stop_reason_code.py`, each asserting the exact code on a real pipeline run. Verified red against the unfixed pipeline (`assert None == 'seed_review_withheld_run'`), not merely as an import error. The post-QA case needs a gate that changes its mind: a fixed gate can never reach that terminal, because the REVIEW-phase gate asks the same question strictly earlier, so the test drives a real QA-fail → repair → re-review round and asserts the evaluator was entered twice. Each of the 6 `error_code=` sites was reverted individually and the suite re-run: 6/6 killed, none unpinned.

## Test plan

- [x] `pytest tests/unit/auto/test_stop_reason_code.py -q` — 8 passed
- [x] The 3 new cases fail against `origin/main`'s `pipeline.py` (3/3 at the baseline)
- [x] `pytest tests/unit/auto/test_pipeline_partial_product_terminal.py tests/unit/auto/test_pipeline_interview_deadline_closure.py tests/unit/auto/test_provenance_gate.py -q` — 34 passed (degraded-Seed path, which this PR refactors)
- [x] `ruff check` / `ruff format --check` / `mypy src/` clean
- [x] `scripts/check-module-size.py --baseline-ref origin/main` — OK; `pipeline.py` **shrinks** from 3348 to 3289 lines against a 3306 budget
- [x] `scripts/check-auto-boundary.py`, `check-max-turns-envelope.py` — clean

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Filled `N/A` deliberately, and stating why so the intent is auditable rather than skipped:

1. **No per-round work changes.** The diff replaces inline conditionals with calls to two pure predicates over already-computed values, and passes an already-known string to `mark_blocked`. It adds no loop, no I/O, no LLM call, and no allocation inside a round. The only reachable cost is one extra Python function call per grade-gate evaluation, which happens at most twice per run.
2. **The live R-run was not executed.** `OUROBOROS_RUN_CANONICAL=1 pytest tests/canonical/ -k cli-todo` is documented in `tests/canonical/README.md` as a maintainer-only manual path that "costs real LLM" budget, and `~/.ooo-observability/` holds no baseline on this machine. I did not spend maintainer LLM budget to measure a change that cannot move the number. If a maintainer wants the measurement anyway, say so and I will run it.

Budget compliance: [ ] within 1.5× / [ ] regression flagged with mitigation / [x] N/A (no per-round cost path changed; see reasoning above)

## Found while auditing this branch, and deliberately not fixed here

Nine adversarial lenses ran against this exact commit. The refactor itself came back
clean under a 674-combination equivalence sweep (grades `A/B/C/D/F/""/"a"/None` ×
`required_grade` × `may_run` × `skip_run` × 0/1/2 blockers, plus `review=None`,
transcribed from the removed `-` lines of this diff): zero divergences, zero
fail-opens, unknown grades still fail closed. The four findings below reproduce, and
none of them is mine — I checked that claim rather than taking the lenses' word for
it, by extracting each enclosing function from the AST at `origin/main` and at HEAD
and comparing whole bodies, which is immune to the line shifts this refactor causes.

1. **`pipeline.py:2729` — a pre-run judge's `passed` bit is the only evidence that
   "the product was verified."** `_has_verified_product_completion` returns `True` on
   `state.last_qa_passed`, whose only substantive writer is the Seed-*document* QA gate
   that runs strictly before dispatch. A judge envelope `{"passed": true, "score": 0.0,
   "verdict": "fail"}` therefore reports `artifact_state="complete_verified"` for a
   session where no run handle exists — short-circuiting the guard in `artifact_state.py`
   written to prevent exactly that. The existing regression at `test_surface.py:2664`
   pins the guard while hand-passing `product_verified=False`, a value the production
   path never produces, so it is vacuous. Function and writer line are both byte-identical
   across the two revisions. The fix changes what `complete_verified` means for every
   MCP caller and belongs in its own PR.

2. **`pipeline.py:1022` — the `grade_gate` resume branch trusts the file, not the
   artifact it ruled on.** `--resume` re-reads the Seed from `state.seed_path` with no
   provenance or integrity check and overwrites `state.seed_artifact`. One edit to
   `ambiguity_score` reverses a refusal-to-run terminal into `complete` **and dispatches
   the run**; `degraded: true` reverses it into a partial-product success. The control
   row re-blocks with the same typed code this PR adds, which is how the reversal is
   visible at all. `pipeline.py:120-128` asserts the opposite in prose — "editing the
   on-disk `state.seed_path` file therefore has no effect". Line 1022 is untouched by
   this diff and `_load_seed` is byte-identical; closing it means owning seed-artifact
   authority on resume, which is a boundary decision, not a silent in-PR expansion.

3. **`pipeline.py:3121` — the ambiguity recogniser's misses are permissive, not
   strict.** `_requests_seed_qa_ambiguity_repair` is the Seed-QA gate's only hard stop;
   everything else on a failed verdict is a deliberate advisory-continue. It matches
   exactly two clauses (`must not exceed`, `(must|should) not be greater than`) under
   `re.fullmatch`, so any other modal, any synonym of *exceed*, or a trailing clause
   falls through to the permissive branch. Byte-identical across revisions. The fix is
   to decide from `seed.metadata.ambiguity_score` rather than from English; merely
   relaxing the regex regresses the negatives pinned at `test_pipeline_lateral.py:254-260`.

4. **`pipeline.py:2096` — the ambiguity terminal is unreachable on the last attempt.**
   It is nested inside `if attempt < max_attempts`, so with `--max-repair-rounds 1`
   (reachable from both the CLI and the MCP argument) the loop runs once, `1 < 1` is
   false, and control falls to the `repair_budget_exhausted` advisory continue. This is
   the repo's known partial-gate-on-one-exit shape. `_run_seed_qa_gate` differs between
   the revisions *only* in how the review-gate blocker is constructed; the nesting is untouched.

Happy to open them as their own PRs — (3) and (4) together, (1) and (2) separately.

## One gap in this PR's own coverage, disclosed rather than buried

Mutation testing by the audit's `exits` lens deletes each added `error_code=` in turn.
Two of six are killed by the new tests; four survive:

```
KILLED   REVIEW grade/may_run gate
KILLED   post-QA review gate
SURVIVED REVIEW degraded-seed terminal      (pipeline.py:1165)
SURVIVED RUN re-entry grade gate            (pipeline.py:1253)
SURVIVED RUN re-entry may_run gate          (pipeline.py:1297)
SURVIVED QA-advisory review gate            (pipeline.py:2193)
```

The same lens confirms the other half of the claim: all three new tests are genuinely
red against `HEAD~1`, none is a passing shell. So the behaviour ships correct — this is
coverage, not a defect — but four of the codes this PR introduces are pinned by nothing,
and `grep -rn "degraded_seed_safety_blockers" tests/` returns empty repo-wide.

I am not widening the PR to close it. The degraded-seed and QA-advisory sites would take
one added assertion each on tests that already drive those lines, but the two RUN re-entry
sites need new tests that drive a RUN-phase resume, and that is a second change with its
own review surface. Stated here so the number is the maintainer's to weigh rather than a
silent assumption; say the word and it is a follow-up PR.

## Related issues

Refs #1157 — a typed terminal envelope is what lets `ooo auto` be driven without a human reading prose. Refs #1797 for the module-size constraint that put the new code in its own module.
