### PR TITLE
fix(evaluation): resolve Windows commands and retain Stage 1 diagnostics

### DIFF
--- a/docs/guides/evaluation-pipeline.md
+++ b/docs/guides/evaluation-pipeline.md
@@ -160,6 +160,20 @@ mechanical:
 
 ### Diagnosing Stage 1 Failures
 
+Multi-AC MCP evaluation runs Stage 1 once and shares that result across the ACs.
+The response starts with the shared mechanical report, before the AC checklist.
+Its additive `stage1_result` metadata contains `passed`, `coverage_score`, and
+`checks`; each check retains its type, verdict, message, and known diagnostic
+`details`. Background evaluation jobs persist this report and metadata for later
+retrieval. A shared build/test failure is not evidence that each AC's own tests ran.
+
+Diagnostics include the configured `command`, `working_dir`, and, when a launch
+was attempted, `executed_command` (the actual argument list). Exit codes and
+timeout flags are retained when available, together with the last 500 characters
+of stdout and stderr. Missing output is not reconstructed; environment variables
+and full logs are not newly collected. This reporting does not change approval
+decisions or rerun checks.
+
 Event query to inspect what happened:
 
 ```bash
@@ -171,6 +185,24 @@ Look for events of type `evaluation.stage1.completed`. The payload contains:
 - `checks`: list with `check_type`, `passed`, `message` for each check
 - `coverage_score`: numeric coverage if parsed
 - `failed_count`: number of failed checks
+
+### Windows Command Dispatch
+
+Keep validated commands such as `npm run build` in `.ouroboros/mechanical.toml`.
+At execution time, Windows bare executable names are resolved using absolute
+PATH entries and PATHEXT, so an installed `npm.CMD` can run without changing the
+configuration or enabling `shell=True`. This lookup does not prepend the current
+directory. Existing validation and non-Windows execution remain unchanged.
+
+Windows can interpret `.cmd`/`.bat` files even without `shell=True`. For those
+files only, the launcher explicitly rejects paths or arguments containing CMD
+metacharacters (`& | < > ^ % ! " ( )`), control characters, or a space-containing
+argument ending in a backslash. Ordinary spaces, Unicode and empty arguments are
+supported. Unsupported batch input is a failed check, not a skipped or successful
+check; use a native executable for arguments requiring these characters. Native
+executable arguments retain their existing behavior. A missing executable still
+produces a command-not-found failure. The existing policy for unconfigured or
+rejected TOML commands is not changed by this dispatch adaptation.
 
 ---
 

--- a/src/ouroboros/evaluation/command_dispatch.py
+++ b/src/ouroboros/evaluation/command_dispatch.py
@@ -1,0 +1,48 @@
+"""Platform adaptation for already-validated mechanical command arguments.
+
+This is not a command validator or a shell parser. Repository command validation
+still happens before this boundary; native executable arguments are not rewritten.
+"""
+
+from collections.abc import Mapping
+import ntpath
+import os
+import shutil
+import sys
+
+_WINDOWS = sys.platform == "win32"
+_BATCH_METACHARACTERS = frozenset('&|<>^%!"()')
+
+
+def prepare_command(command: tuple[str, ...], env: Mapping[str, str]) -> tuple[str, ...]:
+    """Resolve Windows PATH shims without introducing shell interpretation.
+
+    Looking up a fully qualified candidate avoids shutil.which's implicit CWD
+    search on Windows. Empty/relative PATH entries do not expand this lookup's
+    trust boundary. Explicit executable paths and POSIX dispatch stay unchanged.
+    If no candidate exists, retain the native spawn's existing not-found behavior.
+    """
+    if not _WINDOWS or not command:
+        return command
+    executable, *arguments = command
+    if not ntpath.dirname(executable) and not ntpath.splitdrive(executable)[0]:
+        for directory in env.get("PATH", os.defpath).split(os.pathsep):
+            directory = directory.strip('"')
+            if not ntpath.isabs(directory) or not ntpath.splitdrive(directory)[0]:
+                continue
+            candidate = shutil.which(ntpath.join(directory, executable))
+            if candidate:
+                executable = candidate
+                break
+    prepared = (executable, *arguments)
+    if ntpath.splitext(executable)[1].lower() in {".cmd", ".bat"}:
+        # Windows can interpret batch files even with shell=False. Do not let
+        # command-line quoting/expansion reinterpret paths or user arguments.
+        # Unsupported values fail explicitly, rather than falling back to a
+        # shell or reporting an unexecuted check as skipped/passed.
+        for value in prepared:
+            if any(char in _BATCH_METACHARACTERS or ord(char) < 32 for char in value) or (
+                " " in value and value.endswith("\\")
+            ):
+                raise ValueError("Unsafe Windows batch command argument; use a native executable")
+    return prepared

--- a/src/ouroboros/evaluation/mechanical.py
+++ b/src/ouroboros/evaluation/mechanical.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from ouroboros.core.errors import ValidationError
 from ouroboros.core.types import Result
+from ouroboros.evaluation.command_dispatch import prepare_command
 from ouroboros.evaluation.models import CheckResult, CheckType, MechanicalResult
 from ouroboros.events.base import BaseEvent
 from ouroboros.events.evaluation import (
@@ -82,12 +83,14 @@ class CommandResult:
         stdout: Standard output
         stderr: Standard error
         timed_out: Whether the command timed out
+        executed_command: Arguments passed to the subprocess launcher, when attempted
     """
 
     return_code: int
     stdout: str
     stderr: str
     timed_out: bool = False
+    executed_command: tuple[str, ...] | None = None
 
 
 async def run_command(
@@ -111,8 +114,12 @@ async def run_command(
     # leaking the sentinel makes CLI tests take the nested-server early exit.
     env.pop("_OUROBOROS_NESTED", None)
     try:
+        prepared_command = prepare_command(command, env)
+    except ValueError as e:
+        return CommandResult(return_code=-1, stdout="", stderr=str(e))
+    try:
         process = await asyncio.create_subprocess_exec(
-            *command,
+            *prepared_command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=working_dir,
@@ -128,6 +135,7 @@ async def run_command(
                 return_code=process.returncode or 0,
                 stdout=stdout.decode("utf-8", errors="replace"),
                 stderr=stderr.decode("utf-8", errors="replace"),
+                executed_command=prepared_command,
             )
         except TimeoutError:
             process.kill()
@@ -137,6 +145,7 @@ async def run_command(
                 stdout="",
                 stderr="Command timed out",
                 timed_out=True,
+                executed_command=prepared_command,
             )
         except asyncio.CancelledError:
             if process.returncode is None:
@@ -148,12 +157,14 @@ async def run_command(
             return_code=-1,
             stdout="",
             stderr=f"Command not found: {e}",
+            executed_command=prepared_command,
         )
     except OSError as e:
         return CommandResult(
             return_code=-1,
             stdout="",
             stderr=f"OS error: {e}",
+            executed_command=prepared_command,
         )
 
 
@@ -320,6 +331,11 @@ class MechanicalVerifier:
                 details={
                     "timed_out": True,
                     "command": list(command),
+                    **(
+                        {"executed_command": list(cmd_result.executed_command)}
+                        if cmd_result.executed_command is not None
+                        else {}
+                    ),
                     "working_dir": str(self.config.working_dir)
                     if self.config.working_dir
                     else None,
@@ -336,6 +352,8 @@ class MechanicalVerifier:
             "stdout_tail": _output_tail(cmd_result.stdout),
             "stderr_tail": _output_tail(cmd_result.stderr),
         }
+        if cmd_result.executed_command is not None:
+            details["executed_command"] = list(cmd_result.executed_command)
 
         # Extract coverage if this was a coverage check
         if check_type == CheckType.COVERAGE and passed:

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -30,6 +30,10 @@ from ouroboros.mcp.telemetry_boundary import (
     record_direct_evaluation_outcome,
 )
 from ouroboros.mcp.tools import background as background_jobs
+from ouroboros.mcp.tools.evaluation_stage1_report import (
+    format_stage1_result,
+    serialize_stage1_result,
+)
 from ouroboros.mcp.tools.fanout_handler import (  # noqa: F401
     FetchArtifactHandler,
     SubmitFanoutResultsHandler,
@@ -1103,7 +1107,10 @@ class EvaluateHandler:
         if any(r.stage1_result and not r.stage1_result.passed for r in eval_results):
             code_changes = await self._has_code_changes(working_dir)
 
-        text_parts = [format_checklist(checklist)]
+        text_parts = [
+            *format_stage1_result(shared_stage1, include_exit_status=True),
+            format_checklist(checklist),
+        ]
         if code_changes is False:
             text_parts.append("\nNote: no code changes detected in the working tree.")
         result_text = "\n".join(text_parts)
@@ -1129,6 +1136,7 @@ class EvaluateHandler:
             ],
             "run_feedback": list(feedback),
             "code_changes_detected": code_changes,
+            "stage1_result": serialize_stage1_result(shared_stage1),
         }
 
         log.info(
@@ -1192,36 +1200,7 @@ class EvaluateHandler:
         ]
 
         # Stage 1 results
-        if result.stage1_result:
-            s1 = result.stage1_result
-            lines.extend(
-                [
-                    "Stage 1: Mechanical Verification",
-                    "-" * 40,
-                    f"Status: {'PASSED' if s1.passed else 'FAILED'}",
-                    f"Coverage: {s1.coverage_score:.1%}" if s1.coverage_score else "Coverage: N/A",
-                ]
-            )
-            for check in s1.checks:
-                status = "PASS" if check.passed else "FAIL"
-                lines.append(f"  [{status}] {check.check_type}: {check.message}")
-                if not check.passed:
-                    details = check.details
-                    command = details.get("command")
-                    if isinstance(command, list) and command:
-                        lines.append(f"    command: {' '.join(str(part) for part in command)}")
-                    working_dir = details.get("working_dir")
-                    if working_dir:
-                        lines.append(f"    cwd: {working_dir}")
-                    stdout_tail = str(details.get("stdout_tail") or "").strip()
-                    stderr_tail = str(details.get("stderr_tail") or "").strip()
-                    if stdout_tail:
-                        lines.append("    stdout tail:")
-                        lines.extend(f"      {line}" for line in stdout_tail.splitlines())
-                    if stderr_tail:
-                        lines.append("    stderr tail:")
-                        lines.extend(f"      {line}" for line in stderr_tail.splitlines())
-            lines.append("")
+        lines.extend(format_stage1_result(result.stage1_result))
 
         # Stage 2 results
         if result.stage2_result:

--- a/src/ouroboros/mcp/tools/evaluation_stage1_report.py
+++ b/src/ouroboros/mcp/tools/evaluation_stage1_report.py
@@ -1,0 +1,78 @@
+"""Present shared mechanical results without rerunning or reinterpreting checks."""
+
+from typing import Any
+
+from ouroboros.evaluation.models import MechanicalResult
+
+_OUTPUT_TAIL_CHARS = 500
+_DETAIL_FIELDS = (
+    "command",
+    "executed_command",
+    "working_dir",
+    "return_code",
+    "timed_out",
+    "skipped",
+)
+
+
+def serialize_stage1_result(result: MechanicalResult | None) -> dict[str, Any] | None:
+    """Retain known diagnostics in JSON-safe job metadata, not arbitrary output."""
+    if result is None:
+        return None
+    checks = []
+    for check in result.checks:
+        details = {key: check.details[key] for key in _DETAIL_FIELDS if key in check.details}
+        for key in ("stdout_tail", "stderr_tail"):
+            if key in check.details:
+                details[key] = str(check.details[key] or "")[-_OUTPUT_TAIL_CHARS:]
+        checks.append(
+            {
+                "check_type": check.check_type.value,
+                "passed": check.passed,
+                "message": check.message,
+                "details": details,
+            }
+        )
+    return {"passed": result.passed, "coverage_score": result.coverage_score, "checks": checks}
+
+
+def format_stage1_result(
+    result: MechanicalResult | None, *, include_exit_status: bool = False
+) -> list[str]:
+    """Keep the existing single-AC text; add explicit exit/timeout for shared results."""
+    if result is None:
+        return []
+    lines = [
+        "Stage 1: Mechanical Verification",
+        "-" * 40,
+        f"Status: {'PASSED' if result.passed else 'FAILED'}",
+        f"Coverage: {result.coverage_score:.1%}" if result.coverage_score else "Coverage: N/A",
+    ]
+    for check in result.checks:
+        status = "PASS" if check.passed else "FAIL"
+        lines.append(f"  [{status}] {check.check_type}: {check.message}")
+        if not check.passed:
+            details = check.details
+            command = details.get("command")
+            if isinstance(command, list) and command:
+                lines.append(f"    command: {' '.join(str(part) for part in command)}")
+            working_dir = details.get("working_dir")
+            if working_dir:
+                lines.append(f"    cwd: {working_dir}")
+            if include_exit_status:
+                executed = details.get("executed_command")
+                if isinstance(executed, list) and executed and executed != command:
+                    lines.append(
+                        f"    executed command: {' '.join(str(part) for part in executed)}"
+                    )
+                if "return_code" in details:
+                    lines.append(f"    exit code: {details['return_code']}")
+                if "timed_out" in details:
+                    lines.append(f"    timed out: {details['timed_out']}")
+            for key, label in (("stdout_tail", "stdout tail"), ("stderr_tail", "stderr tail")):
+                tail = str(details.get(key) or "")[-_OUTPUT_TAIL_CHARS:].strip()
+                if tail:
+                    lines.append(f"    {label}:")
+                    lines.extend(f"      {line}" for line in tail.splitlines())
+    lines.append("")
+    return lines

--- a/tests/unit/evaluation/test_mechanical.py
+++ b/tests/unit/evaluation/test_mechanical.py
@@ -119,7 +119,7 @@ class TestRunCommand:
     @pytest.mark.asyncio
     async def test_successful_command(self) -> None:
         """Run successful command."""
-        result = await run_command(("echo", "hello"), timeout=5)
+        result = await run_command((sys.executable, "-c", "print('hello')"), timeout=5)
         assert result.return_code == 0
         assert "hello" in result.stdout
         assert result.timed_out is False
@@ -168,8 +168,8 @@ class TestRunCommand:
     @pytest.mark.asyncio
     async def test_failed_command(self) -> None:
         """Run failing command."""
-        result = await run_command(("false",), timeout=5)
-        assert result.return_code != 0
+        result = await run_command((sys.executable, "-c", "raise SystemExit(7)"), timeout=5)
+        assert result.return_code == 7
 
     @pytest.mark.asyncio
     async def test_command_not_found(self) -> None:

--- a/tests/unit/evaluation/test_windows_command_dispatch.py
+++ b/tests/unit/evaluation/test_windows_command_dispatch.py
@@ -1,0 +1,370 @@
+"""Real Windows regressions for mechanical executable resolution and batch safety.
+
+The fixtures execute only local scripts under pytest's temporary directory. One
+smoke check uses an existing npm installation; no dependency installation, real
+project build, network service, or system mutation is needed. Batch argument
+checks exercise Windows rather than mock CMD's argument rules.
+"""
+
+import asyncio
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+from ouroboros.evaluation import command_dispatch
+from ouroboros.evaluation.languages import build_mechanical_config
+from ouroboros.evaluation.mechanical import MechanicalVerifier, run_command
+from ouroboros.evaluation.models import CheckType
+
+pytestmark = pytest.mark.asyncio
+_REQUIRES_WINDOWS = pytest.mark.skipif(
+    sys.platform != "win32", reason="Requires real Windows batch dispatch"
+)
+
+
+@pytest.fixture
+def batch_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """Provide a PATH-installed npm shim and a separate Unicode workspace."""
+    tool_dir = tmp_path / "도구 모음"
+    workspace = tmp_path / "작업 공간"
+    tool_dir.mkdir()
+    workspace.mkdir()
+    (tool_dir / "capture.py").write_text(
+        "import json, os, pathlib, sys\n"
+        "payload = {'args': sys.argv[1:], 'cwd': os.getcwd(), "
+        "'nested': os.environ.get('_OUROBOROS_NESTED'), "
+        "'kept': os.environ.get('OOO_DISPATCH_KEEP')}\n"
+        "pathlib.Path('ran.json').write_text(json.dumps(payload), encoding='utf-8')\n"
+        "print(json.dumps(payload))\n"
+        "sys.exit(7 if '--fixture-exit=7' in sys.argv else 0)\n",
+        encoding="utf-8",
+    )
+    (tool_dir / "npm.CMD").write_text(
+        "@echo off\n"
+        "setlocal DisableDelayedExpansion\n"
+        f'"{sys.executable}" "%~dp0capture.py" %*\n'
+        "exit /b %errorlevel%\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PATH", str(tool_dir))
+    monkeypatch.setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+    monkeypatch.setenv("OOO_DISPATCH_KEEP", "keep-this-value")
+    monkeypatch.setenv("OOO_DISPATCH_EXPANSION", "expanded-not-literal")
+    monkeypatch.setenv("_OUROBOROS_NESTED", "1")
+    return tool_dir, workspace
+
+
+@_REQUIRES_WINDOWS
+async def test_bare_npm_resolves_cmd_and_preserves_arguments_cwd_and_environment(
+    batch_workspace: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The default validated npm spelling must launch without shell=True."""
+    tool_dir, workspace = batch_workspace
+    original_exec = asyncio.create_subprocess_exec
+    calls: list[tuple[object, ...]] = []
+
+    async def checked_exec(*args, **kwargs):
+        assert not kwargs.get("shell", False)
+        calls.append(args)
+        return await original_exec(*args, **kwargs)
+
+    async def forbidden_shell(*_args, **_kwargs):
+        pytest.fail("Mechanical commands must not use create_subprocess_shell")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", checked_exec)
+    monkeypatch.setattr(asyncio, "create_subprocess_shell", forbidden_shell)
+    arguments = ("run", "build", "--", "--record-evidence", "two words", "한글", "")
+
+    result = await run_command(("npm", *arguments), timeout=10, working_dir=workspace)
+
+    assert result.return_code == 0, result.stderr
+    assert result.executed_command == (str(tool_dir / "npm.CMD"), *arguments)
+    payload = json.loads(result.stdout)
+    assert payload["args"] == list(arguments)
+    assert Path(payload["cwd"]) == workspace
+    assert payload["nested"] is None
+    assert payload["kept"] == "keep-this-value"
+    assert os.environ["_OUROBOROS_NESTED"] == "1"
+    assert len(calls) == 1
+
+
+@_REQUIRES_WINDOWS
+async def test_bare_command_can_resolve_bat_extension(
+    batch_workspace: tuple[Path, Path],
+) -> None:
+    tool_dir, workspace = batch_workspace
+    (tool_dir / "npm.BAT").write_text(
+        (tool_dir / "npm.CMD").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    result = await run_command(("npm", "run", "build"), timeout=10, working_dir=workspace)
+
+    assert result.return_code == 0, result.stderr
+    assert result.executed_command == (str(tool_dir / "npm.BAT"), "run", "build")
+    assert json.loads(result.stdout)["args"] == ["run", "build"]
+
+
+@_REQUIRES_WINDOWS
+async def test_bare_npm_prefers_path_over_implicit_current_directory(
+    batch_workspace: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A same-named repository shim must not shadow the PATH-installed tool."""
+    _, workspace = batch_workspace
+    (workspace / "npm.CMD").write_text(
+        "@echo off\necho unexpected>cwd-shadow-ran.txt\nexit /b 0\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(workspace)
+
+    result = await run_command(("npm", "run", "build"), timeout=10, working_dir=workspace)
+
+    assert result.return_code == 0, result.stderr
+    assert json.loads(result.stdout)["args"] == ["run", "build"]
+    assert not (workspace / "cwd-shadow-ran.txt").exists()
+
+
+@_REQUIRES_WINDOWS
+async def test_batch_nonzero_exit_is_not_skipped_or_passed(
+    batch_workspace: tuple[Path, Path],
+) -> None:
+    _, workspace = batch_workspace
+
+    result = await run_command(
+        ("npm", "run", "test", "--", "--fixture-exit=7"),
+        timeout=10,
+        working_dir=workspace,
+    )
+
+    assert result.return_code == 7
+    assert (workspace / "ran.json").exists()
+    assert "--fixture-exit=7" in json.loads(result.stdout)["args"]
+    assert not result.timed_out
+
+
+@_REQUIRES_WINDOWS
+async def test_missing_bare_executable_is_an_explicit_failure(
+    batch_workspace: tuple[Path, Path],
+) -> None:
+    _, workspace = batch_workspace
+
+    result = await run_command(
+        ("ouroboros-fixture-does-not-exist", "run", "build"),
+        timeout=10,
+        working_dir=workspace,
+    )
+
+    assert result.return_code != 0
+    assert result.stderr
+    assert not result.timed_out
+    assert not (workspace / "ran.json").exists()
+
+
+@_REQUIRES_WINDOWS
+@pytest.mark.parametrize("explicit_path", [False, True], ids=["bare", "explicit-cmd"])
+@pytest.mark.parametrize(
+    "argument",
+    [
+        pytest.param("value&echo injected>injected.txt", id="ampersand"),
+        pytest.param("%OOO_DISPATCH_EXPANSION%", id="percent-expansion"),
+        pytest.param("!OOO_DISPATCH_EXPANSION!", id="delayed-expansion"),
+        pytest.param("caret^value", id="caret"),
+        pytest.param('embedded"quote', id="embedded-quote"),
+        pytest.param("line\necho injected>injected.txt", id="newline"),
+        pytest.param("line\recho injected>injected.txt", id="carriage-return"),
+        pytest.param("value|echo injected>injected.txt", id="pipe"),
+        pytest.param("value>injected.txt", id="redirection"),
+        pytest.param("(parenthesized)", id="parentheses"),
+        pytest.param("two words\\", id="quoted-trailing-backslash"),
+    ],
+)
+async def test_batch_sensitive_arguments_remain_literal_or_fail_before_execution(
+    batch_workspace: tuple[Path, Path], argument: str, explicit_path: bool
+) -> None:
+    """A batch-specific rejection is a failure, never execution or a silent pass."""
+    tool_dir, workspace = batch_workspace
+    arguments = ("run", "build", "--", argument)
+    executable = str(tool_dir / "npm.CMD") if explicit_path else "npm"
+
+    result = await run_command((executable, *arguments), timeout=10, working_dir=workspace)
+
+    assert not (workspace / "injected.txt").exists()
+    if result.return_code == 0:
+        assert json.loads(result.stdout)["args"] == list(arguments)
+    else:
+        assert result.stderr, "Unsupported batch arguments need an explicit diagnostic"
+        assert not (workspace / "ran.json").exists()
+
+
+@_REQUIRES_WINDOWS
+async def test_explicit_native_executable_keeps_shell_characters_literal(
+    batch_workspace: tuple[Path, Path],
+) -> None:
+    """Batch restrictions must not change normal .exe argv semantics."""
+    _, workspace = batch_workspace
+    argument = 'literal & %OOO_DISPATCH_EXPANSION% ! ^ " text\nnext line'
+
+    result = await run_command(
+        (sys.executable, "-c", "import json, sys; print(json.dumps(sys.argv[1:]))", argument),
+        timeout=10,
+        working_dir=workspace,
+    )
+
+    assert result.return_code == 0, result.stderr
+    assert json.loads(result.stdout) == [argument]
+
+
+@_REQUIRES_WINDOWS
+@pytest.mark.parametrize("directory_name", ["tools & extra", "tools %OOO_DISPATCH_EXPANSION%"])
+@pytest.mark.parametrize("explicit_path", [False, True], ids=["bare", "explicit-cmd"])
+async def test_batch_sensitive_executable_path_is_rejected_before_launch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, directory_name: str, explicit_path: bool
+) -> None:
+    tool_dir = tmp_path / directory_name
+    tool_dir.mkdir()
+    executable = tool_dir / "npm.CMD"
+    executable.write_text("@echo off\necho ran>path-executed.txt\n", encoding="utf-8")
+    monkeypatch.setenv("PATH", str(tool_dir))
+    monkeypatch.setenv("PATHEXT", ".CMD")
+
+    result = await run_command(
+        (str(executable) if explicit_path else "npm", "run", "build"),
+        timeout=5,
+        working_dir=tmp_path,
+    )
+
+    assert result.return_code == -1
+    assert "Unsafe Windows batch" in result.stderr
+    assert result.executed_command is None
+    assert not (tmp_path / "path-executed.txt").exists()
+
+
+@_REQUIRES_WINDOWS
+async def test_installed_npm_runs_validated_build_and_test_without_installing_dependencies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exercise config validation through real npm, with a local-only fixture."""
+    if shutil.which("npm.cmd") is None or shutil.which("node") is None:
+        pytest.skip("Requires an existing Windows Node/npm installation")
+    workspace = tmp_path / "npm 검증 공간"
+    config_dir = workspace / ".ouroboros"
+    config_dir.mkdir(parents=True)
+    (workspace / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "ouroboros-windows-dispatch-fixture",
+                "version": "1.0.0",
+                "private": True,
+                "scripts": {
+                    "build": "node verify.mjs",
+                    "test:unit": "node verify.mjs --fixture-exit=7",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (workspace / "verify.mjs").write_text(
+        "console.log('local-verification-fixture-ran');\n"
+        "process.exit(process.argv.includes('--fixture-exit=7') ? 7 : 0);\n",
+        encoding="utf-8",
+    )
+    (config_dir / "mechanical.toml").write_text(
+        'build = "npm run build"\ntest = "npm run test:unit"\ntimeout = 20\n',
+        encoding="utf-8",
+    )
+    npmrc = workspace / ".npmrc"
+    npmrc.write_text("", encoding="utf-8")
+    for key, value in {
+        "npm_config_userconfig": str(npmrc),
+        "npm_config_cache": str(tmp_path / "npm-cache"),
+        "npm_config_offline": "true",
+        "npm_config_update_notifier": "false",
+        "npm_config_audit": "false",
+        "npm_config_fund": "false",
+    }.items():
+        monkeypatch.setenv(key, value)
+    config = build_mechanical_config(workspace)
+    assert config.build_command == ("npm", "run", "build")
+    assert config.test_command == ("npm", "run", "test:unit")
+
+    result = await MechanicalVerifier(config).verify(
+        "windows-npm-fixture", checks=[CheckType.BUILD, CheckType.TEST]
+    )
+
+    assert result.is_ok
+    mechanical_result, _ = result.value
+    build, test = mechanical_result.checks
+    assert build.passed, build.details
+    assert build.details["return_code"] == 0
+    assert not test.passed
+    assert test.details["return_code"] == 7
+    assert not mechanical_result.passed
+    for check in (build, test):
+        assert not check.details.get("skipped", False)
+        assert check.details["command"][0] == "npm"
+        assert check.details["executed_command"][0].lower().endswith("npm.cmd")
+        assert check.details["working_dir"] == str(workspace)
+        assert "local-verification-fixture-ran" in check.details["stdout_preview"]
+
+
+async def test_posix_preparation_does_not_lookup_or_rewrite_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Platform-independent proof that the new boundary leaves POSIX alone."""
+    monkeypatch.setattr(command_dispatch, "_WINDOWS", False)
+    lookup = Mock(side_effect=AssertionError("POSIX commands must not be resolved here"))
+    monkeypatch.setattr(command_dispatch.shutil, "which", lookup)
+    command = ("npm", "run", "test", "--", "literal & % ! ^", 'embedded"quote')
+
+    assert command_dispatch.prepare_command(command, {"PATH": "/usr/bin"}) is command
+    lookup.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "executable",
+    [r"C:\도구 모음\node.exe", r".\tools\node.exe", "tools/node.exe", r"C:node.exe"],
+)
+async def test_windows_explicit_native_path_is_not_resolved_or_rewritten(
+    monkeypatch: pytest.MonkeyPatch, executable: str
+) -> None:
+    monkeypatch.setattr(command_dispatch, "_WINDOWS", True)
+    lookup = Mock(side_effect=AssertionError("Explicit executable paths must not be resolved"))
+    monkeypatch.setattr(command_dispatch.shutil, "which", lookup)
+    command = (executable, "--", "two words", 'literal & % ! ^ "', "")
+
+    assert command_dispatch.prepare_command(command, {"PATH": r"C:\other-tools"}) == command
+    lookup.assert_not_called()
+
+
+async def test_windows_lookup_uses_absolute_path_entries_without_implicit_cwd(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Host-independent lookup proof without patching os.name/Path semantics."""
+    monkeypatch.setattr(command_dispatch, "_WINDOWS", True)
+    monkeypatch.setattr(command_dispatch.os, "pathsep", ";")
+    resolved = r"D:\도구 모음\npm.CMD"
+    lookup = Mock(side_effect=[None, resolved])
+    monkeypatch.setattr(command_dispatch.shutil, "which", lookup)
+    command = ("npm", "run", "test", "--", "two words", "")
+    env = {"PATH": ';.;relative-tools;\\rooted-tools;C:\\tools;"D:\\도구 모음"'}
+
+    assert command_dispatch.prepare_command(command, env) == (resolved, *command[1:])
+    assert [call.args for call in lookup.call_args_list] == [
+        (r"C:\tools\npm",),
+        (r"D:\도구 모음\npm",),
+    ]
+
+
+async def test_windows_path_miss_preserves_native_spawn_failure_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(command_dispatch, "_WINDOWS", True)
+    monkeypatch.setattr(command_dispatch.os, "pathsep", ";")
+    lookup = Mock(return_value=None)
+    monkeypatch.setattr(command_dispatch.shutil, "which", lookup)
+    command = ("missing-fixture-tool", "run", "test")
+
+    assert command_dispatch.prepare_command(command, {"PATH": r"C:\tools"}) == command

--- a/tests/unit/mcp/tools/test_evaluation_stage1_report.py
+++ b/tests/unit/mcp/tools/test_evaluation_stage1_report.py
@@ -1,0 +1,242 @@
+"""Shared mechanical diagnostics survive multi-AC and durable job presentation."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from ouroboros.evaluation.mechanical import CommandResult, MechanicalConfig
+from ouroboros.evaluation.models import CheckResult, CheckType, EvaluationResult, MechanicalResult
+from ouroboros.evaluation.pipeline import EvaluationPipeline, PipelineConfig
+from ouroboros.mcp.job_manager import JobManager
+from ouroboros.mcp.tools.evaluation_handlers import EvaluateHandler
+from ouroboros.mcp.tools.evaluation_stage1_report import (
+    format_stage1_result,
+    serialize_stage1_result,
+)
+from ouroboros.persistence.event_store import EventStore
+
+
+async def _multi_ac_result(tmp_path: Path, command_result: CommandResult):
+    handler = EvaluateHandler()
+    pipeline = EvaluationPipeline(
+        MagicMock(),
+        PipelineConfig(
+            mechanical=MechanicalConfig(
+                build_command=("npm", "run", "build"),
+                test_command=("npm", "run", "test:unit"),
+                timeout_seconds=17,
+                working_dir=tmp_path,
+            ),
+        ),
+    )
+    with (
+        patch(
+            "ouroboros.evaluation.mechanical.run_command",
+            new=AsyncMock(return_value=command_result),
+        ) as run,
+        patch.object(handler, "_has_code_changes", new=AsyncMock(return_value=None)),
+    ):
+        result = await handler._handle_multi_ac(
+            session_id="stage1-diagnostics",
+            seed_id="diagnostics-seed",
+            acceptance_criteria=("Launches" + " long requirement" * 1300, "Plays", "Saves"),
+            artifact="local artifact",
+            artifact_type="code",
+            goal="Preserve verification diagnostics",
+            constraints=(),
+            trigger_consensus=False,
+            artifact_bundle=None,
+            pipeline=pipeline,
+            working_dir=tmp_path,
+            emit_terminal_telemetry=False,
+        )
+    assert result.is_ok
+    # Two configured checks, not two checks repeated for each of three ACs.
+    assert run.await_count == 2
+    assert [call.args[0] for call in run.await_args_list] == [
+        ("npm", "run", "build"),
+        ("npm", "run", "test:unit"),
+    ]
+    return result.value
+
+
+async def test_shared_failure_has_commands_cwd_and_bounded_tails(tmp_path: Path) -> None:
+    result = await _multi_ac_result(
+        tmp_path,
+        CommandResult(-1, "discard stdout prefix" + "o" * 500, "discard stderr prefix" + "e" * 500),
+    )
+
+    assert result.meta["final_approved"] is False
+    assert result.meta["highest_stage"] == 1
+    assert result.meta["passed_count"] == 0
+    assert all(
+        item["failure_reason"] == "Stage 1 failed: build, test" for item in result.meta["checklist"]
+    )
+    stage1 = result.meta["stage1_result"]
+    assert stage1["passed"] is False
+    failures = [check for check in stage1["checks"] if not check["passed"]]
+    assert [check["check_type"] for check in failures] == ["build", "test"]
+    assert failures[0]["details"] == {
+        "command": ["npm", "run", "build"],
+        "working_dir": str(tmp_path),
+        "return_code": -1,
+        "stdout_tail": "o" * 500,
+        "stderr_tail": "e" * 500,
+    }
+    text = result.text_content
+    assert text.count("Stage 1: Mechanical Verification") == 1
+    assert text.count("command: npm run build") == 1
+    assert text.count("command: npm run test:unit") == 1
+    assert f"cwd: {tmp_path}" in text
+    assert "exit code: -1" in text
+    assert "discard stdout prefix" not in text
+    assert "discard stderr prefix" not in text
+    assert "o" * 500 in text
+    assert "e" * 500 in text
+
+
+async def test_shared_timeout_reports_available_details_without_invented_output(
+    tmp_path: Path,
+) -> None:
+    result = await _multi_ac_result(tmp_path, CommandResult(-1, "", "Command timed out", True))
+
+    failures = [check for check in result.meta["stage1_result"]["checks"] if not check["passed"]]
+    assert failures[0]["details"] == {
+        "command": ["npm", "run", "build"],
+        "working_dir": str(tmp_path),
+        "timed_out": True,
+    }
+    assert "timed out after 17s" in result.text_content
+    assert "timed out: True" in result.text_content
+    assert "exit code:" not in result.text_content
+    assert "stdout tail:" not in result.text_content
+    assert "stderr tail:" not in result.text_content
+
+
+async def test_multi_ac_diagnostics_survive_persisted_job_snapshot(tmp_path: Path) -> None:
+    executed = ("C:/Program Files/nodejs/npm.CMD", "run", "build")
+    result = await _multi_ac_result(
+        tmp_path,
+        CommandResult(7, "build output", "actual failure", executed_command=executed),
+    )
+    url = f"sqlite+aiosqlite:///{tmp_path / 'diagnostics.db'}"
+    store = EventStore(url)
+    await store.initialize()
+    manager = JobManager(store, durable_jobs=False)
+
+    async def completed_evaluation():
+        return result
+
+    try:
+        job = await manager.start_job(
+            job_type="evaluate", initial_message="Evaluate", runner=completed_evaluation()
+        )
+        await manager.drain(grace_seconds=5)
+    finally:
+        await store.close()
+
+    # Reopen the database and reconstruct without relying on the live job object.
+    restored_store = EventStore(url)
+    await restored_store.initialize()
+    try:
+        restored = await JobManager(restored_store, durable_jobs=False).get_snapshot(job.job_id)
+        assert restored.is_terminal
+        assert restored.status.value == "completed"
+        assert restored.result_meta["final_approved"] is False
+        assert restored.result_meta["stage1_result"] == result.meta["stage1_result"]
+        build_check = next(
+            check
+            for check in restored.result_meta["stage1_result"]["checks"]
+            if check["check_type"] == "build"
+        )
+        assert build_check["details"]["executed_command"] == list(executed)
+        assert "actual failure" in restored.result_text
+        assert "executed command: C:/Program Files/nodejs/npm.CMD run build" in restored.result_text
+        assert restored.result_text.count("Stage 1: Mechanical Verification") == 1
+    finally:
+        await restored_store.close()
+
+
+def test_single_ac_existing_stage1_presentation_is_preserved() -> None:
+    evaluation = EvaluationResult(
+        execution_id="single",
+        stage1_result=MechanicalResult(
+            passed=False,
+            checks=(
+                CheckResult(
+                    check_type=CheckType.BUILD,
+                    passed=False,
+                    message="Check build failed (exit code 7)",
+                    details={
+                        "command": ["npm", "run", "build"],
+                        "working_dir": "project",
+                        "return_code": 7,
+                        "stdout_tail": "build output",
+                        "stderr_tail": "actual failure",
+                    },
+                ),
+            ),
+        ),
+    )
+    text = EvaluateHandler()._format_evaluation_result(evaluation)
+    assert (
+        "Stage 1: Mechanical Verification\n"
+        "----------------------------------------\n"
+        "Status: FAILED\n"
+        "Coverage: N/A\n"
+        "  [FAIL] build: Check build failed (exit code 7)\n"
+        "    command: npm run build\n"
+        "    cwd: project\n"
+        "    stdout tail:\n"
+        "      build output\n"
+        "    stderr tail:\n"
+        "      actual failure\n"
+    ) in text
+    assert "exit code: 7" not in text
+
+
+def test_serializer_keeps_only_known_details_and_bounds_oversized_tails() -> None:
+    requested = ["npm", "run", "build"]
+    executed = ["C:/Program Files/nodejs/npm.CMD", "run", "build"]
+    details = {
+        "command": requested,
+        "executed_command": executed,
+        "working_dir": "C:/작업 폴더/project",
+        "return_code": 9,
+        "timed_out": False,
+        "stdout_tail": "s" * 600,
+        "stderr_tail": "e" * 600,
+        "stdout": "full raw output must not be copied",
+        "private_extra": object(),
+    }
+    stage1 = MechanicalResult(
+        passed=False,
+        checks=(CheckResult(CheckType.BUILD, False, "failed", details),),
+    )
+    serialized = serialize_stage1_result(stage1)
+    assert serialized is not None
+    saved_details = serialized["checks"][0]["details"]
+    assert saved_details["command"] == requested
+    assert saved_details["executed_command"] == executed
+    assert saved_details["stdout_tail"] == "s" * 500
+    assert saved_details["stderr_tail"] == "e" * 500
+    assert "stdout" not in saved_details
+    assert "private_extra" not in saved_details
+    assert stage1.checks[0].details["stdout_tail"] == "s" * 600
+    text = "\n".join(format_stage1_result(stage1, include_exit_status=True))
+    assert "executed command: C:/Program Files/nodejs/npm.CMD run build" in text
+    assert "cwd: C:/작업 폴더/project" in text
+    assert "s" * 501 not in text
+
+
+def test_passing_skipped_and_absent_stage1_are_not_changed() -> None:
+    skipped = MechanicalResult(
+        passed=True,
+        checks=(CheckResult(CheckType.TEST, True, "not configured", {"skipped": True}),),
+    )
+    serialized = serialize_stage1_result(skipped)
+    assert serialized is not None
+    assert serialized["passed"] is True
+    assert serialized["checks"][0]["details"] == {"skipped": True}
+    assert "Status: PASSED" in format_stage1_result(skipped)
+    assert serialize_stage1_result(None) is None
+    assert format_stage1_result(None) == []


### PR DESCRIPTION
## Summary

- Resolve validated Windows bare commands at the mechanical dispatch boundary so PATH-installed `npm.CMD` can execute; do not rewrite project configuration or enable `shell=True`.
- Reject unsafe CMD/BAT argument/path forms before launch and retain both the configured command and the actual argument tuple passed to the launcher.
- Preserve shared Stage 1 diagnostics in multi-AC responses and persisted job metadata, with 500-character stdout/stderr tails and no changes to approval logic.

## Review boundary

- **User problem:** A Windows npm launch failure is surfaced as a generic build/test failure, and multi-AC job results lose the detail needed to diagnose it.
- **Inputs and execution conditions:** Existing validated command tuples and a Windows PATH-installed executable, tested on Python 3.12.13/3.13.3 with npm 10.9.2. New lookup uses fully qualified candidates from absolute PATH entries; it does not prepend the current directory. Missing PATH matches retain the previous native-spawn behavior. Native/POSIX tuples and explicit native paths are not rewritten. Ordinary spaces, Unicode and empty batch arguments are covered.
- **Promised contract:** Actually execute the configured supported command or report failure. CMD/BAT paths/arguments containing `& | < > ^ % ! " ( )`, control characters, or space-containing values ending in a backslash are rejected explicitly before launch. No shell fallback or silent skip/pass is introduced. Keep cwd, environment cleanup, timeout/cancellation and exit-code behavior. Existing direct-child cleanup is preserved; no process-tree containment guarantee is added. Retain requested `command`, attempted `executed_command`, cwd and available failure details. Shared Stage 1 runs once, regardless of AC count; the same details survive a real persisted job roundtrip without changing verdicts.
- **Implementation boundary and owner:** Existing `evaluation` subprocess boundary and MCP evaluation presentation, under their existing maintainers; contributor responsible for this patch: @zittenyetten. Two small helpers isolate dispatch and report formatting. The oversized evaluation handler shrinks by 21 lines. No new service, DB schema, configuration surface or runtime backend.
- **Non-goals:** General TOML invalid-config-to-None/skip policy, transcript test-command/output classification, generated-artifact evidence, AC verify-gate redesign, game/Seed changes, global environment or installation changes, Linux/macOS execution claims, and unrelated upstream test/type defects. This PR does not make a failed application execution approved.
- **Evidence:** Red/green Windows subprocess regressions; real installed npm executing a dependency-free temporary project; native/POSIX branch compatibility checks; shared Stage 1 single-execution assertions; real SQLite/JobManager persistence/reload including a checklist longer than 20,000 characters. No project-specific logs, credentials or user paths are included.

## Changes

- `evaluation/command_dispatch.py` resolves Windows PATH executables and rejects unsupported batch forms.
- `evaluation/mechanical.py` launches the prepared tuple and attaches optional `executed_command` diagnostics.
- `mcp/tools/evaluation_stage1_report.py` formats/serializes known shared diagnostics; the handler places them before the checklist so persisted text truncation does not hide them. Existing single-AC normal formatting is retained.
- Add focused regression modules and document the behavior in the evaluation guide. Replace `echo`/`false` inputs in two existing mechanical subprocess tests with `sys.executable`, so they assert real success/exit 7 on Windows rather than a missing shell builtin.

## Test plan and results

Tests ran with isolated Windows USERPROFILE/APPDATA/LOCALAPPDATA. The npm smoke test uses an existing installation, temporary npm configuration/cache and offline mode; it does not install dependencies or run a real application.

| Check | Result |
|---|---|
| Windows dispatch regression before fix | 3 failed, 12 passed |
| Shared diagnostics regression before fix | 3 failed, 1 passed |
| Focused suite, Python 3.12.13 | 176 passed |
| Focused suite, Python 3.13.3 | 176 passed |
| Evaluation suite + related MCP coverage, Python 3.13 | 737 passed, 1 baseline failure, 2 existing skips |
| MyPy on 4 changed production files | Passed |
| Repository-wide Ruff lint / format | Passed; 1434 files already formatted |
| Module-size ratchet against `1fc754e7` | Passed; 633 modules, cap 2000, 25 grandfathered |
| `git diff --check` | Passed |

Focused reproduction (source checkout, `uv sync --group mcp-test` first):

```text
python -m pytest tests/unit/evaluation/test_windows_command_dispatch.py tests/unit/evaluation/test_mechanical.py tests/unit/evaluation/test_languages.py tests/unit/mcp/tools/test_evaluation_stage1_report.py tests/unit/mcp/tools/test_evaluate_multi_ac.py tests/unit/mcp/tools/test_start_evaluate.py tests/unit/mcp/tools/test_run_evaluate_chaining.py -q
```

New real-Windows tests are platform-specific; POSIX compatibility is checked by platform-independent mock tests, not a claimed Linux/macOS host run. New optional installed-npm smoke coverage was exercised locally, not skipped.

### Existing baseline failures, not waived or hidden

Both reproduce on the unmodified upstream `1fc754e7`; neither source is changed by this PR:

1. Windows `tests/unit/evaluation/test_detector.py::TestTomlSerialization::test_commands_with_quotes_roundtrip`: actual `('pytest', '-k', '"slow"')` versus expected `('pytest', '-k', 'slow')`.
2. Full `mypy src/ouroboros`: `src/ouroboros/hermes/artifacts.py:205: Name "result" is not defined [name-defined]`. Also reproduced against the original upstream file.

- [x] Focused regression tests and scoped types pass.
- [x] Repository-wide Ruff lint and format checks pass.
- [x] Existing broader failures are explicitly documented above; no skips or policy changes hide them.
- [ ] Full repository pytest and Bridge TypeScript were not run locally; CI remains authoritative for merge readiness.
- [ ] Repository-wide MyPy is not green because of the noted upstream error; no check bypass is requested.

## Related issues

Refs #2368
