### PR TITLE
fix(lateral): classify malformed citation URLs as invalid

### DIFF
--- a/src/ouroboros/mcp/tools/citation_check.py
+++ b/src/ouroboros/mcp/tools/citation_check.py
@@ -130,8 +130,12 @@ def audit_citations(
     deadline = time.monotonic() + total_budget_seconds
     checked = 0
     for url in urls:
-        parsed = urllib.parse.urlparse(url)
-        if parsed.scheme not in ("http", "https") or len(url) > _MAX_URL_LEN:
+        try:
+            parsed = urllib.parse.urlparse(url)
+            valid_url = parsed.scheme in ("http", "https") and bool(parsed.netloc)
+        except (TypeError, ValueError):
+            valid_url = False
+        if not valid_url or len(url) > _MAX_URL_LEN:
             verdicts[url] = INVALID
             continue
         if checked >= max_urls or time.monotonic() >= deadline:

--- a/tests/unit/mcp/tools/test_citation_check.py
+++ b/tests/unit/mcp/tools/test_citation_check.py
@@ -93,3 +93,12 @@ def test_fetcher_exception_degrades_to_unreachable() -> None:
     audit = audit_citations([_EVIDENCE], fetch=fetch)
     assert audit is not None
     assert set(audit["urls"].values()) == {UNREACHABLE}
+
+
+def test_malformed_url_is_invalid_and_does_not_raise() -> None:
+    audit = audit_citations(
+        ['```json\n{"external_sources": ["https://[invalid"]}\n```'],
+        fetch=lambda _url, _timeout: True,
+    )
+    assert audit is not None
+    assert audit["urls"]["https://[invalid"] == INVALID


### PR DESCRIPTION
Refs #2336

## User problem
Deep-tier lateral citation auditing could raise on malformed URLs instead of returning a withhold-only verdict.

## Promised contract
Malformed or non-http citation URLs are classified as `invalid`; citation auditing never raises and continues auditing other URLs.

## Implementation boundary
`src/ouroboros/mcp/tools/citation_check.py` and its unit tests.

## Evidence
`uv run pytest -q tests/unit/mcp/tools/test_citation_check.py` passes.
