### PR TITLE
chore(release): v0.54.3

### DIFF
--- a/.claude-plugin/.mcp.json
+++ b/.claude-plugin/.mcp.json
@@ -7,7 +7,7 @@
         "--python",
         ">=3.12",
         "--from",
-        "ouroboros-ai[mcp]==0.54.2",
+        "ouroboros-ai[mcp]==0.54.3",
         "ouroboros",
         "mcp",
         "serve",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "ouroboros",
       "description": "Sits in front of Claude Code and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
-      "version": "0.54.2",
+      "version": "0.54.3",
       "author": {
         "name": "Q00",
         "email": "jqyu.lee@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros",
-  "version": "0.54.2",
+  "version": "0.54.3",
   "description": "Sits in front of Claude Code and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
   "author": {
     "name": "Q00",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros",
-  "version": "0.54.2",
+  "version": "0.54.3",
   "description": "Sits in front of Codex CLI and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
   "author": {
     "name": "Q00",

--- a/.mcp.codex.json
+++ b/.mcp.codex.json
@@ -7,7 +7,7 @@
         "--python",
         ">=3.12",
         "--from",
-        "ouroboros-ai[mcp]==0.54.2",
+        "ouroboros-ai[mcp]==0.54.3",
         "ouroboros",
         "mcp",
         "serve",

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -296,7 +296,7 @@ A backup will be created: CLAUDE.md.bak
 **If "Preview first", show:**
 ````markdown
 <!-- ooo:START -->
-<!-- ooo:VERSION:0.54.2 -->
+<!-- ooo:VERSION:0.54.3 -->
 # Ouroboros — Specification-First AI Development
 
 > Before telling AI what to build, define what should be built.


### PR DESCRIPTION
## Summary
- Patch release v0.54.3: syncs plugin metadata versions (plugin.json, marketplace.json, .mcp.json variants, setup/SKILL.md) on top of main.
- Includes fix(telemetry): name pre-launch and recovered run failures instead of unknown (#2387)

## Test plan
- [x] `uv run ruff format` / `ruff check --fix` — no changes
- [x] `uv run mypy src/ouroboros` — passes
- [x] `python3 scripts/sync-plugin-version.py` — all files OK, no drift
- [ ] CI required checks (Bridge TypeScript, MyPy Type Check, Ruff Lint, Test Python 3.12)

no-issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vc9MuEJSdZpyzbyfdqxjph