### PR TITLE
fix(mcp): stdin dead-peer probe no longer flips fd 0 non-blocking (socketpair stdin exit after initialize)

### DIFF
--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -587,15 +587,21 @@ def _make_stdin_peer_probe(stdin_fd: int = 0) -> Callable[[], bool] | None:
         with contextlib.suppress(OSError):
             os.close(wire_fd)
         return None
-    try:
-        wire.setblocking(False)
-    except OSError:
+    # Never setblocking(False) here: O_NONBLOCK lives on the open file
+    # description that the duplicate *shares* with fd 0, so flipping it on
+    # the dup also flips the wire the MCP SDK reads. A blocking readline on
+    # an idle socket then returns "" (EOF) and the server exits ~5 ms after
+    # `initialize` under every socketpair-stdin client — Node/libuv spawns,
+    # i.e. Claude Code (#2337). MSG_DONTWAIT makes only this peek
+    # non-blocking, per call, without touching shared descriptor state.
+    dontwait = getattr(socket, "MSG_DONTWAIT", None)
+    if dontwait is None:
         wire.close()
         return None
 
     def _peer_is_dead() -> bool:
         try:
-            data = wire.recv(1, socket.MSG_PEEK)
+            data = wire.recv(1, socket.MSG_PEEK | dontwait)
         except BlockingIOError:
             return False  # live peer, nothing queued
         except OSError:

--- a/tests/unit/cli/test_mcp_stdin_peer_probe.py
+++ b/tests/unit/cli/test_mcp_stdin_peer_probe.py
@@ -121,7 +121,8 @@ class TestMakeStdinPeerProbe:
             late_writer.start()
             assert reader.readline() == "second\n"
         finally:
-            late_writer.join()
+            if late_writer.is_alive():  # join() raises if start() was never reached
+                late_writer.join()
             os.close(private_fd)
             ours.close()
             theirs.close()

--- a/tests/unit/cli/test_mcp_stdin_peer_probe.py
+++ b/tests/unit/cli/test_mcp_stdin_peer_probe.py
@@ -75,6 +75,57 @@ class TestMakeStdinPeerProbe:
             os.close(devnull)
             ours.close()
 
+    def test_probe_leaves_shared_blocking_flag_untouched(self) -> None:
+        """Building the probe must not flip O_NONBLOCK on the wire (#2337).
+
+        The probe watches a dup of fd 0, and O_NONBLOCK lives on the open file
+        description the dup shares with the original. #2331 called
+        setblocking(False) on the dup, which made the MCP SDK's blocking
+        readline on an idle socketpair stdin return "" (EOF) — the server
+        exited ~5 ms after `initialize` under every Node/libuv client.
+        """
+        ours, theirs = socket.socketpair()
+        try:
+            assert os.get_blocking(ours.fileno()) is True
+            probe = mcp_module._make_stdin_peer_probe(ours.fileno())
+            assert probe is not None
+            assert os.get_blocking(ours.fileno()) is True
+            assert probe() is False
+            assert os.get_blocking(ours.fileno()) is True, "peeking must not mutate it either"
+        finally:
+            ours.close()
+            theirs.close()
+
+    def test_sdk_style_blocking_reader_survives_idle_peer(self) -> None:
+        """A blocking text reader on the same wire must not observe EOF while idle.
+
+        Mirrors the mcp>=2.0 stdio transport: a private dup of fd 0 wrapped in
+        a TextIOWrapper, read line by line. The first line is already queued
+        (like `initialize`); the second arrives only after the reader is
+        already blocked waiting for it (like `tools/list`). A wire left
+        non-blocking returns "" immediately instead — the #2337 exit.
+        """
+        import io
+        import threading
+
+        ours, theirs = socket.socketpair()
+        private_fd = os.dup(ours.fileno())
+        late_writer = threading.Timer(0.2, lambda: theirs.sendall(b"second\n"))
+        try:
+            probe = mcp_module._make_stdin_peer_probe(ours.fileno())
+            assert probe is not None
+            reader = io.TextIOWrapper(os.fdopen(private_fd, "rb", closefd=False), encoding="utf-8")
+            theirs.sendall(b"first\n")
+            assert reader.readline() == "first\n"
+            assert probe() is False
+            late_writer.start()
+            assert reader.readline() == "second\n"
+        finally:
+            late_writer.join()
+            os.close(private_fd)
+            ours.close()
+            theirs.close()
+
     def test_non_socket_stdin_returns_none(self, tmp_path) -> None:
         read_fd, write_fd = os.pipe()
         try:


### PR DESCRIPTION
## User problem
`ouroboros mcp serve` (0.53.0) answers `initialize` and exits ~5 ms later whenever its stdin is a UNIX socketpair — which is how every Node/libuv client (Claude Code included) wires child stdio. No tools ever load (`tools fetch failed — Connection closed`).

## Root cause
#2331 added a dead-peer probe that `dup`s fd 0 and calls `setblocking(False)` on the duplicate. `O_NONBLOCK` is a flag of the *open file description*, which the dup shares with fd 0, so the MCP SDK's blocking `readline` on the wire sees `""` (EOF) as soon as the socket is idle — right after the buffered `initialize` bytes are consumed. The SDK's reader loop ends, `serve_exit duration_ms=5`, orderly shutdown, no error logged. Pipes are unaffected because the probe returns early for non-sockets (`ENOTSOCK`), which is also why the reporter's FIFO+`O_NONBLOCK` experiment did not contradict this: it never reached the `setblocking` call.

## Fix
Peek with `MSG_PEEK | MSG_DONTWAIT`: the peek is non-blocking per call, and no shared descriptor state is ever mutated. Same `BlockingIOError → alive / OSError → dead / b"" → dead` semantics, so all existing probe and watchdog tests are unchanged. Platforms without `MSG_DONTWAIT` get no probe (Windows already returned `None`).

## Supported inputs / execution conditions
POSIX `mcp serve --transport stdio` with a socket, pipe, or tty stdin. No change to streamable-http, to the orphan watchdog policy, or to Windows.

## Observable contract / invariants
- Building or polling the probe never changes `os.get_blocking(0)`.
- A blocking reader on the wire waits for the next line instead of reading EOF while the peer is idle.
- Dead-peer detection (orderly close, ECONNRESET, fd-0 diversion) behaves exactly as before.

## Changed subsystem / owner
`src/ouroboros/cli/commands/mcp.py::_make_stdin_peer_probe` only. Owner: MCP serve lifecycle (same as #2331).

## Non-goals
No transport rewrite, no socket-aware stdin path in the SDK wrapper, no new lifecycle or config surface.

## Evidence
- Mechanism probe: `os.get_blocking(fd0)` flips `True → False` after `setblocking(False)` on a dup; `TextIOWrapper.readline()` then returns `''` on an idle socketpair.
- E2E with the reporter's repro script pointed at local source (`uv run --group mcp-test ouroboros mcp serve`, scratch `HOME`):
  - before: `stdin=socketpair initialize=ok exit=0 DIED` / `stdin=os.pipe alive tools=36`
  - after: `stdin=socketpair initialize=ok exit=None alive tools=36` / `stdin=os.pipe alive tools=36`
- RED→GREEN: the two new tests fail on `main` and pass on this branch; the 12 pre-existing probe/watchdog tests are unchanged and green.
- `ruff format` / `ruff check` clean; `mypy src/ouroboros` clean (632 files); `tests/unit/cli -k mcp`: 453 passed, 6 skipped.

Refs #2337

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7KkyzN4kpkpTRndZVbjQ7
