### PR TITLE
fix(lateral): preserve decision fanout identity and research contract

### DIFF
--- a/src/ouroboros/mcp/tools/lateral_think_handler.py
+++ b/src/ouroboros/mcp/tools/lateral_think_handler.py
@@ -330,23 +330,30 @@ class LateralThinkHandler(BridgeAwareMixin):
                 # natural response documents alternative-thinking metadata.
                 # Expose persona_count + dispatch status at top level so callers
                 # can branch on delegation without parsing the envelope.
+                dispatch_record = stamp_decision_meta(
+                    {
+                        "status": "delegated_to_subagent",
+                        "dispatch_mode": "plugin",
+                        "persona_count": len(payloads),
+                    },
+                    mode,
+                )
+                stamp_lateral_persona_fanout(
+                    dispatch_record,
+                    self.fanout_registry,
+                    session_id=str(arguments.get("session_id") or ""),
+                    payloads=payloads,
+                )
                 record_subagent_dispatch_emitted(
                     fanout_kind="lateral_persona_panel",
                     payload_count=len(payloads),
                     dispatch_mode=dispatch,
                     worker_backend=self.agent_runtime_backend,
-                    fanout_reentry_available=False,
+                    fanout_reentry_available="fanout_id" in dispatch_record,
                 )
                 return build_multi_subagent_result(
                     payloads,
-                    response_shape=stamp_decision_meta(
-                        {
-                            "status": "delegated_to_subagent",
-                            "dispatch_mode": "plugin",
-                            "persona_count": len(payloads),
-                        },
-                        mode,
-                    ),
+                    response_shape=dispatch_record,
                 )
 
             # --- Inline/sequential fallback: concatenate persona prompts ---
@@ -595,6 +602,10 @@ class LateralThinkHandler(BridgeAwareMixin):
                 )
 
                 response_text += DECISION_INLINE_CONTRACT_TEXT
+            if research:
+                from ouroboros.mcp.tools.lateral_decision import build_lateral_research_block
+
+                response_text += build_lateral_research_block(True)
 
             single_meta = stamp_decision_meta(
                 {
@@ -604,6 +615,8 @@ class LateralThinkHandler(BridgeAwareMixin):
                 },
                 mode,
             )
+            if research:
+                single_meta["research"] = True
             return Result.ok(
                 MCPToolResult(
                     content=(MCPContentItem(type=ContentType.TEXT, text=response_text),),

--- a/tests/unit/mcp/tools/test_lateral_think_handler.py
+++ b/tests/unit/mcp/tools/test_lateral_think_handler.py
@@ -26,6 +26,7 @@ from ouroboros.mcp.host_context import (
     use_mcp_host_context,
 )
 from ouroboros.mcp.tools.evaluation_handlers import LateralThinkHandler
+from ouroboros.mcp.tools.fanout import FanoutRegistry
 from ouroboros.mcp.tools.subagent import (
     continue_interview_after_lateral_persona_synthesis,
     lateral_persona_panel_metadata_from_capability_definitions,
@@ -1192,6 +1193,45 @@ async def test_research_flag_adds_evidence_contract_to_payloads() -> None:
     assert all("do not fabricate sources" in prompt for prompt in prompts)
     contexts = [p["context"] for p in meta["payloads"]]
     assert all(ctx["mode"] == "decision" and ctx["research"] is True for ctx in contexts)
+
+
+@pytest.mark.asyncio
+async def test_plugin_decision_fanout_registers_reentry_id() -> None:
+    registry = FanoutRegistry()
+    handler = LateralThinkHandler(
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+        fanout_registry=registry,
+    )
+    result = await handler.handle(
+        {
+            "problem_context": "SQLite vs Postgres",
+            "current_approach": "undecided",
+            "mode": "decision",
+            "session_id": "session-1",
+        }
+    )
+    assert result.is_ok
+    assert result.unwrap().meta["fanout_id"].startswith("fanout_")
+    assert registry.load(result.unwrap().meta["fanout_id"]) is not None
+
+
+@pytest.mark.asyncio
+async def test_single_persona_research_carries_evidence_contract() -> None:
+    handler = LateralThinkHandler(agent_runtime_backend="subprocess")
+    result = await handler.handle(
+        {
+            "problem_context": "choose an auth library",
+            "current_approach": "undecided",
+            "persona": "researcher",
+            "mode": "decision",
+            "research": True,
+        }
+    )
+    assert result.is_ok
+    payload = result.unwrap()
+    assert "external_sources" in payload.content[0].text
+    assert payload.meta["research"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Refs #2336

## User problem
Decision-mode lateral results lost re-entry identity on the OpenCode plugin path, and `research=true` was omitted from single-persona inline responses.

## Promised contract
Plugin decision fan-outs register and return a `fanout_id` for later synthesis and decision recording. Single-persona deep-tier responses include the evidence contract and expose the research mode.

## Implementation boundary
`lateral_think_handler.py` and its unit tests. Existing unstuck behavior and the citation audit remain unchanged.

## Evidence
`uv run pytest -q tests/unit/mcp/tools/test_lateral_think_handler.py` and the lateral/verify target suite pass.
