### PR TITLE
fix(lateral): retain plugin decision fanout identity

### DIFF
--- a/src/ouroboros/mcp/tools/lateral_think_handler.py
+++ b/src/ouroboros/mcp/tools/lateral_think_handler.py
@@ -330,23 +330,30 @@ class LateralThinkHandler(BridgeAwareMixin):
                 # natural response documents alternative-thinking metadata.
                 # Expose persona_count + dispatch status at top level so callers
                 # can branch on delegation without parsing the envelope.
+                dispatch_record = stamp_decision_meta(
+                    {
+                        "status": "delegated_to_subagent",
+                        "dispatch_mode": "plugin",
+                        "persona_count": len(payloads),
+                    },
+                    mode,
+                )
+                stamp_lateral_persona_fanout(
+                    dispatch_record,
+                    self.fanout_registry,
+                    session_id=str(arguments.get("session_id") or ""),
+                    payloads=payloads,
+                )
                 record_subagent_dispatch_emitted(
                     fanout_kind="lateral_persona_panel",
                     payload_count=len(payloads),
                     dispatch_mode=dispatch,
                     worker_backend=self.agent_runtime_backend,
-                    fanout_reentry_available=False,
+                    fanout_reentry_available="fanout_id" in dispatch_record,
                 )
                 return build_multi_subagent_result(
                     payloads,
-                    response_shape=stamp_decision_meta(
-                        {
-                            "status": "delegated_to_subagent",
-                            "dispatch_mode": "plugin",
-                            "persona_count": len(payloads),
-                        },
-                        mode,
-                    ),
+                    response_shape=dispatch_record,
                 )
 
             # --- Inline/sequential fallback: concatenate persona prompts ---

--- a/tests/unit/mcp/tools/test_lateral_think_handler.py
+++ b/tests/unit/mcp/tools/test_lateral_think_handler.py
@@ -26,6 +26,7 @@ from ouroboros.mcp.host_context import (
     use_mcp_host_context,
 )
 from ouroboros.mcp.tools.evaluation_handlers import LateralThinkHandler
+from ouroboros.mcp.tools.fanout import FanoutRegistry
 from ouroboros.mcp.tools.subagent import (
     continue_interview_after_lateral_persona_synthesis,
     lateral_persona_panel_metadata_from_capability_definitions,
@@ -1192,6 +1193,26 @@ async def test_research_flag_adds_evidence_contract_to_payloads() -> None:
     assert all("do not fabricate sources" in prompt for prompt in prompts)
     contexts = [p["context"] for p in meta["payloads"]]
     assert all(ctx["mode"] == "decision" and ctx["research"] is True for ctx in contexts)
+
+
+@pytest.mark.asyncio
+async def test_plugin_decision_fanout_registers_reentry_id() -> None:
+    registry = FanoutRegistry()
+    handler = LateralThinkHandler(
+        agent_runtime_backend="opencode", opencode_mode="plugin", fanout_registry=registry
+    )
+    result = await handler.handle(
+        {
+            "problem_context": "SQLite vs Postgres",
+            "current_approach": "undecided",
+            "mode": "decision",
+            "session_id": "session-1",
+        }
+    )
+    assert result.is_ok
+    fanout_id = result.unwrap().meta["fanout_id"]
+    assert fanout_id.startswith("fanout_")
+    assert registry.load(fanout_id) is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Refs #2336

## User problem
OpenCode plugin decision fan-outs had no durable re-entry identity, so their results could not be submitted for synthesis or used by the decision-record template.

## Promised contract
Plugin decision fan-outs register with the fanout registry and return a `fanout_id`, while preserving the existing subagent envelope.

## Implementation boundary
Lateral MCP handler and its regression test. Existing unstuck dispatch remains unchanged.

## Evidence
`uv run pytest -q tests/unit/mcp/tools/test_lateral_think_handler.py` passes.
