### PR TITLE
chore(release): v0.54.2

### DIFF
--- a/.claude-plugin/.mcp.json
+++ b/.claude-plugin/.mcp.json
@@ -7,7 +7,7 @@
         "--python",
         ">=3.12",
         "--from",
-        "ouroboros-ai[mcp]==0.54.1",
+        "ouroboros-ai[mcp]==0.54.2",
         "ouroboros",
         "mcp",
         "serve",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "ouroboros",
       "description": "Sits in front of Claude Code and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
-      "version": "0.54.1",
+      "version": "0.54.2",
       "author": {
         "name": "Q00",
         "email": "jqyu.lee@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "description": "Sits in front of Claude Code and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
   "author": {
     "name": "Q00",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "description": "Sits in front of Codex CLI and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
   "author": {
     "name": "Q00",

--- a/.mcp.codex.json
+++ b/.mcp.codex.json
@@ -7,7 +7,7 @@
         "--python",
         ">=3.12",
         "--from",
-        "ouroboros-ai[mcp]==0.54.1",
+        "ouroboros-ai[mcp]==0.54.2",
         "ouroboros",
         "mcp",
         "serve",

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -296,7 +296,7 @@ A backup will be created: CLAUDE.md.bak
 **If "Preview first", show:**
 ````markdown
 <!-- ooo:START -->
-<!-- ooo:VERSION:0.54.1 -->
+<!-- ooo:VERSION:0.54.2 -->
 # Ouroboros — Specification-First AI Development
 
 > Before telling AI what to build, define what should be built.


### PR DESCRIPTION
## One user problem

Ship v0.54.2: sync plugin metadata to the release version so `claude plugin install`
and the bundled `.mcp.json` launchers resolve `0.54.2` rather than the previous `0.54.1`.

## Supported inputs and execution conditions

Release-mechanics only. Runs on `main` after merge; the `v0.54.2` tag is created on the
squash-merged commit, and `release.yml` builds and publishes to PyPI from that tag.

## Observable contract and invariants

`scripts/sync-plugin-version.py` (dry-run mode) reports no drift: every plugin manifest,
MCP launcher, and the `ooo:VERSION` marker in `skills/setup/SKILL.md` agree with the
hatch-vcs source version.

## Changed subsystem, data/security boundary, owner

Plugin metadata files only. No `src/` change, no data or security boundary touched.
Owner: @Q00.

## Non-goals

No behavior change. No code, dependency, or CI change — `uv.lock` is unchanged.

## Evidence

- `uv run ruff format src/ tests/` — 1432 files left unchanged
- `uv run ruff check src/ tests/ --fix` — All checks passed
- `uv run mypy src/ouroboros` — Success: no issues found in 632 source files
- `uv run --group mcp-test pytest tests/ -n 4 --dist worksteal -m "not performance"` — see comment
- `python3 scripts/sync-plugin-version.py` — no drift

## Release contents (v0.54.1..v0.54.2)

- #2376 / #2377 / #2378 — verifier false-rejection stack (codex bench 3/9 → 10/10)
- #2382 / #2383 — CLI workflow outcome telemetry, including non-success terminations
- #2375 — seed origin stamping so interview-less adoption is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvsR73SGeQmepCYWuaC2Ek
