### PR TITLE
fix(workflow-ir): preserve semantic_ac_key through the criterion alias

### DIFF
--- a/src/ouroboros/cli/commands/workflow_ir.py
+++ b/src/ouroboros/cli/commands/workflow_ir.py
@@ -76,8 +76,12 @@ def _normalize_seed_payload(raw: dict[str, Any]) -> dict[str, Any]:
 
 def _normalize_criterion(item: Any) -> str | dict[str, Any]:
     if isinstance(item, dict):
+        # Hand the mapping through intact: Seed's own validator aliases
+        # ``criterion``/``content`` to ``description`` and keeps sibling keys
+        # such as ``semantic_ac_key``. Reducing to the bare string here threw
+        # the persisted AC identity away before Seed ever saw it (#2338).
         if isinstance(item.get("criterion"), str):
-            return item["criterion"]
+            return item
         if isinstance(item.get("description"), str) or isinstance(item.get("content"), str):
             return item
     if isinstance(item, str):

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -575,6 +575,42 @@ class TestWorkflowIRCommands:
         assert "Edges: 2" in result.output
         assert "Validation: ok" in result.output
 
+    def test_workflow_ir_inspect_preserves_criterion_semantic_ac_key(self, tmp_path: Path) -> None:
+        """A ``{criterion, semantic_ac_key}`` entry keeps its persisted identity (#2338).
+
+        The loader used to reduce such a mapping to the bare criterion string, so
+        Seed re-derived a fresh hash from the text and the explicit key was lost.
+        """
+        from ouroboros.cli.commands.workflow_ir import _load_seed
+
+        seed_file = tmp_path / "seed.yaml"
+        seed_file.write_text(
+            "\n".join(
+                [
+                    "goal: Inspect Workflow IR",
+                    "acceptance_criteria:",
+                    "  - criterion: A",
+                    "    semantic_ac_key: ac_a123456789abcdef",
+                    "ontology_schema:",
+                    "  name: Receipt",
+                    "  description: A reconciliation receipt",
+                    "  fields: []",
+                    "metadata:",
+                    "  seed_id: seed_cli_semantic_key",
+                    "  ambiguity_score: 0.1",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        loaded = _load_seed(seed_file)
+        result = runner.invoke(app, ["workflow-ir", "inspect", str(seed_file), "--json"])
+
+        assert loaded.acceptance_criteria[0].description == "A"
+        assert loaded.acceptance_criteria[0].semantic_ac_key == "ac_a123456789abcdef"
+        assert result.exit_code == 0
+        assert '"ok": true' in result.output
+
     def test_workflow_ir_inspect_rejects_blank_ac(self, tmp_path: Path) -> None:
         seed_file = tmp_path / "seed.yaml"
         seed_file.write_text(


### PR DESCRIPTION
## User problem
`workflow-ir inspect` (and anything using its `_load_seed`) silently replaced an explicit `semantic_ac_key` with a freshly derived hash whenever the AC entry was written as `{criterion: ..., semantic_ac_key: ...}`. The persisted AC identity was lost before Seed validation ever ran.

## Root cause
`_normalize_criterion` reduced a `criterion` mapping to its bare string, dropping every sibling key. Seed's own `_coerce_acceptance_criteria` already aliases `criterion`/`content` to `description` and keeps the rest, so the loader-side reduction was both redundant and lossy.

## Fix
Return the mapping intact for the `criterion` case. One line plus a comment. Behavioral nuance: an entry carrying both `criterion` and `description` now follows the Seed contract (`description` wins); the old reduction let `criterion` win.

## Scope of issue #2338 that this PR covers
- "Workflow IR normalization can reduce `{criterion, semantic_ac_key}` to a bare string" — **fixed here**, reproduced on `main` (`ac_a123456789abcdef` became `ac_66dc2887d574bf4f`).
- "Compatibility normalization can treat malformed all-hex keys as legacy labels and rehash them" — **not present on `main`**. That normalization only existed in closed #2283. On `main`, `ac_a123456789abcdef0` fails the strict `^ac_[a-f0-9]{16}$` pattern in both `Seed.from_dict` and `Seed.model_validate` (verified). No producer in this repository has ever emitted `metadata.version: 1.0.4` / `generation_mode: revised_after_qa` (`git log -S revised_after_qa` across all branches is empty; the version default is `1.0.0`), so no migration envelope is added.

Relationship to #2339: it contains the identical one-line loader change plus a v1.0.4 migration layer for the format above. This PR carries only the change that a supported input reproduces.

## Supported inputs / execution conditions
YAML/JSON Seed files loaded through `workflow-ir inspect`. No runtime, worker-role, or orchestration behavior changes.

## Observable contract / invariants
- Canonical `semantic_ac_key` values survive `{criterion, semantic_ac_key}` loading byte-for-byte.
- Malformed keys keep failing Seed's existing strict validation.
- Unrecognized entry shapes still raise the loader's descriptive `ValueError`.

## Changed subsystem / owner
`src/ouroboros/cli/commands/workflow_ir.py::_normalize_criterion` only. Owner: CLI Workflow IR loader.

## Non-goals
No compatibility/migration layer, no Seed model change, no ontology-description backfill.

## Evidence
- RED→GREEN: the new test fails on `main` (`'ac_66dc2887d574bf4f' == 'ac_a123456789abcdef'`) and passes here.
- `tests/unit/cli/test_main.py -k workflow_ir`: 4 passed.
- `ruff format` / `ruff check` clean; `mypy src/ouroboros` clean (632 files).

Refs #2338

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7KkyzN4kpkpTRndZVbjQ7
