### PR TITLE
chore(release): v0.54.0

### DIFF
--- a/.claude-plugin/.mcp.json
+++ b/.claude-plugin/.mcp.json
@@ -7,7 +7,7 @@
         "--python",
         ">=3.12",
         "--from",
-        "ouroboros-ai[mcp]==0.53.0",
+        "ouroboros-ai[mcp]==0.54.0",
         "ouroboros",
         "mcp",
         "serve",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "ouroboros",
       "description": "Sits in front of Claude Code and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "author": {
         "name": "Q00",
         "email": "jqyu.lee@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "Sits in front of Claude Code and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
   "author": {
     "name": "Q00",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "Sits in front of Codex CLI and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
   "author": {
     "name": "Q00",

--- a/.mcp.codex.json
+++ b/.mcp.codex.json
@@ -7,7 +7,7 @@
         "--python",
         ">=3.12",
         "--from",
-        "ouroboros-ai[mcp]==0.53.0",
+        "ouroboros-ai[mcp]==0.54.0",
         "ouroboros",
         "mcp",
         "serve",

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -296,7 +296,7 @@ A backup will be created: CLAUDE.md.bak
 **If "Preview first", show:**
 ````markdown
 <!-- ooo:START -->
-<!-- ooo:VERSION:0.53.0 -->
+<!-- ooo:VERSION:0.54.0 -->
 # Ouroboros — Specification-First AI Development
 
 > Before telling AI what to build, define what should be built.


### PR DESCRIPTION
## One user problem

Cut the v0.54.0 stable release. 0.53.0 is unusable from Claude Code and every other Node-based MCP client (#2337): the server exits ~5 ms after `initialize`. The fix (#2351) is on `main`; users pick it up automatically once a release is on PyPI because `.mcp.json` runs `uvx` unpinned.

## Why a minor bump

10 commits since `v0.53.0`, including two feature milestones: the OMP (Oh My Pi) runtime and LLM backend (#2299) and the grounded lateral decision advisory + interview-less seed, RFC P1–P4 (#2336). Versions are sized by narrative, not by commit count.

## Scope

Mechanical version sync only — `scripts/sync-plugin-version.py --write --version 0.54.0`:

- `.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`
- `.claude-plugin/.mcp.json`
- `.codex-plugin/plugin.json`
- `.mcp.codex.json`
- `skills/setup/SKILL.md`

No source, behavior, or dependency changes. `uv lock` was a no-op.

## Release content since v0.53.0

Fixed
- **mcp**: stdin dead-peer probe no longer flips fd 0 non-blocking; socketpair-stdin clients (Claude Code) no longer lose the server right after `initialize`. Regression from #2331 in 0.53.0. Remove the `cat |` workaround after upgrading. (#2351, refs #2337)
- **workflow-ir**: `{criterion, semantic_ac_key}` entries keep their persisted AC identity (#2352, refs #2338)
- **auto**: grade-gate `stop_reason_code` is typed instead of shipping `None` (#2341)
- **codex**: mid-run drift of frozen authority inputs is observed instead of failing the run (#2343); degrade when `renameat2` rejects `RENAME_NOREPLACE` (#2274)
- **run**: verify-gate mutations are attributed, run failure causes are named, concurrent codex trust writes are tolerated (#2342)

Added
- **runtime**: OMP (Oh My Pi) runtime and LLM backend (#2299)
- **lateral**: grounded decision advisory + interview-less seed, RFC P1–P4 (#2336)
- **auto**: ambiguity gate override rate is surfaced (#2286)

Chore
- `authoring_handlers.py` back under its module-size budget (#2345)

## Non-goals

Any functional change.

## Evidence

```
python3 scripts/sync-plugin-version.py --version 0.54.0   # OK on all six files, no drift
uv lock                                                   # no-op
```

Metadata-only diff; `ruff`, `mypy`, and `pytest` run in CI on this tree (the six required checks are the gate). Built in an isolated worktree because the primary checkout is in use by another session.

## After merge

```bash
git checkout main && git pull origin main --ff-only
git tag -a v0.54.0 -m "Release v0.54.0" && git push origin v0.54.0
```

Then prepend the curated notes to the CI-generated GitHub Release (`gh release edit v0.54.0 --notes-file`), and close #2337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7KkyzN4kpkpTRndZVbjQ7
