### PR TITLE
test: share packaging fixtures and classify integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,13 @@ jobs:
           if [[ "${{ github.event_name }}" != "pull_request" && "${{ matrix.python-version }}" == "3.12" ]]; then
             COV_ARGS="--cov=src/ouroboros --cov-report=xml"
           fi
-          uv run --python "${{ matrix.python-version }}" --no-sync pytest tests/ -n 4 --dist worksteal --durations=25 -m "not performance" $COV_ARGS -q
+          MARKER_EXPR="not performance"
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # Artifact-building tests are covered on pushes; keep PR feedback
+            # focused on fast correctness checks.
+            MARKER_EXPR="not performance and not slow"
+          fi
+          uv run --python "${{ matrix.python-version }}" --no-sync pytest tests/ -n 4 --dist worksteal --durations=25 -m "$MARKER_EXPR" $COV_ARGS -q
 
       - name: Upload coverage artifact
         if: github.event_name != 'pull_request' && matrix.python-version == '3.12'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ def built_wheel(tmp_path_factory: pytest.TempPathFactory) -> Path:
     assert len(wheels) == 1, f"expected exactly one wheel, got {wheels}"
     return wheels[0]
 
+
 # In CI, GITHUB_ACTIONS env var causes Typer to set force_terminal=True on
 # Rich Console (see typer/rich_utils.py:75-78). This makes Rich emit ANSI
 # escape codes even into CliRunner's string buffer, inserting style sequences

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,40 @@ import inspect
 import os
 from pathlib import Path
 import shutil
+import subprocess
 import sys
 import tempfile
 
 import pytest
 import pytest_asyncio
+
+
+@pytest.fixture(scope="session")
+def built_wheel(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Build one wheel for packaging-contract tests that inspect its contents.
+
+    The wheel is an immutable artifact for the duration of a test session;
+    rebuilding it in each test only repeats a 20–30 second subprocess.
+    """
+    uv = shutil.which("uv")
+    if uv is None:
+        pytest.skip("uv not on PATH; wheel packaging tests require a build")
+    output = tmp_path_factory.mktemp("built-wheel")
+    project_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [uv, "build", "--wheel", "--out-dir", str(output)],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"uv build failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    wheels = list(output.glob("*.whl"))
+    assert len(wheels) == 1, f"expected exactly one wheel, got {wheels}"
+    return wheels[0]
 
 # In CI, GITHUB_ACTIONS env var causes Typer to set force_terminal=True on
 # Rich Console (see typer/rich_utils.py:75-78). This makes Rich emit ANSI

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 
 class FakeCLIStream:
     """Minimal async byte stream for subprocess stdout/stderr tests."""

--- a/tests/integration/plugin/test_wheel_packaging.py
+++ b/tests/integration/plugin/test_wheel_packaging.py
@@ -14,7 +14,6 @@ from email.parser import Parser
 import json
 import os
 from pathlib import Path
-import shutil
 import subprocess
 import sys
 import tomllib
@@ -41,11 +40,9 @@ def _extract_python_resolver(contents: str) -> str:
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(
-    shutil.which("uv") is None,
-    reason="uv not on PATH — wheel build cannot run in this environment.",
-)
-def test_built_wheel_preserves_packaging_contracts(tmp_path: Path) -> None:
+def test_built_wheel_preserves_packaging_contracts(
+    built_wheel: Path, tmp_path: Path
+) -> None:
     """Build the wheel and verify schema assets plus dependency markers.
 
     A future change that drops the `force-include` for
@@ -54,28 +51,13 @@ def test_built_wheel_preserves_packaging_contracts(tmp_path: Path) -> None:
     `vendored schema directory missing from installed package` for every
     `load_manifest()` call in production.
     """
-    out_dir = tmp_path / "dist"
-    result = subprocess.run(
-        ["uv", "build", "--wheel", "--out-dir", str(out_dir)],
-        cwd=PROJECT_ROOT,
-        capture_output=True,
-        text=True,
-        timeout=180,
-        check=False,
-    )
-    assert result.returncode == 0, (
-        f"`uv build --wheel` failed: stdout={result.stdout!r} stderr={result.stderr!r}"
-    )
-
-    wheels = list(out_dir.glob("*.whl"))
-    assert len(wheels) == 1, f"expected exactly one wheel, got {wheels}"
-
+    wheels = [built_wheel]
     expected = {
         f"ouroboros/plugin/schemas/{version}/{asset}"
         for version in SUPPORTED_SCHEMA_VERSIONS
         for asset in ("plugin.schema.json", "audit-event.schema.json")
     }
-    with zipfile.ZipFile(wheels[0]) as archive:
+    with zipfile.ZipFile(built_wheel) as archive:
         names = archive.namelist()
         present = [n for n in names if n.startswith("ouroboros/plugin/schemas/")]
         # Each schema asset must appear exactly once. Hatchling's
@@ -311,33 +293,13 @@ def test_built_wheel_preserves_packaging_contracts(tmp_path: Path) -> None:
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(
-    shutil.which("uv") is None,
-    reason="uv not on PATH — wheel build cannot run in this environment.",
-)
 def test_built_wheel_ships_builtin_interview_adapter_packs_once_and_loadable(
-    tmp_path: Path,
+    built_wheel: Path, tmp_path: Path,
 ) -> None:
-    out_dir = tmp_path / "dist"
-    result = subprocess.run(
-        ["uv", "build", "--wheel", "--out-dir", str(out_dir)],
-        cwd=PROJECT_ROOT,
-        capture_output=True,
-        text=True,
-        timeout=180,
-        check=False,
-    )
-    assert result.returncode == 0, (
-        f"`uv build --wheel` failed: stdout={result.stdout!r} stderr={result.stderr!r}"
-    )
-
-    wheels = list(out_dir.glob("*.whl"))
-    assert len(wheels) == 1, f"expected exactly one wheel, got {wheels}"
-
     expected = {
         f"ouroboros/interview_adapters/packs/{pack_name}" for pack_name in BUILTIN_GLOSSARY_PACKS
     }
-    with zipfile.ZipFile(wheels[0]) as archive:
+    with zipfile.ZipFile(built_wheel) as archive:
         names = archive.namelist()
         present = [n for n in names if n.startswith("ouroboros/interview_adapters/packs/")]
         for path in present:

--- a/tests/integration/plugin/test_wheel_packaging.py
+++ b/tests/integration/plugin/test_wheel_packaging.py
@@ -40,9 +40,7 @@ def _extract_python_resolver(contents: str) -> str:
 
 
 @pytest.mark.slow
-def test_built_wheel_preserves_packaging_contracts(
-    built_wheel: Path, tmp_path: Path
-) -> None:
+def test_built_wheel_preserves_packaging_contracts(built_wheel: Path, tmp_path: Path) -> None:
     """Build the wheel and verify schema assets plus dependency markers.
 
     A future change that drops the `force-include` for
@@ -294,7 +292,8 @@ def test_built_wheel_preserves_packaging_contracts(
 
 @pytest.mark.slow
 def test_built_wheel_ships_builtin_interview_adapter_packs_once_and_loadable(
-    built_wheel: Path, tmp_path: Path,
+    built_wheel: Path,
+    tmp_path: Path,
 ) -> None:
     expected = {
         f"ouroboros/interview_adapters/packs/{pack_name}" for pack_name in BUILTIN_GLOSSARY_PACKS

--- a/tests/unit/mcp/client/test_manager.py
+++ b/tests/unit/mcp/client/test_manager.py
@@ -40,10 +40,11 @@ class _ToolAdapter:
 class _SlowToolAdapter:
     def __init__(self):
         self.calls = 0
+        self.release = asyncio.Event()
 
     async def call_tool(self, _tool_name, _arguments=None):
         self.calls += 1
-        await asyncio.sleep(10)
+        await self.release.wait()
 
 
 class _ResourceAdapter:

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -4944,7 +4944,7 @@ async def test_server_shutdown_drains_runtime_control_bus() -> None:
 
     async def blocked(_event: BaseEvent) -> None:
         started.set()
-        await asyncio.sleep(60)
+        await asyncio.Event().wait()
 
     bus.subscribe(lambda _event: True, blocked)
     tasks = bus.publish(

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -4983,7 +4983,7 @@ async def test_server_shutdown_stops_before_dependents_when_control_bus_refuses_
     async def stubborn(_event: BaseEvent) -> None:
         started.set()
         try:
-            await asyncio.sleep(60)
+            await asyncio.Event().wait()
         except asyncio.CancelledError:
             await release.wait()
 

--- a/tests/unit/mcp/tools/test_ralph_handler.py
+++ b/tests/unit/mcp/tools/test_ralph_handler.py
@@ -58,12 +58,13 @@ class _BlockingEvolveHandler:
     """Fake evolve handler that blocks until the Ralph job is cancelled."""
 
     started: asyncio.Event = field(default_factory=asyncio.Event)
+    release: asyncio.Event = field(default_factory=asyncio.Event)
     calls: int = 0
 
     async def handle(self, arguments: dict[str, Any]):  # noqa: ARG002 - protocol fixture
         self.calls += 1
         self.started.set()
-        await asyncio.sleep(60)
+        await self.release.wait()
         return Result.ok(
             MCPToolResult(
                 content=(MCPContentItem(type=ContentType.TEXT, text="late"),),

--- a/tests/unit/orchestrator/test_control_bus.py
+++ b/tests/unit/orchestrator/test_control_bus.py
@@ -308,7 +308,7 @@ async def test_close_cancels_stragglers_after_timeout() -> None:
 
     async def blocked(event: BaseEvent) -> None:
         started.set()
-        await asyncio.sleep(60)
+        await asyncio.Event().wait()
 
     bus.subscribe(_is_directive, blocked)
     tasks = bus.publish(_directive_event())
@@ -330,7 +330,7 @@ async def test_close_does_not_hang_when_cancel_is_ignored() -> None:
     async def stubborn(event: BaseEvent) -> None:
         started.set()
         try:
-            await asyncio.sleep(60)
+            await asyncio.Event().wait()
         except asyncio.CancelledError:
             cancelled.set()
             await release.wait()
@@ -381,7 +381,7 @@ async def test_close_does_not_raise_when_cancelled_task_finishes_after_wait(
     async def exits_after_cancel(event: BaseEvent) -> None:
         started.set()
         try:
-            await asyncio.sleep(60)
+            await asyncio.Event().wait()
         except asyncio.CancelledError:
             await asyncio.sleep(0)
 

--- a/tests/unit/orchestrator/test_profile_loader.py
+++ b/tests/unit/orchestrator/test_profile_loader.py
@@ -349,6 +349,7 @@ class TestWheelPackaging:
 
     def test_wheel_contains_profile_yamls(self, built_wheel: Path) -> None:
         import zipfile
+
         with zipfile.ZipFile(built_wheel) as zf:
             # Keep the list — not a set — so duplicate ZIP entries (which
             # PyPI rejects) are caught here. The exclude/force-include

--- a/tests/unit/orchestrator/test_profile_loader.py
+++ b/tests/unit/orchestrator/test_profile_loader.py
@@ -347,36 +347,9 @@ class TestWheelPackaging:
     cannot spawn external builds).
     """
 
-    @pytest.mark.slow
-    def test_wheel_contains_profile_yamls(self, tmp_path: Path) -> None:
-        import shutil
-        import subprocess
+    def test_wheel_contains_profile_yamls(self, built_wheel: Path) -> None:
         import zipfile
-
-        if shutil.which("uv") is None:
-            pytest.skip("uv is not on PATH; cannot build the wheel here")
-
-        repo_root = Path(__file__).resolve().parents[3]
-        out = tmp_path / "dist"
-        result = subprocess.run(
-            ["uv", "build", "--wheel", "--out-dir", str(out)],
-            cwd=repo_root,
-            capture_output=True,
-            text=True,
-            timeout=120,
-            check=False,
-        )
-        # The whole point of this test is to catch packaging regressions —
-        # a non-zero build status is the regression signal, not a skip.
-        assert result.returncode == 0, (
-            f"uv build failed (rc={result.returncode}):\n"
-            f"stderr:\n{result.stderr}\nstdout:\n{result.stdout}"
-        )
-
-        wheels = list(out.glob("*.whl"))
-        assert wheels, f"no wheel produced in {out}"
-        wheel = wheels[0]
-        with zipfile.ZipFile(wheel) as zf:
+        with zipfile.ZipFile(built_wheel) as zf:
             # Keep the list — not a set — so duplicate ZIP entries (which
             # PyPI rejects) are caught here. The exclude/force-include
             # pairing in pyproject.toml is fragile; this is the guard.

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -55,27 +55,25 @@ class TestVerificationModels:
         with pytest.raises(Exception):
             a.ac_index = 1  # type: ignore[misc]
 
-    @pytest.mark.parametrize("invalid_index", [True, False, "0", "1", 0.0, 1.0, 1.5, -1])
-    def test_spec_assertion_requires_raw_non_negative_integer_index(
-        self,
-        invalid_index: object,
-    ) -> None:
-        with pytest.raises(ValidationError):
-            SpecAssertion.model_validate(
-                {
-                    "ac_index": invalid_index,
-                    "ac_text": "Create config",
-                    "tier": "t2_structural",
-                }
-            )
-
-    @pytest.mark.parametrize("invalid_index", [True, False, "0", "1", 0.0, 1.0, 1.5, -1])
+    @pytest.mark.parametrize(
+        ("model", "invalid_index"),
+        [
+            (SpecAssertion, invalid_index)
+            for invalid_index in (True, False, "0", "1", 0.0, 1.0, 1.5, -1)
+        ]
+        + [
+            (ACVerificationReport, invalid_index)
+            for invalid_index in (True, False, "0", "1", 0.0, 1.0, 1.5, -1)
+        ],
+        ids=lambda value: value.__name__ if isinstance(value, type) else repr(value),
+    )
     def test_ac_report_requires_raw_non_negative_integer_index(
         self,
+        model: type[SpecAssertion] | type[ACVerificationReport],
         invalid_index: object,
     ) -> None:
         with pytest.raises(ValidationError):
-            ACVerificationReport.model_validate(
+            model.model_validate(
                 {
                     "ac_index": invalid_index,
                     "ac_text": "Create config",


### PR DESCRIPTION
Refs #2336

## User problem
Packaging tests rebuilt the same wheel independently and the test suite did not classify integration tests consistently. PR checks also ran artifact-building `slow` tests by default.

## Promised contract
Packaging assertions inspect one session-scoped wheel artifact, preserving all existing checks while removing duplicate builds. Integration tests are explicitly marked, and PR checks skip only `slow` tests; pushes retain the full non-performance suite.

## Implementation boundary
Pytest fixtures and markers, wheel packaging/profile tests, and the test workflow. No production code or test assertions are removed.

## Evidence
- Packaging/profile target: 44 passed.
- `ruff check` clean.
- Collection with the PR expression: 22,146 selected / 8 slow tests deselected.
- The packaging target fell from 29.01s to 24.90s locally.
