### PR TITLE
fix(orchestrator): reject cyclic AC plans without dropping dependencies

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -282,6 +282,21 @@ independently-verifiable units.
 - `orchestrator/decomposition_params.py` - Profile-driven decomposition prompts (axis / `min_unit` / branching)
 - `orchestrator/runner.py` - Orchestration entry point and dependency analysis
 
+**Dependency planning:**
+
+For dependency-analyzed AC execution, the analyzer combines structured constraints
+with inferred edges and computes deterministic topological levels. A cycle in the
+resulting graph returns `Result.err(DependencyCycleError)`, including the blocked
+AC indices (which may also contain downstream dependents). The runner must not
+replace this error with an independent parallel plan: it records the planning
+failure through its existing session failure path before dispatching any workers.
+Direct planner callers receive the same `ExecutionPlanningError`-compatible error.
+
+Cycle detection does not add model calls or attempt automatic graph repair.
+Ordinary provider or response-parsing failures still use the existing structured
+fallback, which is checked for cycles too. Explicit sequential execution and
+reuse of a persisted resume plan retain their existing behavior.
+
 **Recursive Decomposition:**
 
 Each AC defaults to **atomic** execution. Preflight splitting is retired: a split

--- a/src/ouroboros/orchestrator/__init__.py
+++ b/src/ouroboros/orchestrator/__init__.py
@@ -60,6 +60,7 @@ try:
         ACSharedRuntimeResource,
         DependencyAnalysisError,
         DependencyAnalyzer,
+        DependencyCycleError,
         DependencyGraph,
         ExecutionPlanningError,
         ExecutionStage,
@@ -72,6 +73,7 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility for partial inst
     ACSharedRuntimeResource = None
     DependencyAnalysisError = None
     DependencyAnalyzer = None
+    DependencyCycleError = None
     DependencyGraph = None
     ExecutionPlanningError = None
     ExecutionStage = None
@@ -207,6 +209,7 @@ __all__ = [
     "ACSharedRuntimeResource",
     "DependencyAnalyzer",
     "DependencyAnalysisError",
+    "DependencyCycleError",
     "DependencyGraph",
     "ExecutionPlanningError",
     "ExecutionStage",

--- a/src/ouroboros/orchestrator/dependency_analyzer.py
+++ b/src/ouroboros/orchestrator/dependency_analyzer.py
@@ -399,17 +399,15 @@ class DependencyAnalyzer:
 
         log.info("dependency_analyzer.analysis.started", ac_count=count)
 
-        if count <= 1:
-            nodes = tuple(ACNode(index=spec.index, content=spec.content) for spec in specs)
-            levels = ((specs[0].index,),) if specs else ()
-            return Result.ok(DependencyGraph(nodes=nodes, execution_levels=levels))
+        if count == 0:
+            return Result.ok(DependencyGraph(nodes=(), execution_levels=()))
 
         structured_dependencies, serialization_reasons = self._analyze_structured_dependencies(
             specs
         )
 
         dependencies = {index: set(values) for index, values in structured_dependencies.items()}
-        if self._llm is not None:
+        if self._llm is not None and count > 1:
             try:
                 llm_dependencies = await self._analyze_with_llm(
                     tuple(spec.content for spec in specs)
@@ -476,7 +474,7 @@ class DependencyAnalyzer:
         for spec in specs:
             for raw_reference in spec.prerequisites:
                 resolved = self._resolve_reference(raw_reference, key_to_index, len(specs))
-                if resolved is None or resolved == spec.index:
+                if resolved is None:
                     continue
                 dependencies[spec.index].add(resolved)
                 reasons[spec.index].append(f"prerequisite AC {resolved + 1}")
@@ -485,7 +483,7 @@ class DependencyAnalyzer:
                 raw_value = spec.metadata.get(metadata_key)
                 for raw_reference in _coerce_reference_list(raw_value):
                     resolved = self._resolve_reference(raw_reference, key_to_index, len(specs))
-                    if resolved is None or resolved == spec.index:
+                    if resolved is None:
                         continue
                     dependencies[spec.index].add(resolved)
                     reasons[spec.index].append(f"metadata dependency on AC {resolved + 1}")
@@ -493,14 +491,14 @@ class DependencyAnalyzer:
             for context_name, context in _iter_dependency_contexts(spec):
                 for raw_reference in _collect_context_dependency_references(context):
                     resolved = self._resolve_reference(raw_reference, key_to_index, len(specs))
-                    if resolved is None or resolved == spec.index:
+                    if resolved is None:
                         continue
                     dependencies[spec.index].add(resolved)
                     reasons[spec.index].append(f"{context_name} dependency on AC {resolved + 1}")
 
                 for raw_reference in _collect_context_shared_prerequisites(context):
                     resolved = self._resolve_reference(raw_reference, key_to_index, len(specs))
-                    if resolved is None or resolved == spec.index:
+                    if resolved is None:
                         continue
                     dependencies[spec.index].add(resolved)
                     reasons[spec.index].append(
@@ -591,9 +589,7 @@ class DependencyAnalyzer:
             ac_index = item.get("ac_index", 0)
             raw_dependencies = item.get("depends_on", [])
             valid_dependencies = [
-                dep
-                for dep in raw_dependencies
-                if isinstance(dep, int) and 0 <= dep < len(criteria) and dep != ac_index
+                dep for dep in raw_dependencies if isinstance(dep, int) and 0 <= dep < len(criteria)
             ]
             dependencies[ac_index] = valid_dependencies
 

--- a/src/ouroboros/orchestrator/dependency_analyzer.py
+++ b/src/ouroboros/orchestrator/dependency_analyzer.py
@@ -231,6 +231,10 @@ class ExecutionPlanningError(Exception):
     """Raised when dependency analysis cannot produce safe execution stages."""
 
 
+class DependencyCycleError(DependencyAnalysisError, ExecutionPlanningError):
+    """A cyclic graph cannot be scheduled or replaced by an independent fallback."""
+
+
 DEPENDENCY_ANALYSIS_PROMPT = """Analyze the following acceptance criteria and determine their dependencies.
 
 Acceptance Criteria:
@@ -389,7 +393,7 @@ class DependencyAnalyzer:
         self,
         acceptance_criteria: Sequence[AcceptanceCriterionInput] | Sequence[ACDependencySpec],
     ) -> Result[DependencyGraph, DependencyAnalysisError]:
-        """Analyze AC dependencies and return a graph with execution levels."""
+        """Return execution levels, or a cycle error without discarding dependency edges."""
         specs = self._normalize_specs(acceptance_criteria)
         count = len(specs)
 
@@ -424,7 +428,10 @@ class DependencyAnalyzer:
             method = "structured_only"
 
         nodes = self._build_nodes(specs, dependencies, serialization_reasons)
-        levels = _apply_serial_only_constraints(_compute_execution_levels(nodes), nodes)
+        try:
+            levels = _apply_serial_only_constraints(_compute_execution_levels(nodes), nodes)
+        except DependencyCycleError as exc:
+            return Result.err(exc)
         graph = DependencyGraph(nodes=nodes, execution_levels=levels)
 
         log.info(
@@ -675,7 +682,9 @@ def _compute_execution_levels(
                 "dependency_analyzer.circular_dependency_detected",
                 remaining=sorted(remaining),
             )
-            ready = tuple(sorted(remaining))
+            raise DependencyCycleError(
+                f"Circular AC dependencies detected; blocked AC indices: {sorted(remaining)}"
+            )
 
         levels.append(ready)
         for node_index in ready:
@@ -894,6 +903,7 @@ __all__ = [
     "ACSharedRuntimeResource",
     "DependencyAnalysisError",
     "DependencyAnalyzer",
+    "DependencyCycleError",
     "DependencyGraph",
     "ExecutionPlanningError",
     "ExecutionStage",

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -10230,21 +10230,21 @@ class OrchestratorRunner:
 
             analyzer = self._build_dependency_analyzer()
             dep_result = await analyzer.analyze(seed.acceptance_criteria)
-
             if dep_result.is_err:
+                from ouroboros.orchestrator.dependency_analyzer import DependencyCycleError
+
+                if isinstance(dep_result.error, DependencyCycleError):
+                    raise dep_result.error
                 log.warning(
                     "orchestrator.runner.dependency_analysis_failed",
                     execution_id=exec_id,
                     error=str(dep_result.error),
                 )
                 # Fallback: run all ACs in a single parallel level
-                all_indices = tuple(range(len(seed.acceptance_criteria)))
+                acs = tuple(ACNode(i, ac_text(ac)) for i, ac in enumerate(seed.acceptance_criteria))
                 dependency_graph = DependencyGraph(
-                    nodes=tuple(
-                        ACNode(index=i, content=ac_text(ac), depends_on=())
-                        for i, ac in enumerate(seed.acceptance_criteria)
-                    ),
-                    execution_levels=(all_indices,) if all_indices else (),
+                    nodes=acs,
+                    execution_levels=(tuple(node.index for node in acs),) if acs else (),
                 )
             else:
                 dependency_graph = dep_result.value

--- a/tests/unit/orchestrator/test_dependency_analyzer.py
+++ b/tests/unit/orchestrator/test_dependency_analyzer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+import json
 from typing import Any
 
 import pytest
@@ -15,7 +16,9 @@ from ouroboros.orchestrator.dependency_analyzer import (
     ACDependencySpec,
     ACNode,
     ACSharedRuntimeResource,
+    DependencyAnalysisError,
     DependencyAnalyzer,
+    DependencyCycleError,
     DependencyGraph,
     ExecutionPlanningError,
     ExecutionStage,
@@ -36,6 +39,7 @@ class StubLLMAdapter:
     def __init__(self, content: str | None = None, error: ProviderError | None = None) -> None:
         self._content = content
         self._error = error
+        self.call_count = 0
 
     def frugality_prepare_completion(
         self,
@@ -67,6 +71,7 @@ class StubLLMAdapter:
     async def complete(
         self, messages: list[Any], config: Any
     ) -> Result[CompletionResponse, ProviderError]:
+        self.call_count += 1
         if self._error is not None:
             return Result.err(self._error)
 
@@ -400,6 +405,185 @@ class TestDependencyAnalyzer:
         graph = result.value
         assert graph.execution_levels == ((7,),)
         assert graph.to_runtime_execution_plan().execution_levels == ((7,),)
+
+
+class TestDependencyCycles:
+    """A cycle is an analysis failure, never an executable parallel batch."""
+
+    @pytest.mark.parametrize(
+        "provider_mode", ["none", "empty-response", "failure", "malformed-json"]
+    )
+    async def test_analyze_rejects_structured_cycles_including_provider_fallback(
+        self, provider_mode: str
+    ) -> None:
+        specs = (
+            ACDependencySpec(
+                index=0,
+                content="Criterion A",
+                metadata={"id": "a"},
+                prerequisites=("b",),
+            ),
+            ACDependencySpec(
+                index=1,
+                content="Criterion B",
+                metadata={"id": "b"},
+                prerequisites=("a",),
+            ),
+        )
+        adapter = (
+            None
+            if provider_mode == "none"
+            else StubLLMAdapter(
+                "{invalid json"
+                if provider_mode == "malformed-json"
+                else _empty_dependency_response(2),
+                error=(
+                    ProviderError("provider unavailable", provider="test")
+                    if provider_mode == "failure"
+                    else None
+                ),
+            )
+        )
+
+        result = await DependencyAnalyzer(adapter, model="test-model").analyze(specs)
+
+        assert result.is_err
+        assert isinstance(result.error, DependencyAnalysisError)
+        assert isinstance(result.error, ExecutionPlanningError)
+        assert isinstance(result.error, DependencyCycleError)
+        assert "blocked AC indices: [0, 1]" in str(result.error)
+        if adapter is not None:
+            assert adapter.call_count == 1
+
+    @pytest.mark.parametrize(
+        ("dependencies", "blocked_indices"),
+        [
+            pytest.param(((1,), (0,)), [0, 1], id="mutual-dependency"),
+            pytest.param(
+                ((4,), (0,), (1, 4), (0, 1, 4), (1, 2, 3)),
+                [0, 1, 2, 3, 4],
+                id="five-node-cycle",
+            ),
+            pytest.param(
+                ((), (2,), (1,), (2,)),
+                [1, 2, 3],
+                id="cycle-and-blocked-descendant-after-ready-prefix",
+            ),
+        ],
+    )
+    async def test_analyze_rejects_inferred_cycles_without_retrying(
+        self,
+        dependencies: tuple[tuple[int, ...], ...],
+        blocked_indices: list[int],
+    ) -> None:
+        adapter = StubLLMAdapter(
+            json.dumps(
+                {
+                    "dependencies": [
+                        {"ac_index": index, "depends_on": edges}
+                        for index, edges in enumerate(dependencies)
+                    ]
+                }
+            )
+        )
+        analyzer = DependencyAnalyzer(llm_adapter=adapter, model="test-model")
+
+        result = await analyzer.analyze(tuple(f"Criterion {i}" for i in range(len(dependencies))))
+
+        assert result.is_err
+        assert isinstance(result.error, DependencyAnalysisError)
+        assert isinstance(result.error, ExecutionPlanningError)
+        assert isinstance(result.error, DependencyCycleError)
+        assert str(result.error) == (
+            f"Circular AC dependencies detected; blocked AC indices: {blocked_indices}"
+        )
+        assert adapter.call_count == 1
+
+    async def test_analyze_rejects_cycle_created_by_merging_structured_and_inferred_edges(
+        self,
+    ) -> None:
+        specs = (
+            ACDependencySpec(index=0, content="Create foundation", metadata={"id": "base"}),
+            ACDependencySpec(index=1, content="Extend foundation", prerequisites=("base",)),
+        )
+        adapter = StubLLMAdapter(
+            '{"dependencies": [{"ac_index": 0, "depends_on": [1]}, '
+            '{"ac_index": 1, "depends_on": []}]}'
+        )
+
+        result = await DependencyAnalyzer(adapter, model="test-model").analyze(specs)
+
+        assert result.is_err
+        assert isinstance(result.error, DependencyAnalysisError)
+        assert isinstance(result.error, ExecutionPlanningError)
+        assert isinstance(result.error, DependencyCycleError)
+        assert "blocked AC indices: [0, 1]" in str(result.error)
+        assert adapter.call_count == 1
+        assert specs[1].prerequisites == ("base",)
+
+    async def test_analyze_preserves_valid_structured_and_inferred_edges(self) -> None:
+        specs = (
+            ACDependencySpec(index=0, content="Create foundation", metadata={"id": "base"}),
+            ACDependencySpec(index=1, content="Extend foundation", prerequisites=("base",)),
+            ACDependencySpec(index=2, content="Integrate extension"),
+        )
+        adapter = StubLLMAdapter(
+            '{"dependencies": [{"ac_index": 0, "depends_on": []}, '
+            '{"ac_index": 1, "depends_on": []}, {"ac_index": 2, "depends_on": [1]}]}'
+        )
+
+        result = await DependencyAnalyzer(adapter, model="test-model").analyze(specs)
+
+        assert result.is_ok
+        graph = result.value
+        assert graph.get_dependencies(0) == ()
+        assert graph.get_dependencies(1) == (0,)
+        assert graph.get_dependencies(2) == (1,)
+        assert graph.to_runtime_execution_plan().execution_levels == ((0,), (1,), (2,))
+        assert adapter.call_count == 1
+
+    @pytest.mark.parametrize("levels", [(), ((0, 1),), ((0,), (1,))])
+    def test_planner_rejects_cycles_with_missing_or_supplied_levels(
+        self, levels: tuple[tuple[int, ...], ...]
+    ) -> None:
+        graph = DependencyGraph(
+            nodes=(
+                ACNode(index=0, content="Criterion A", depends_on=(1,)),
+                ACNode(index=1, content="Criterion B", depends_on=(0,)),
+            ),
+            execution_levels=levels,
+        )
+
+        with pytest.raises(ExecutionPlanningError, match="Circular AC dependencies") as failure:
+            graph.to_runtime_execution_plan()
+
+        assert isinstance(failure.value, DependencyAnalysisError)
+        assert isinstance(failure.value, DependencyCycleError)
+        assert "blocked AC indices: [0, 1]" in str(failure.value)
+
+    def test_planner_rejects_normalized_single_node_self_loop(self) -> None:
+        graph = DependencyGraph(nodes=(ACNode(index=0, content="Criterion A", depends_on=(0,)),))
+
+        with pytest.raises(ExecutionPlanningError, match="Circular AC dependencies") as failure:
+            graph.to_execution_plan()
+
+        assert isinstance(failure.value, DependencyCycleError)
+        assert "blocked AC indices: [0]" in str(failure.value)
+
+    def test_planner_reports_blocked_sparse_indices_not_only_cycle_members(self) -> None:
+        graph = DependencyGraph(
+            nodes=(
+                ACNode(index=2, content="Independent criterion"),
+                ACNode(index=4, content="Criterion A", depends_on=(7,)),
+                ACNode(index=7, content="Criterion B", depends_on=(4,)),
+                ACNode(index=9, content="Blocked descendant", depends_on=(7,)),
+            )
+        )
+
+        with pytest.raises(ExecutionPlanningError, match="Circular AC dependencies") as failure:
+            graph.to_execution_plan()
+
+        assert "blocked AC indices: [4, 7, 9]" in str(failure.value)
 
 
 class TestHybridExecutionPlanner:

--- a/tests/unit/orchestrator/test_dependency_analyzer.py
+++ b/tests/unit/orchestrator/test_dependency_analyzer.py
@@ -521,6 +521,37 @@ class TestDependencyCycles:
         assert adapter.call_count == 1
         assert specs[1].prerequisites == ("base",)
 
+    async def test_analyze_rejects_structured_single_node_self_loop(self) -> None:
+        specs = (
+            ACDependencySpec(
+                index=0,
+                content="Criterion A",
+                metadata={"id": "a"},
+                prerequisites=("a",),
+            ),
+        )
+
+        result = await DependencyAnalyzer().analyze(specs)
+
+        assert result.is_err
+        assert isinstance(result.error, DependencyCycleError)
+        assert "blocked AC indices: [0]" in str(result.error)
+
+    async def test_analyze_rejects_inferred_single_node_self_loop(self) -> None:
+        adapter = StubLLMAdapter(
+            '{"dependencies": [{"ac_index": 0, "depends_on": [0]}, '
+            '{"ac_index": 1, "depends_on": []}]}'
+        )
+
+        result = await DependencyAnalyzer(adapter, model="test-model").analyze(
+            ("Criterion A", "Criterion B")
+        )
+
+        assert result.is_err
+        assert isinstance(result.error, DependencyCycleError)
+        assert "blocked AC indices: [0]" in str(result.error)
+        assert adapter.call_count == 1
+
     async def test_analyze_preserves_valid_structured_and_inferred_edges(self) -> None:
         specs = (
             ACDependencySpec(index=0, content="Create foundation", metadata={"id": "base"}),

--- a/tests/unit/orchestrator/test_runner_dependency_cycles.py
+++ b/tests/unit/orchestrator/test_runner_dependency_cycles.py
@@ -1,0 +1,188 @@
+"""Regression tests for dependency-cycle failures at the runner boundary."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+from ouroboros.core.types import Result
+from ouroboros.orchestrator.dependency_analyzer import DependencyAnalysisError, DependencyAnalyzer
+from ouroboros.orchestrator.parallel_executor import ACExecutionResult, ParallelExecutionResult
+from ouroboros.orchestrator.runner import OrchestratorRunner
+from ouroboros.orchestrator.session import SessionRepository, SessionStatus
+from ouroboros.persistence.event_store import EventStore
+from ouroboros.providers.base import CompletionResponse, UsageInfo
+
+
+@pytest.fixture
+def seed() -> Seed:
+    return Seed(
+        goal="Build two cooperating components",
+        acceptance_criteria=("Build component A", "Build component B"),
+        ontology_schema=OntologySchema(name="Components", description="Two components"),
+        metadata=SeedMetadata(),
+    )
+
+
+@pytest.fixture
+def adapter(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setenv("OUROBOROS_MODEL_TIER_ROUTING", "0")
+    runtime = MagicMock()
+    runtime.runtime_backend = "opencode"
+    runtime.llm_backend = "test-llm"
+    runtime._model = "test-model"
+    runtime.working_directory = str(tmp_path)
+    runtime.permission_mode = "acceptEdits"
+    runtime.aclose = AsyncMock()
+    return runtime
+
+
+@pytest.mark.asyncio
+async def test_execute_seed_cycle_persists_failure_without_dispatch(
+    seed: Seed, adapter: MagicMock, tmp_path: Path
+) -> None:
+    """Real analysis and runner setup reject a cycle before publishing a plan."""
+    database_url = f"sqlite+aiosqlite:///{tmp_path / 'cycle.db'}"
+    store = EventStore(database_url)
+    await store.initialize()
+    runner = OrchestratorRunner(adapter, store, MagicMock(), enable_decomposition=False)
+    analyzer = DependencyAnalyzer(llm_adapter=MagicMock(), model="test-model")
+    completion = AsyncMock(
+        return_value=Result.ok(
+            CompletionResponse(
+                content=json.dumps(
+                    {
+                        "dependencies": [
+                            {"ac_index": 0, "depends_on": [1]},
+                            {"ac_index": 1, "depends_on": [0]},
+                        ]
+                    }
+                ),
+                model="test-model",
+                usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            )
+        )
+    )
+    try:
+        with (
+            patch.object(runner, "_build_dependency_analyzer", return_value=analyzer),
+            patch("ouroboros.orchestrator.dependency_analyzer.tracked_complete", completion),
+            patch("ouroboros.orchestrator.parallel_executor.ParallelACExecutor") as executor,
+        ):
+            result = await runner.execute_seed(
+                seed, execution_id="execution-dependencies", session_id="session-dependencies"
+            )
+
+        assert result.is_err
+        executor.assert_not_called()
+        adapter.execute_task.assert_not_called()
+        assert "Circular AC dependencies" in result.error.message
+        completion.assert_awaited_once()
+        adapter.aclose.assert_awaited_once()
+    finally:
+        await store.close()
+
+    # Reopen the database so the assertions prove durable state, not a mock or cache.
+    persisted_store = EventStore(database_url)
+    await persisted_store.initialize()
+    try:
+        reconstructed = await SessionRepository(persisted_store).reconstruct_session(
+            "session-dependencies"
+        )
+        assert reconstructed.is_ok
+        assert reconstructed.value.status is SessionStatus.FAILED
+        failures = await persisted_store.query_events(
+            aggregate_id="session-dependencies", event_type="orchestrator.session.failed"
+        )
+        assert len(failures) == 1
+        assert failures[0].data["error_type"] == "DependencyCycleError"
+        assert "Circular AC dependencies" in failures[0].data["error"]
+        plans = await persisted_store.query_events(
+            aggregate_id="execution-dependencies", event_type="execution.plan.created"
+        )
+        assert plans == []
+    finally:
+        await persisted_store.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("generic_error", [False, True], ids=["acyclic", "ordinary-analysis-error"])
+async def test_execute_seed_preserves_noncycle_planning(
+    seed: Seed, adapter: MagicMock, tmp_path: Path, generic_error: bool
+) -> None:
+    """A DAG keeps its edges; an ordinary analysis error keeps the legacy fallback."""
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'noncycle.db'}")
+    await store.initialize()
+    runner = OrchestratorRunner(adapter, store, MagicMock(), enable_decomposition=False)
+    completion = AsyncMock(
+        return_value=Result.ok(
+            CompletionResponse(
+                content=json.dumps(
+                    {
+                        "dependencies": [
+                            {"ac_index": 0, "depends_on": []},
+                            {"ac_index": 1, "depends_on": [0]},
+                        ]
+                    }
+                ),
+                model="test-model",
+                usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            )
+        )
+    )
+    analyzer = DependencyAnalyzer(llm_adapter=MagicMock(), model="test-model")
+    if generic_error:
+        analyzer.analyze = AsyncMock(
+            return_value=Result.err(DependencyAnalysisError("unavailable"))
+        )
+    parallel_result = ParallelExecutionResult(
+        results=tuple(
+            ACExecutionResult(
+                ac_index=index, ac_content=criterion, success=True, final_message="done"
+            )
+            for index, criterion in enumerate(seed.acceptance_criteria)
+        ),
+        success_count=2,
+        failure_count=0,
+        total_messages=2,
+    )
+    dispatch = AsyncMock(return_value=parallel_result)
+    try:
+        with (
+            patch.object(runner, "_build_dependency_analyzer", return_value=analyzer),
+            patch("ouroboros.orchestrator.dependency_analyzer.tracked_complete", completion),
+            patch(
+                "ouroboros.orchestrator.parallel_executor.ParallelACExecutor.execute_parallel",
+                dispatch,
+            ),
+        ):
+            result = await runner.execute_seed(
+                seed, execution_id="execution-noncycle", session_id="session-noncycle"
+            )
+
+        assert result.is_ok, result.error if result.is_err else None
+        assert result.value.success
+        dispatch.assert_awaited_once()
+        execution_plan = dispatch.await_args.kwargs["execution_plan"]
+        expected_levels = ((0, 1),) if generic_error else ((0,), (1,))
+        assert execution_plan.execution_levels == expected_levels
+        assert execution_plan.get_dependencies(0) == ()
+        assert execution_plan.get_dependencies(1) == (() if generic_error else (0,))
+        if generic_error:
+            completion.assert_not_awaited()
+        else:
+            completion.assert_awaited_once()
+        persisted = await runner._session_repo.reconstruct_session("session-noncycle")
+        assert persisted.is_ok
+        assert persisted.value.status is SessionStatus.COMPLETED
+        plans = await store.query_events(
+            aggregate_id="execution-noncycle", event_type="execution.plan.created"
+        )
+        assert len(plans) == 1
+    finally:
+        await store.close()


### PR DESCRIPTION
## Summary

The analyzer currently returns successful but invalid execution levels for cyclic dependencies. Return a clear typed analysis failure and ensure the runner cannot turn this new error into its generic independent-plan fallback.

## Review boundary

- **User problem**: Cyclic AC dependencies are reported as a successful analysis and later fail ambiguously; the typed analysis error must not be converted into a dependency-dropping fallback.
- **Inputs and execution conditions**: Supported inputs are normalized AC graphs with valid, unique node indices and resolved dependency edges, reached through dependency-analyzed execution or direct planner use.

### Promised contract

- `DependencyAnalyzer.analyze()` returns `Result.err(DependencyCycleError)` for a cycle.
- Direct planners continue to expose an `ExecutionPlanningError`-compatible exception.
- The diagnostic identifies blocked AC indices, including any downstream dependents; it does not claim to enumerate only the strongly connected cycle members.
- The runner rejects this typed error before its ordinary analysis-error fallback, publishes no executable plan, and dispatches no implementation worker.
- The existing session failure boundary persists the failure.
- Acyclic ordering, supplied dependency constraints, and ordinary non-cycle fallback behavior remain unchanged.
- The change adds no provider calls, retries, or graph-repair attempts.

### Implementation boundary and owner

Existing orchestrator dependency analysis and runner planning boundary; owned by the orchestrator subsystem. The change adds an exported error subtype, changes the no-ready branch of topological ordering, returns the subtype through the analyzer's `Result` API, and recognizes it at the runner boundary. Existing persistence, cleanup, and execution-authority mechanisms are reused rather than replaced. No new subsystem, data schema, runtime authority, or external service is introduced.

`DependencyCycleError` derives from both `DependencyAnalysisError` and `ExecutionPlanningError` to preserve the two existing caller contracts. The runner's fallback construction is compacted without changing its behavior; the grandfathered runner module does not grow.

### Non-goals

- Automatic or model-based cycle repair.
- CLI/model selection, installation diagnostics, observer lifecycle, or game changes.
- General malformed-input parsing changes beyond preserving self-references as explicit cycles.
- Changing explicit sequential execution or revalidating already-persisted resume plans.
- Fixing existing Windows portability failures, skipping tests, or bypassing verification gates.

## Test plan and evidence

All dependency-analysis responses in the regression tests are stubbed/mocked; no live dependency-model or game-completion evidence is claimed.

- During initial development, 11 new behavioral cycle cases failed on the original implementation.
- With the analyzer change alone, the real runner reached its ordinary fallback and attempted executor dispatch. The final runner guard prevents that regression.
- 19 added regression cases pass, including structured and inferred self-referential cycles, valid DAG preservation, ordinary-error fallback compatibility, malformed provider output with structured cyclic dependencies, and a normalized single-node self-loop.
- The 17 cases also pass in two separate processes with fresh test profiles/databases: normal collection order (17 passed in 15.36s) and reversed order (17 passed in 19.89s). Both processes have a 180-second timeout; neither timed out.
- The real `execute_seed()` path invokes the real analyzer/parser. Its test closes and reopens an isolated SQLite store, reconstructs `FAILED`, verifies `DependencyCycleError`, and verifies no executor construction, worker call, or plan event.
- Final expanded candidate suite: **817 passed, 56 failed, 18 skipped** in 323.81s across the analyzer, runner-cycle, existing runner, and parallel-executor test files (891 cases).
- Pristine same-commit baseline: **800 passed, the same 56 failed, 18 skipped** across the three existing files. Failure test identifiers match exactly; no candidate-only failure was observed in this comparison.
- Full `ruff check src/ tests/` and `ruff format --check src/ tests/` pass.
- Changed production files pass mypy with imported-module diagnostics suppressed. Whole-source Windows mypy reproduces the baseline `hermes/artifacts.py:205` undefined `result` error. Whole-source `mypy --platform linux` passes; this is a static target check, not a Linux runtime test.
- Module-size and `git diff --check` pass. The generated patch passes a clean-baseline apply check and a candidate reverse check.

The pre-existing failures are not hidden or waived: one analyzer instrumentation-completeness test, three runner cwd tests, and 52 parallel-executor tests fail on both revisions in this Windows environment. Remote CI, the full repository suite, actual Linux/macOS runs, and unrelated TypeScript/Rust checks have not been run.

## Related issues

Fixes #2362.

Maintainer continuation of #2363 on current main. Supersedes #2363 because its contributor branch cannot be updated by maintainers.