### PR TITLE
fix(verifier): classify completed command test claims as evidence-form mismatches

### DIFF
--- a/src/ouroboros/orchestrator/evidence/test_detection.py
+++ b/src/ouroboros/orchestrator/evidence/test_detection.py
@@ -9,6 +9,7 @@ from ouroboros.orchestrator.adapter import AgentMessage
 from ouroboros.orchestrator.evidence.claims import (
     _runtime_message_command_values,
     _runtime_message_has_conflicting_tool_call_ids,
+    _runtime_message_has_following_success,
     _runtime_message_has_success_evidence,
     _runtime_message_is_tool_completion,
     _runtime_message_supports_command_claim,
@@ -31,6 +32,76 @@ from ouroboros.orchestrator.evidence.shell_parsing import (
     _test_command_invocation,
     _test_command_invocation_allowing_output_plumbing,
 )
+
+
+def _runtime_messages_have_completed_command_for_test_claim(
+    *, value: str, messages: tuple[AgentMessage, ...]
+) -> bool:
+    """Diagnose a command-valued test claim without approving its result.
+
+    A correlated zero-exit command is related runtime work, but need not have
+    run any tests. This runner-neutral fallback is only for classifying an
+    already rejected claim as an evidence-form mismatch. It does not parse
+    output or infer test names, and requires a distinct, ID-linked completion.
+    """
+    for index, message in enumerate(messages):
+        if message.tool_name != "Bash" or _runtime_message_is_tool_completion(message):
+            continue
+        call_id = _runtime_message_tool_call_id(message)
+        if call_id is None or not _runtime_message_supports_command_claim(value, message):
+            continue
+        # Unlike inline success, following-success requires unique starts and
+        # completions and rejects contradictory correlation aliases.
+        if not _runtime_message_has_following_success(messages, index):
+            continue
+        completions = [
+            candidate
+            for candidate in messages
+            if _runtime_message_is_tool_completion(candidate)
+            and _runtime_message_tool_call_id(candidate) == call_id
+        ]
+        # Also reject reused IDs with a completion preceding this start.
+        if len(completions) != 1:
+            continue
+        completion = completions[0]
+        exit_code = completion.data.get("exit_code")
+        if type(exit_code) is not int or exit_code != 0:
+            continue
+        pair = [message, completion]
+        if _test_chunk_has_structured_failure(pair):
+            continue
+        if any(_completed_command_has_invalid_status(item) for item in pair):
+            continue
+        return True
+    return False
+
+
+def _completed_command_has_invalid_status(message: AgentMessage) -> bool:
+    """Veto malformed markers and nested exits in the diagnostic-only path."""
+    containers = [message.data]
+    tool_result = message.data.get("tool_result")
+    if isinstance(tool_result, dict):
+        containers.append(tool_result)
+    for container in containers:
+        if container.get("is_error_invalid") is True:
+            return True
+        if "exit_code" in container and (
+            type(container["exit_code"]) is not int or container["exit_code"] != 0
+        ):
+            return True
+        for key in ("status", "runtime_event_type"):
+            if key in container and not isinstance(container[key], str):
+                return True
+        if str(container.get("status", "")).strip().lower() in {"failed", "error"}:
+            return True
+        if (
+            str(container.get("runtime_event_type", ""))
+            .strip()
+            .lower()
+            .endswith((".failed", ".error"))
+        ):
+            return True
+    return False
 
 
 def _runtime_messages_have_masked_test_command_for_test_claim(

--- a/src/ouroboros/orchestrator/evidence/verification.py
+++ b/src/ouroboros/orchestrator/evidence/verification.py
@@ -19,6 +19,7 @@ from ouroboros.orchestrator.evidence.harness_observation import (
 )
 from ouroboros.orchestrator.evidence.test_detection import (
     _functional_command_supports_test_claim,
+    _runtime_messages_have_completed_command_for_test_claim,
     _runtime_messages_have_masked_test_command_for_test_claim,
     _runtime_messages_support_test_claim,
 )
@@ -95,6 +96,8 @@ def _verify_atomic_evidence_against_runtime_messages(
 
     unsupported: list[str] = []
     evidence_form_mismatches: list[str] = []
+    masked_command_mismatch = False
+    completed_command_mismatch = False
     backed_commands = tuple(
         command
         for command in _flatten_evidence_values(typed_evidence.get("commands_run"))
@@ -136,6 +139,7 @@ def _verify_atomic_evidence_against_runtime_messages(
                     value,
                     field_messages,
                 ):
+                    masked_command_mismatch = True
                     evidence_form_mismatches.append(f"{field_name}: {value}")
                     unsupported.append(f"{field_name}: {value}")
                     continue
@@ -178,9 +182,15 @@ def _verify_atomic_evidence_against_runtime_messages(
                     messages=support_messages,
                     task_cwd=workspace_cwd,
                 ):
+                    masked_command_mismatch = True
                     evidence_form_mismatches.append(f"{field_name}: {value}")
                     unsupported.append(f"{field_name}: {value}")
                     continue
+                if _runtime_messages_have_completed_command_for_test_claim(
+                    value=value, messages=support_messages
+                ):
+                    completed_command_mismatch = True
+                    evidence_form_mismatches.append(f"{field_name}: {value}")
                 unsupported.append(f"{field_name}: {value}")
                 continue
             if not _runtime_messages_support_claim(value, field_messages):
@@ -192,12 +202,20 @@ def _verify_atomic_evidence_against_runtime_messages(
             if evidence_form_mismatches and len(evidence_form_mismatches) == len(unsupported)
             else "FABRICATION_SUSPECTED"
         )
-        reason_prefix = (
-            "evidence form mismatch; unprotected output-filter pipeline "
-            "cannot prove a clean command claim"
-            if failure_class == "EVIDENCE_FORM_MISMATCH"
-            else "unsupported evidence claims"
-        )
+        reason_prefix = "unsupported evidence claims"
+        if failure_class == "EVIDENCE_FORM_MISMATCH":
+            details = []
+            if masked_command_mismatch:
+                details.append(
+                    "unprotected output-filter pipeline cannot prove a clean command claim"
+                )
+            if completed_command_mismatch:
+                details.append(
+                    "recorded command completion cannot prove tests_passed; "
+                    "retry with contract-compliant test evidence from the runtime "
+                    "or a runner-owned adapter"
+                )
+            reason_prefix = "evidence form mismatch; " + "; ".join(details)
         return VerifierVerdict(
             passed=False,
             reasons=(reason_prefix + ": " + "; ".join(unsupported),),

--- a/tests/unit/orchestrator/evidence/test_command_form_mismatch.py
+++ b/tests/unit/orchestrator/evidence/test_command_form_mismatch.py
@@ -1,0 +1,298 @@
+"""A completed command is related work, not necessarily proof of passing tests."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from ouroboros.orchestrator.adapter import AgentMessage
+from ouroboros.orchestrator.evidence.verification import (
+    _verify_atomic_evidence_against_runtime_messages,
+)
+from ouroboros.orchestrator.evidence_schema import EvidenceRecord
+from ouroboros.orchestrator.failure_taxonomy import FailureClass, RecoveryAction, policy_for
+from ouroboros.orchestrator.profile_loader import EvidenceSchema, load_profile
+from ouroboros.orchestrator.verifier import VerifierVerdict
+
+TAP_OUTPUT = """TAP version 13
+# Subtest: addition
+ok 1 - addition
+1..1
+# tests 1
+# suites 0
+# pass 1
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+"""
+
+
+def _pair(command: str, output: str = TAP_OUTPUT) -> tuple[AgentMessage, AgentMessage]:
+    return (
+        AgentMessage(
+            type="tool",
+            content="Command started",
+            tool_name="Bash",
+            data={"tool_call_id": "run", "tool_input": {"command": command}},
+        ),
+        AgentMessage(
+            type="tool_result",
+            content=output,
+            data={"tool_call_id": "run", "exit_code": 0, "is_error": False},
+        ),
+    )
+
+
+def _verify(
+    messages: tuple[AgentMessage, ...],
+    claim: str,
+    *,
+    extra_claim: str | None = None,
+) -> VerifierVerdict:
+    return _verify_atomic_evidence_against_runtime_messages(
+        messages=(*messages, AgentMessage(type="result", content="done")),
+        typed_evidence=EvidenceRecord(
+            data={"tests_passed": [claim, *([extra_claim] if extra_claim else [])]}
+        ),
+        ac_content="Verify the implementation",
+        execution_profile=load_profile("code").model_copy(
+            update={"evidence_schema": EvidenceSchema(required=("tests_passed",))}
+        ),
+        task_cwd=None,
+        adapter_working_directory=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "command,output",
+    [
+        ("npm test", TAP_OUTPUT),
+        ("npm.cmd test", TAP_OUTPUT),
+        ("npm run verify:ac1", TAP_OUTPUT),
+        ("node --test checks.test.cjs", TAP_OUTPUT),
+        ("custom-check --all", "Checks completed."),
+        ("pytest -q", "expected failure case PASSED\n1 passed"),
+        ("npm run build", "Build complete."),
+        ("npm test", "No tests found"),
+        ("npm test", "0 passed"),
+    ],
+)
+def test_completed_command_with_unproven_test_result_is_mismatch(command, output) -> None:
+    verdict = _verify(_pair(command, output), command)
+
+    assert verdict.passed is False
+    assert verdict.failure_class == FailureClass.EVIDENCE_FORM_MISMATCH.value
+    reason = " ".join(verdict.reasons)
+    assert "cannot prove tests_passed" in reason
+    assert "retry with contract-compliant" in reason
+    assert "unprotected output-filter pipeline" not in reason
+    assert policy_for(FailureClass(verdict.failure_class)).action is RecoveryAction.RETRY
+
+
+@pytest.mark.parametrize("exit_code", [1, -1, "0", False, None])
+def test_failed_or_malformed_completion_is_not_reclassified(exit_code) -> None:
+    start, result = _pair("npm test")
+    result.data["exit_code"] = exit_code
+
+    verdict = _verify((start, result), "npm test")
+
+    assert verdict.passed is False
+    assert verdict.failure_class == FailureClass.FABRICATION_SUSPECTED.value
+
+
+def test_missing_completion_is_not_reclassified() -> None:
+    start, _ = _pair("npm test")
+    verdict = _verify((start,), "npm test")
+    assert verdict.passed is False
+    assert verdict.failure_class == FailureClass.FABRICATION_SUSPECTED.value
+
+
+def test_unrelated_completion_is_not_reclassified() -> None:
+    start, result = _pair("npm test")
+    result.data["tool_call_id"] = "different-run"
+    verdict = _verify((start, result), "npm test")
+    assert verdict.passed is False
+    assert verdict.failure_class == FailureClass.FABRICATION_SUSPECTED.value
+
+
+def test_unrelated_or_additional_unbacked_claim_keeps_fabrication_precedence() -> None:
+    for claim, extra in [("npm run invented", None), ("npm test", "invented test")]:
+        verdict = _verify(_pair("npm test"), claim, extra_claim=extra)
+        assert verdict.passed is False
+        assert verdict.failure_class == FailureClass.FABRICATION_SUSPECTED.value
+
+
+def test_existing_supported_test_proof_still_passes() -> None:
+    verdict = _verify(_pair("npm test", "1 passed"), "npm test")
+    assert verdict.passed is True
+
+
+@pytest.mark.parametrize(
+    "contradiction",
+    [
+        {"is_error": True},
+        {"is_error": "false"},
+        {"is_error_invalid": True},
+        {"status": "failed"},
+        {"status": 42},
+        {"runtime_event_type": "tool.failed"},
+        {"tool_result": "unstructured"},
+        {"tool_result": {"is_error": True}},
+        {"tool_result": {"is_error": "false"}},
+        {"tool_result": {"is_error_invalid": True}},
+        {"tool_result": {"status": "failed"}},
+        {"tool_result": {"status": " ERROR "}},
+        {"tool_result": {"runtime_event_type": "tool.failed"}},
+        {"tool_result": {"runtime_event_type": " TOOL.ERROR "}},
+        {"tool_result": {"exit_code": 1}},
+        {"tool_result": {"exit_code": False}},
+        {"tool_result": {"exit_code": "0"}},
+        {"tool_result": {"meta": {"exit_status": 1}}},
+        {"tool_result": {"meta": {"exit_status": False}}},
+        {"call_id": "conflicting-run"},
+        {"tool_result": {"meta": {"tool_call_id": "conflicting-run"}}},
+    ],
+)
+def test_contradictory_completion_is_not_reclassified(contradiction) -> None:
+    start, result = _pair("npm test")
+    result.data.update(contradiction)
+    verdict = _verify((start, result), "npm test")
+    assert verdict.passed is False
+    assert verdict.failure_class == FailureClass.FABRICATION_SUSPECTED.value
+
+
+@pytest.mark.parametrize("duplicate", ["start", "result", "result-with-inline-success"])
+def test_duplicate_correlation_is_not_reclassified(duplicate) -> None:
+    start, result = _pair("npm test")
+    second_start, second_result = _pair("npm test")
+    if duplicate == "start":
+        messages = (start, second_start, result)
+    else:
+        if duplicate == "result-with-inline-success":
+            start.data["exit_code"] = 0
+        messages = (start, result, second_result)
+    verdict = _verify(messages, "npm test")
+    assert verdict.passed is False
+    assert verdict.failure_class == FailureClass.FABRICATION_SUSPECTED.value
+
+
+def test_completion_before_start_cannot_hide_a_reused_id() -> None:
+    start, result = _pair("npm test")
+    _, earlier_result = _pair("npm test")
+    earlier_result.data["exit_code"] = 1
+    verdict = _verify((earlier_result, start, result), "npm test")
+    assert verdict.passed is False
+    assert verdict.failure_class == FailureClass.FABRICATION_SUSPECTED.value
+
+
+def test_invalid_error_marker_on_start_is_not_reclassified() -> None:
+    start, result = _pair("npm test")
+    start.data["is_error_invalid"] = True
+    verdict = _verify((start, result), "npm test")
+    assert verdict.passed is False
+    assert verdict.failure_class == FailureClass.FABRICATION_SUSPECTED.value
+
+
+@pytest.mark.parametrize(
+    "missing_proof",
+    ["no-exit", "no-ids", "wrong-tool", "inline-only", "conflicting-start", "start-failed"],
+)
+def test_incomplete_or_conflicting_execution_is_not_reclassified(missing_proof) -> None:
+    start, result = _pair("npm test")
+    messages = (start, result)
+    if missing_proof == "no-exit":
+        result.data.pop("exit_code")
+    elif missing_proof == "no-ids":
+        start.data.pop("tool_call_id")
+        result.data.pop("tool_call_id")
+    elif missing_proof == "wrong-tool":
+        messages = (start, replace(result, tool_name="Read"))
+    elif missing_proof == "inline-only":
+        start.data["exit_code"] = 0
+        messages = (start,)
+    elif missing_proof == "conflicting-start":
+        start.data["call_id"] = "other-run"
+    else:
+        start.data["exit_code"] = 1
+    verdict = _verify(messages, "npm test")
+    assert verdict.passed is False
+    assert verdict.failure_class == FailureClass.FABRICATION_SUSPECTED.value
+
+
+def test_narration_and_terminal_self_report_cannot_supply_completion() -> None:
+    start, _ = _pair("npm test")
+    narration = AgentMessage(type="assistant", content=TAP_OUTPUT, data={"exit_code": 0})
+    verdict = _verify((start, narration), "npm test")
+    assert verdict.passed is False
+    assert verdict.failure_class == FailureClass.FABRICATION_SUSPECTED.value
+    # The terminal result must be removed before looking for correlated completion.
+    terminal = AgentMessage(
+        type="result",
+        content=TAP_OUTPUT,
+        data={"tool_call_id": "run", "exit_code": 0, "tool_result": {"is_error": False}},
+    )
+    verdict = _verify_atomic_evidence_against_runtime_messages(
+        messages=(start, terminal),
+        typed_evidence=EvidenceRecord(data={"tests_passed": ["npm test"]}),
+        ac_content="Verify implementation",
+        execution_profile=load_profile("code").model_copy(
+            update={"evidence_schema": EvidenceSchema(required=("tests_passed",))}
+        ),
+        task_cwd=None,
+        adapter_working_directory=None,
+    )
+    assert verdict.passed is False
+    assert verdict.failure_class == FailureClass.FABRICATION_SUSPECTED.value
+
+
+@pytest.mark.parametrize("claim", ["checks.test.cjs", "addition", "npm test: 99 passed"])
+def test_command_completion_cannot_reclassify_names_or_invented_summaries(claim) -> None:
+    verdict = _verify(_pair("npm test"), claim)
+    assert verdict.passed is False
+    assert verdict.failure_class == FailureClass.FABRICATION_SUSPECTED.value
+
+
+def test_default_code_profile_keeps_unbacked_file_claim_precedence() -> None:
+    verdict = _verify_atomic_evidence_against_runtime_messages(
+        messages=(*_pair("npm test"), AgentMessage(type="result", content="done")),
+        typed_evidence=EvidenceRecord(
+            data={
+                "files_touched": ["invented.cjs"],
+                "commands_run": ["npm test"],
+                "tests_passed": ["npm test"],
+            }
+        ),
+        ac_content="Implement and test addition",
+        execution_profile=load_profile("code"),
+        task_cwd=None,
+        adapter_working_directory=None,
+    )
+    assert verdict.passed is False
+    assert verdict.failure_class == FailureClass.FABRICATION_SUSPECTED.value
+
+
+@pytest.mark.parametrize(
+    "wrapped",
+    [
+        '/bin/sh -lc "npm test"',
+        'powershell.exe -NoProfile -Command "npm test"',
+    ],
+)
+def test_existing_command_wrapper_equivalence_is_reused(wrapped) -> None:
+    verdict = _verify(_pair(wrapped), "npm test")
+    assert verdict.passed is False
+    assert verdict.failure_class == FailureClass.EVIDENCE_FORM_MISMATCH.value
+
+
+def test_mixed_masked_and_completed_commands_keep_both_diagnostics() -> None:
+    start, result = _pair("pytest -q | tail -100", "1 passed")
+    start.data["tool_call_id"] = "filtered"
+    result.data["tool_call_id"] = "filtered"
+    verdict = _verify((*_pair("npm test"), start, result), "npm test", extra_claim="pytest -q")
+    assert verdict.passed is False
+    assert verdict.failure_class == FailureClass.EVIDENCE_FORM_MISMATCH.value
+    reason = " ".join(verdict.reasons)
+    assert "unprotected output-filter pipeline" in reason
+    assert "recorded command completion cannot prove tests_passed" in reason


### PR DESCRIPTION
Refs #2380

## User problem

A command recorded in the runtime transcript and completed with exit 0 can be reported as fabricated when its `tests_passed` proof form is unsupported.

## Contract and boundary

This is a diagnostic/recovery-classification fix, not new test-proof admission. For command-valued claims already rejected by existing proof checks, require a distinct matching-ID completion with an integer exit code 0 and unambiguous correlation. Reject contradictory or malformed status. Classify the still-failed verdict as `EVIDENCE_FORM_MISMATCH` only if all unsupported claims have a supported mismatch form. Keep existing precedence for unbacked claims and preserve masked-pipeline diagnostics.

Changed owner/subsystem: core verifier evidence diagnostics, owned by Ouroboros verifier maintainers. Source changes are restricted to `evidence/test_detection.py` and `evidence/verification.py`; regression tests are in `tests/unit/orchestrator/evidence/test_command_form_mismatch.py`.

No runner parsers/allowlist changes, package-manifest reads, approval shortcuts, new artifact trust, shell/dispatch changes, profile schema changes, retry-policy changes, or new dependencies. ID-less/inline-only completions and file/case-name claim inference are outside this narrow diagnostic extension.

## Changes

- Add a runner-neutral completed-command diagnostic after existing proof paths.
- Validate matching IDs, unique starts/completions, explicit zero exit, and contradictory status across normalized result containers.
- Keep `passed=False`, report evidence-form mismatch with retry guidance, and retain both diagnostics when masked and completed-command mismatches coexist.
- Add 58 positive/negative regression cases with npm/Node examples and generic commands, including duplicate IDs, nested failure flags, fabricated summaries, narration, terminal results, missing proof, and mixed unsupported claims.

## Verification

- Submission base: v0.54.1 (`0dccbf1ba6f38e32b1892c37826fd8a2c0d1d925`). Initial wider QA below used v0.54.0; the affected verifier sources are unchanged upstream. Python 3.12/3.13 focused tests were rerun on v0.54.1.
- Red reproduction before patch: 9 failed / 9 passed.
- Final focused tests, Python 3.13: 58 passed; local independent code review approved the declared diagnostic-only boundary after adversarial checks.
- Python 3.12 focused + existing atomic/pipeline selection: 64 passed, 1 existing skip because this Windows environment cannot create symlinks.
- Native Node/npm smoke: 5 passed, using actual process output and normalized verifier messages (not a full seed execution).
- Broader evidence/atomic support suites, Python 3.13: 365 passed, 4 failed. All four reproduce on unmodified main: one symlink privilege failure and three test-reexecution portability assertions. No test skips were added.
- Ruff format/check over src and tests: pass.
- Module-size and diff whitespace checks: pass.
- Full Windows MyPy: 1 unchanged baseline error at `hermes/artifacts.py:205` on both main and this branch. Changed source modules: no type errors.

Full Linux CI, Bridge TypeScript, and seed E2E were not run locally.

## Limits / follow-up

The policy-compatible correction is honest failure classification, not automatic acceptance of TAP or arbitrary npm scripts. Full test-proof admission belongs in a separately designed runner-owned adapter or runner-neutral proof contract, owned by the verifier/profile maintainers. This patch neither installs such an adapter nor claims to recover the earlier failed execution.