### PR TITLE
fix(lateral): preserve research contract for single persona

### DIFF
--- a/src/ouroboros/mcp/tools/lateral_think_handler.py
+++ b/src/ouroboros/mcp/tools/lateral_think_handler.py
@@ -595,6 +595,10 @@ class LateralThinkHandler(BridgeAwareMixin):
                 )
 
                 response_text += DECISION_INLINE_CONTRACT_TEXT
+            if research:
+                from ouroboros.mcp.tools.lateral_decision import build_lateral_research_block
+
+                response_text += build_lateral_research_block(True)
 
             single_meta = stamp_decision_meta(
                 {
@@ -604,6 +608,8 @@ class LateralThinkHandler(BridgeAwareMixin):
                 },
                 mode,
             )
+            if research:
+                single_meta["research"] = True
             return Result.ok(
                 MCPToolResult(
                     content=(MCPContentItem(type=ContentType.TEXT, text=response_text),),

--- a/tests/unit/mcp/tools/test_lateral_think_handler.py
+++ b/tests/unit/mcp/tools/test_lateral_think_handler.py
@@ -1195,6 +1195,24 @@ async def test_research_flag_adds_evidence_contract_to_payloads() -> None:
 
 
 @pytest.mark.asyncio
+async def test_single_persona_research_carries_evidence_contract() -> None:
+    handler = LateralThinkHandler(agent_runtime_backend="subprocess")
+    result = await handler.handle(
+        {
+            "problem_context": "choose an auth library",
+            "current_approach": "undecided",
+            "persona": "researcher",
+            "mode": "decision",
+            "research": True,
+        }
+    )
+    assert result.is_ok
+    payload = result.unwrap()
+    assert "external_sources" in payload.content[0].text
+    assert payload.meta["research"] is True
+
+
+@pytest.mark.asyncio
 async def test_decision_single_persona_inline_appends_convergence_contract() -> None:
     handler = LateralThinkHandler(agent_runtime_backend="subprocess")
 


### PR DESCRIPTION
Refs #2336

## User problem
`research=true` was honored for multi-persona payloads but disappeared on the single-persona inline path.

## Promised contract
Single-persona deep-tier responses include the same fetched-source evidence instructions and expose `research=true` in metadata; runtimes without web tools still degrade safely.

## Implementation boundary
Lateral MCP handler and its regression test. No change to default unstuck behavior.

## Evidence
`uv run pytest -q tests/unit/mcp/tools/test_lateral_think_handler.py` passes.
