### PR TITLE
feat(telemetry): carry ac_passed/ac_total on run outcomes

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -89,7 +89,7 @@ use. Each row below is the exact property set accepted by the serializer.
 | `subagent_dispatch` | A session used subagent fan-out — at most one row per user/day/phase/fanout_kind | phase (`emitted`/`submitted`/`unknown`), fanout_kind, runtime_backend, app_version, os, ci, `$insert_id` |
 | `command_run` (service=mcp) | A retained lifecycle MCP command succeeds/is accepted, or any MCP command fails/is blocked | command, service, status (`succeeded`, `accepted`, `failed`, `rejected`, `blocked`), error_type (exception failures only), origin (`command=seed` only; closed enum, see below), runtime_backend, app_version, os, ci, `$insert_id` |
 | `command_run` (service=cli) | A direct non-internal `ooo <command>` is invoked | command, service (`cli`), status (`invoked`), app_version, os, ci, `$insert_id` |
-| `workflow_outcome` | A background workflow, a terminal `ooo run`, or direct evaluation reaches a terminal result inside Ouroboros (a paused run is not terminal and emits nothing) | command, terminal_status, verified, failure_reason_code (non-success only), failure_cause (non-success `run` only; closed enum, see below), runtime_backend, app_version, os, ci, `$insert_id` |
+| `workflow_outcome` | A background workflow, a terminal `ooo run`, or direct evaluation reaches a terminal result inside Ouroboros (a paused run is not terminal and emits nothing) | command, terminal_status, verified, failure_reason_code (non-success only), failure_cause (non-success `run` only; closed enum, see below), ac_passed / ac_total (`run` only; see below), runtime_backend, app_version, os, ci, `$insert_id` |
 | `runtime_drift` | A frozen runtime authority input (Codex config, CLI executable, dispatch registry, profile routing) is observed to have changed after the runtime initialized; the run continues on the re-baselined input | kind (closed enum: `codex_config`/`cli_executable`/`skill_dispatcher`/`mcp_handler_registry`/`skill_dispatch_registry`/`profile_routing`/`baseline_unavailable`/`attestation_timeout`/`unknown`), runtime_backend, app_version, os, ci |
 | `ac_verify_failed` | The orchestrator's deterministic AC verify gate rejects an attempt (`run_verify_commands` enabled) | cause (closed enum: `invalid_contract`/`artifacts_missing`/`artifacts_missing_found_elsewhere`/`environment_unverifiable`/`timeout`/`exit_nonzero`/`output_assertion_unmatched`/`workspace_mutated`/`unknown`), runtime_backend, app_version, os, ci |
 
@@ -156,6 +156,14 @@ Notes:
   carries only the branch-level `failure_reason_code` its handler already
   reports on the direct path (`validation`/`config`/`auth`/`timeout`/`model`),
   never a `failure_cause`.
+- `ac_passed` / `ac_total` on a `run` outcome count the root-level acceptance
+  criteria the executor judged accepted versus judged at all, derived from
+  durable `execution.ac.attempt_judged` events (counts only — never AC text,
+  paths, commands, or output). A run is all-or-nothing, so this is what
+  separates a run that delivered 3 of 4 criteria from one that delivered
+  none. Absent when nothing was judged (e.g. a pre-launch rejection); the
+  boundary forwards the pair only as consistent non-negative integers with
+  `ac_passed <= ac_total`.
 - `command` values come only from static built-in command/tool/job registries.
 - `$insert_id` on `command_run` and `service_active` is a SHA-256 digest of the
   anonymous ID, UTC day, event, and retained dimensions. Job-derived

--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -613,6 +613,7 @@ async def _record_cli_run_outcome(
     outcome id is fresh per invocation because ``--resume`` reuses the
     execution id and each attempt is its own outcome. Never raises.
     """
+    from ouroboros.mcp.tools.run_ac_tally import derive_run_ac_tally
     from ouroboros.mcp.tools.run_failure_meta import derive_run_failure_meta
     from ouroboros.orchestrator.session import SessionStatus
 
@@ -651,6 +652,16 @@ async def _record_cli_run_outcome(
                         session_id=session_id,
                         execution_id=execution_id,
                         session_status=session_status,
+                    )
+                )
+            except Exception:
+                pass
+        if session_id is not None:
+            # Same enrichment rule: the tally never blocks the outcome.
+            try:
+                result_meta.update(
+                    await derive_run_ac_tally(
+                        event_store, session_id=session_id, execution_id=execution_id
                     )
                 )
             except Exception:

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -1989,20 +1989,24 @@ class JobManager:
         """Name why a recovered ``execute_seed`` job's linked run failed.
 
         Same closed vocabulary and evidence as the live handler path
-        (``derive_run_failure_meta``); only run jobs carry ``failure_cause``.
+        (``derive_run_failure_meta`` + ``derive_run_ac_tally``); only run
+        jobs carry ``failure_cause`` and the ``ac_passed``/``ac_total`` tally.
         """
         if snapshot.job_type != "execute_seed":
             return {}
         if not snapshot.links.session_id or not snapshot.links.execution_id:
             return {}
+        from ouroboros.mcp.tools.run_ac_tally import derive_run_ac_tally
         from ouroboros.mcp.tools.run_failure_meta import derive_run_failure_meta
 
-        return await derive_run_failure_meta(
-            self._event_store,
-            session_id=snapshot.links.session_id,
-            execution_id=snapshot.links.execution_id,
-            session_status=SessionStatus.FAILED,
+        ids = {
+            "session_id": snapshot.links.session_id,
+            "execution_id": snapshot.links.execution_id,
+        }
+        failure_meta = await derive_run_failure_meta(
+            self._event_store, session_status=SessionStatus.FAILED, **ids
         )
+        return {**failure_meta, **await derive_run_ac_tally(self._event_store, **ids)}
 
     async def _recover_linked_execution_terminal_snapshot(
         self,

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -243,6 +243,7 @@ def _execution_completed_job_event(
     result_text: str,
     *,
     session_id: str | None = None,
+    result_meta: Mapping[str, Any] | None = None,
 ) -> BaseEvent:
     """Build the synthetic/persisted job-completion event for execution recovery."""
     return BaseEvent(
@@ -257,6 +258,7 @@ def _execution_completed_job_event(
             "result_meta": {
                 "completed_from_execution_terminal": True,
                 **_run_only_verification_meta(session_id),
+                **dict(result_meta or {}),
             },
             "is_error": False,
             "timestamp": datetime.now(UTC).isoformat(),
@@ -264,7 +266,11 @@ def _execution_completed_job_event(
     )
 
 
-def _progress_accounting_failed_job_event(job_id: str, blocker: str) -> BaseEvent:
+def _progress_accounting_failed_job_event(
+    job_id: str,
+    blocker: str,
+    result_meta: Mapping[str, Any] | None = None,
+) -> BaseEvent:
     """Build the synthetic/persisted job-failure event for execution recovery."""
     return BaseEvent(
         id=f"{_RECOVERED_FAILURE_EVENT_ID_PREFIX}{job_id}",
@@ -277,7 +283,10 @@ def _progress_accounting_failed_job_event(job_id: str, blocker: str) -> BaseEven
                 "message": "Job failed: workflow progress accounting stalled",
                 "error": blocker,
                 "result_text": blocker,
-                "result_meta": {"failed_from_progress_accounting_stall": True},
+                "result_meta": {
+                    "failed_from_progress_accounting_stall": True,
+                    **dict(result_meta or {}),
+                },
                 "is_error": True,
                 "timestamp": datetime.now(UTC).isoformat(),
             }
@@ -1222,6 +1231,7 @@ class JobManager:
         *,
         check_current: bool = True,
         event_id: str | None = None,
+        result_meta: Mapping[str, Any] | None = None,
     ) -> bool:
         """Persist durable job failure derived from terminal execution evidence."""
         if check_current:
@@ -1236,7 +1246,10 @@ class JobManager:
                 "message": "Job failed: workflow progress accounting stalled",
                 "error": blocker,
                 "result_text": blocker,
-                "result_meta": {"failed_from_progress_accounting_stall": True},
+                "result_meta": {
+                    "failed_from_progress_accounting_stall": True,
+                    **dict(result_meta or {}),
+                },
                 "is_error": True,
             },
             event_id=event_id,
@@ -2052,15 +2065,27 @@ class JobManager:
             if linked_failure is not None
             else None
         )
+        recovery_tally: dict[str, int] | None = None
+        if snapshot.links.session_id:
+            from ouroboros.mcp.tools.run_ac_tally import derive_run_ac_tally
+
+            recovery_tally = await derive_run_ac_tally(
+                self._event_store,
+                session_id=snapshot.links.session_id,
+                execution_id=snapshot.links.execution_id,
+            )
         if getattr(self._event_store, "_read_only", False):
             if completed_result is not None:
                 event = _execution_completed_job_event(
                     snapshot.job_id,
                     completed_result,
                     session_id=snapshot.links.session_id,
+                    result_meta=recovery_tally,
                 )
             elif progress_blocker is not None:
-                event = _progress_accounting_failed_job_event(snapshot.job_id, progress_blocker)
+                event = _progress_accounting_failed_job_event(
+                    snapshot.job_id, progress_blocker, recovery_tally
+                )
             else:
                 event = _linked_execution_failed_job_event(
                     snapshot.job_id, linked_failure or "", linked_failure_meta
@@ -2086,6 +2111,7 @@ class JobManager:
                         snapshot.job_id,
                         completed_result,
                         session_id=snapshot.links.session_id,
+                        result_meta=recovery_tally,
                         check_current=False,
                         event_id=f"{_RECOVERED_COMPLETION_EVENT_ID_PREFIX}{snapshot.job_id}",
                     )
@@ -2095,6 +2121,7 @@ class JobManager:
                         progress_blocker,
                         check_current=False,
                         event_id=f"{_RECOVERED_FAILURE_EVENT_ID_PREFIX}{snapshot.job_id}",
+                        result_meta=recovery_tally,
                     )
                 else:
                     recovered = await self._append_linked_execution_failed_event(

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -56,6 +56,7 @@ from ouroboros.mcp.tools.job_observer import (
     append_job_observer_inline_handoff,
     build_job_observer_contract,
 )
+from ouroboros.mcp.tools.run_ac_tally import derive_run_ac_tally
 from ouroboros.mcp.tools.run_failure_meta import derive_run_failure_meta, launch_error
 from ouroboros.mcp.tools.subagent import (
     DELEGATED_TO_PLUGIN,
@@ -550,6 +551,12 @@ def _pause_metadata_from_progress(progress: dict[str, Any]) -> dict[str, Any]:
     if reason is not None:
         metadata["pause_reason"] = reason
     return metadata
+
+
+# Terminal run statuses whose meta carries the ``ac_passed``/``ac_total`` tally.
+_TALLIED_SESSION_STATUSES = frozenset(
+    {SessionStatus.COMPLETED, SessionStatus.FAILED, SessionStatus.CANCELLED}
+)
 
 
 def _classify_synchronous_execution_status(
@@ -2091,6 +2098,14 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     )
                     meta.update(failure_meta)
                     message += f"Failure Cause: {failure_meta['failure_cause']}\n"
+                if synchronous and session_status in _TALLIED_SESSION_STATUSES:
+                    meta.update(
+                        await derive_run_ac_tally(
+                            event_store,
+                            session_id=tracker.session_id,
+                            execution_id=tracker.execution_id,
+                        )
+                    )
                 if session_status == SessionStatus.PAUSED:
                     meta["paused"] = True
                     meta.update(pause_metadata)

--- a/src/ouroboros/mcp/tools/run_ac_tally.py
+++ b/src/ouroboros/mcp/tools/run_ac_tally.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import structlog
 
+from ouroboros.orchestrator.evidence.common import validate_attempt_judgment_payload
 from ouroboros.persistence.event_store import EventStore
 
 log = structlog.get_logger(__name__)
@@ -23,10 +24,10 @@ AC_PASSED_KEY = "ac_passed"
 AC_TOTAL_KEY = "ac_total"
 _JUDGED_EVENT_TYPE = "execution.ac.attempt_judged"
 _ACCEPTED_OUTCOMES = frozenset({"succeeded", "satisfied_externally"})
-_JUDGED_EVENT_LIMIT = 5000
+_JUDGED_EVENT_PAGE_SIZE = 5000
 
 
-def tally_judged_acs(events: Any, *, session_id: str) -> dict[str, int]:
+def tally_judged_acs(events: Any, *, session_id: str, execution_id: str) -> dict[str, int]:
     """Fold judged attempts into ``{"ac_passed": n, "ac_total": m}``.
 
     A root AC counts as passed when any of its attempts was accepted
@@ -37,13 +38,22 @@ def tally_judged_acs(events: Any, *, session_id: str) -> dict[str, int]:
     passed_by_root: dict[int, bool] = {}
     for event in events:
         data = getattr(event, "data", None)
-        if not isinstance(data, dict) or data.get("session_id") != session_id:
+        if not isinstance(data, dict):
             continue
-        root = data.get("root_ac_index", data.get("ac_index"))
-        if not isinstance(root, int) or isinstance(root, bool):
+        try:
+            judgment = validate_attempt_judgment_payload(
+                data,
+                event_type=getattr(event, "type", None),
+                aggregate_id=getattr(event, "aggregate_id", None),
+                expected_execution_id=execution_id,
+                expected_session_id=session_id,
+            )
+        except ValueError:
             continue
-        accepted = data.get("outcome") in _ACCEPTED_OUTCOMES
-        passed_by_root[root] = passed_by_root.get(root, False) or accepted
+        accepted = judgment.outcome in _ACCEPTED_OUTCOMES
+        passed_by_root[judgment.root_ac_index] = (
+            passed_by_root.get(judgment.root_ac_index, False) or accepted
+        )
     if not passed_by_root:
         return {}
     return {
@@ -60,11 +70,19 @@ async def derive_run_ac_tally(
 ) -> dict[str, int]:
     """Read the run's judged attempts and tally them. Best-effort: never raises."""
     try:
-        events = await event_store.query_events(
-            aggregate_id=execution_id,
-            event_type=_JUDGED_EVENT_TYPE,
-            limit=_JUDGED_EVENT_LIMIT,
-        )
+        events = []
+        offset = 0
+        while True:
+            page = await event_store.query_events(
+                aggregate_id=execution_id,
+                event_type=_JUDGED_EVENT_TYPE,
+                limit=_JUDGED_EVENT_PAGE_SIZE,
+                offset=offset,
+            )
+            events.extend(page)
+            if len(page) < _JUDGED_EVENT_PAGE_SIZE:
+                break
+            offset += len(page)
     except Exception:
         log.warning(
             "mcp.tool.execute_seed.ac_tally_unavailable",
@@ -72,7 +90,7 @@ async def derive_run_ac_tally(
             execution_id=execution_id,
         )
         return {}
-    return tally_judged_acs(events, session_id=session_id)
+    return tally_judged_acs(events, session_id=session_id, execution_id=execution_id)
 
 
 __all__ = ["AC_PASSED_KEY", "AC_TOTAL_KEY", "derive_run_ac_tally", "tally_judged_acs"]

--- a/src/ouroboros/mcp/tools/run_ac_tally.py
+++ b/src/ouroboros/mcp/tools/run_ac_tally.py
@@ -1,0 +1,78 @@
+"""Count how many of a run's acceptance criteria were judged done.
+
+A run's ``workflow_outcome`` is all-or-nothing: one rejected AC (or a final
+revalidation failure) makes the whole run ``failed``, so the fleet cannot
+tell a run that delivered 3 of 4 criteria from one that delivered none.
+This module derives two bounded integers — ``ac_passed`` / ``ac_total`` —
+from the executor's durable ``execution.ac.attempt_judged`` events, per
+root-level AC, so the outcome carries how much of the work was actually
+accepted. Counts only; never AC text, paths, commands, or output.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from ouroboros.persistence.event_store import EventStore
+
+log = structlog.get_logger(__name__)
+
+AC_PASSED_KEY = "ac_passed"
+AC_TOTAL_KEY = "ac_total"
+_JUDGED_EVENT_TYPE = "execution.ac.attempt_judged"
+_ACCEPTED_OUTCOMES = frozenset({"succeeded", "satisfied_externally"})
+_JUDGED_EVENT_LIMIT = 5000
+
+
+def tally_judged_acs(events: Any, *, session_id: str) -> dict[str, int]:
+    """Fold judged attempts into ``{"ac_passed": n, "ac_total": m}``.
+
+    A root AC counts as passed when any of its attempts was accepted
+    (``succeeded`` or ``satisfied_externally``); every judged root AC counts
+    toward the total. Returns ``{}`` when the session judged nothing, so a
+    run rejected before launch never claims ``0/0``.
+    """
+    passed_by_root: dict[int, bool] = {}
+    for event in events:
+        data = getattr(event, "data", None)
+        if not isinstance(data, dict) or data.get("session_id") != session_id:
+            continue
+        root = data.get("root_ac_index", data.get("ac_index"))
+        if not isinstance(root, int) or isinstance(root, bool):
+            continue
+        accepted = data.get("outcome") in _ACCEPTED_OUTCOMES
+        passed_by_root[root] = passed_by_root.get(root, False) or accepted
+    if not passed_by_root:
+        return {}
+    return {
+        AC_PASSED_KEY: sum(1 for accepted in passed_by_root.values() if accepted),
+        AC_TOTAL_KEY: len(passed_by_root),
+    }
+
+
+async def derive_run_ac_tally(
+    event_store: EventStore,
+    *,
+    session_id: str,
+    execution_id: str,
+) -> dict[str, int]:
+    """Read the run's judged attempts and tally them. Best-effort: never raises."""
+    try:
+        events = await event_store.query_events(
+            aggregate_id=execution_id,
+            event_type=_JUDGED_EVENT_TYPE,
+            limit=_JUDGED_EVENT_LIMIT,
+        )
+    except Exception:
+        log.warning(
+            "mcp.tool.execute_seed.ac_tally_unavailable",
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+        return {}
+    return tally_judged_acs(events, session_id=session_id)
+
+
+__all__ = ["AC_PASSED_KEY", "AC_TOTAL_KEY", "derive_run_ac_tally", "tally_judged_acs"]

--- a/src/ouroboros/telemetry.py
+++ b/src/ouroboros/telemetry.py
@@ -19,6 +19,7 @@ Privacy contract — see TELEMETRY.md at the repository root:
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import hashlib
 import json
 import os
@@ -281,6 +282,8 @@ _WORKFLOW_OUTCOME_KEYS = frozenset(
         "verified",
         "failure_reason_code",
         "failure_cause",
+        "ac_passed",
+        "ac_total",
         "$insert_id",
         "runtime_backend",
         "app_version",
@@ -1138,6 +1141,26 @@ def capture_subagent_dispatch(properties: dict[str, Any]) -> None:
         pass
 
 
+_AC_TALLY_CAP = 10_000
+
+
+def _run_ac_tally_properties(meta: Mapping[str, Any]) -> dict[str, int]:
+    """Forward ``ac_passed``/``ac_total`` only as a consistent pair of bounded ints.
+
+    Producer: ``mcp/tools/run_ac_tally.py``. Anything malformed (non-int,
+    bool, negative, passed > total, absurd size) drops both keys rather than
+    forwarding a partial or spoofed tally.
+    """
+    passed = meta.get("ac_passed")
+    total = meta.get("ac_total")
+    for value in (passed, total):
+        if not isinstance(value, int) or isinstance(value, bool):
+            return {}
+    if not (0 <= passed <= total <= _AC_TALLY_CAP):
+        return {}
+    return {"ac_passed": passed, "ac_total": total}
+
+
 def capture_job_outcome(
     job_id: str,
     job_type: str,
@@ -1178,6 +1201,8 @@ def capture_job_outcome(
             "verified": verified,
             "$insert_id": hashlib.sha256(f"ouroboros-job-outcome\0{job_id}".encode()).hexdigest(),
         }
+        if command == "run":
+            properties.update(_run_ac_tally_properties(meta))
         if resolution is not None:
             properties["failure_reason_code"] = resolution.reason_code.value
             # The fine-grained run cause (SSOT: orchestrator/run_failure_cause.py)

--- a/tests/unit/cli/test_run_outcome_telemetry.py
+++ b/tests/unit/cli/test_run_outcome_telemetry.py
@@ -285,3 +285,39 @@ async def test_run_orchestrator_records_and_flushes_non_success_outcomes(
     assert capture.call_args.kwargs["terminal_status"] == expected_status
     assert capture.call_args.kwargs["result_meta"]["success"] is False
     flush.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("success", "status", "terminal"),
+    [(True, SessionStatus.COMPLETED, "completed"), (False, SessionStatus.FAILED, "failed")],
+)
+async def test_terminal_run_carries_ac_tally(
+    success: bool, status: SessionStatus, terminal: str
+) -> None:
+    """The CLI outcome carries the same ac_passed/ac_total pair as an MCP job."""
+    with (
+        patch("ouroboros.telemetry.capture_job_outcome") as capture,
+        patch(
+            "ouroboros.mcp.tools.run_failure_meta.derive_run_failure_meta",
+            new_callable=AsyncMock,
+            return_value=_FAILURE_META,
+        ),
+        patch(
+            "ouroboros.mcp.tools.run_ac_tally.derive_run_ac_tally",
+            new_callable=AsyncMock,
+            return_value={"ac_passed": 3, "ac_total": 4},
+        ) as tally,
+    ):
+        await _record_cli_run_outcome(
+            Result.ok(_exec_result(success=success)),
+            event_store=MagicMock(),
+            session_repo=_session_repo(status),
+            execution_id="exec-local",
+            session_id="sess-local",
+        )
+
+    tally.assert_awaited_once_with(ANY, session_id="sess-test", execution_id="exec-test")
+    forwarded = capture.call_args.kwargs["result_meta"]
+    assert capture.call_args.kwargs["terminal_status"] == terminal
+    assert (forwarded["ac_passed"], forwarded["ac_total"]) == (3, 4)

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -1633,6 +1633,24 @@ class TestJobManager:
                     },
                 )
             )
+            for root, outcome in ((0, "failed"), (1, "succeeded")):
+                await store.append(
+                    BaseEvent(
+                        type="execution.ac.attempt_judged",
+                        aggregate_type="execution",
+                        aggregate_id="exec_default_failed",
+                        data={
+                            "execution_id": "exec_default_failed",
+                            "session_id": "orch_default_failed",
+                            "root_ac_index": root,
+                            "retry_attempt": 0,
+                            "attempt_number": 1,
+                            "is_decomposed": False,
+                            "success": outcome == "succeeded",
+                            "outcome": outcome,
+                        },
+                    )
+                )
 
             with (
                 patch.object(
@@ -1653,10 +1671,13 @@ class TestJobManager:
             # workflow_outcome as ``unknown``.
             assert snapshot.result_meta["failure_cause"] == "worker_fabrication_suspected"
             assert snapshot.result_meta["failure_reason_code"] == "validation"
+            assert snapshot.result_meta["ac_passed"] == 1
+            assert snapshot.result_meta["ac_total"] == 2
             capture.assert_called_once()
             forwarded = capture.call_args.kwargs["result_meta"]
             assert forwarded["failure_cause"] == "worker_fabrication_suspected"
             assert forwarded["failure_reason_code"] == "validation"
+            assert (forwarded["ac_passed"], forwarded["ac_total"]) == (1, 2)
         finally:
             await store.close()
 

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -1364,6 +1364,24 @@ class TestJobManager:
             )
             await store.append(
                 BaseEvent(
+                    type="execution.ac.attempt_judged",
+                    aggregate_type="execution",
+                    aggregate_id="exec_recover_failed",
+                    data={
+                        "execution_id": "exec_recover_failed",
+                        "session_id": "orch_recover_failed",
+                        "root_ac_index": 0,
+                        "ac_index": 0,
+                        "retry_attempt": 0,
+                        "attempt_number": 1,
+                        "is_decomposed": False,
+                        "success": True,
+                        "outcome": "succeeded",
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
                     type="execution.session.completed",
                     aggregate_type="execution",
                     aggregate_id="exec_recover_failed_ac_1",
@@ -1393,6 +1411,8 @@ class TestJobManager:
             assert snapshot.result_meta["failure_reason_code"] == "timeout"
             assert snapshot.result_meta["recovery_action"] == "retry"
             assert snapshot.result_meta["next_step"] == "Retry the workflow."
+            assert snapshot.result_meta["ac_passed"] == 1
+            assert snapshot.result_meta["ac_total"] == 1
             assert "workflow progress accounting stalled" in (snapshot.error or "")
             events, _ = await store.get_events_after("job", "job_recover_failed", last_row_id=0)
             assert [event.type for event in events] == ["mcp.job.created", "mcp.job.failed"]
@@ -1984,6 +2004,24 @@ class TestJobManager:
             )
             await store.append(
                 BaseEvent(
+                    type="execution.ac.attempt_judged",
+                    aggregate_type="execution",
+                    aggregate_id="exec_recover",
+                    data={
+                        "execution_id": "exec_recover",
+                        "session_id": "orch_recover",
+                        "root_ac_index": 0,
+                        "ac_index": 0,
+                        "retry_attempt": 0,
+                        "attempt_number": 1,
+                        "is_decomposed": False,
+                        "success": True,
+                        "outcome": "succeeded",
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
                     type="execution.terminal",
                     aggregate_type="execution",
                     aggregate_id="exec_recover",
@@ -1996,6 +2034,8 @@ class TestJobManager:
             assert snapshot.status is JobStatus.COMPLETED
             assert snapshot.message == "Execution complete; formal evaluation not run"
             assert snapshot.result_meta["completed_from_execution_terminal"] is True
+            assert snapshot.result_meta["ac_passed"] == 1
+            assert snapshot.result_meta["ac_total"] == 1
             assert snapshot.result_meta["evaluated"] is False
             assert snapshot.result_meta["verification_status"] == "executed_unverified"
             assert snapshot.result_meta["formal_evaluation_required"] is True

--- a/tests/unit/mcp/tools/test_run_ac_tally.py
+++ b/tests/unit/mcp/tools/test_run_ac_tally.py
@@ -16,14 +16,22 @@ EXECUTION = "exec_tally"
 
 
 def _judged(root: int, outcome: str, *, session: str = SESSION, **extra: Any) -> BaseEvent:
+    retry_attempt = extra.pop("retry_attempt", 0)
+    attempt_number = extra.pop("attempt_number", retry_attempt + 1)
     return BaseEvent(
         type="execution.ac.attempt_judged",
         aggregate_type="execution",
         aggregate_id=EXECUTION,
         data={
+            "execution_id": EXECUTION,
             "session_id": session,
             "root_ac_index": root,
+            "ac_index": root,
+            "retry_attempt": retry_attempt,
+            "attempt_number": attempt_number,
+            "is_decomposed": False,
             "outcome": outcome,
+            "success": outcome in {"succeeded", "satisfied_externally"},
             "ac_text": "/Users/private/project must never leak",
             **extra,
         },
@@ -39,16 +47,22 @@ def test_counts_each_root_ac_once_and_any_accepted_attempt_as_passed() -> None:
         _judged(3, "satisfied_externally"),
     ]
 
-    assert tally_judged_acs(events, session_id=SESSION) == {"ac_passed": 2, "ac_total": 4}
+    assert tally_judged_acs(events, session_id=SESSION, execution_id=EXECUTION) == {
+        "ac_passed": 2,
+        "ac_total": 4,
+    }
 
 
 def test_decomposed_children_fold_into_their_root() -> None:
     events = [
-        _judged(0, "succeeded", ac_index=5, is_decomposed_child=True),
-        _judged(0, "failed", ac_index=6, is_decomposed_child=True),
+        _judged(0, "succeeded", is_decomposed=True, is_decomposed_child=True),
+        _judged(0, "failed", is_decomposed=True, is_decomposed_child=True),
     ]
 
-    assert tally_judged_acs(events, session_id=SESSION) == {"ac_passed": 1, "ac_total": 1}
+    assert tally_judged_acs(events, session_id=SESSION, execution_id=EXECUTION) == {
+        "ac_passed": 1,
+        "ac_total": 1,
+    }
 
 
 def test_other_sessions_and_malformed_rows_are_ignored() -> None:
@@ -69,11 +83,31 @@ def test_other_sessions_and_malformed_rows_are_ignored() -> None:
         _judged(1, "failed"),
     ]
 
-    assert tally_judged_acs(events, session_id=SESSION) == {"ac_passed": 0, "ac_total": 1}
+    assert tally_judged_acs(events, session_id=SESSION, execution_id=EXECUTION) == {
+        "ac_passed": 0,
+        "ac_total": 1,
+    }
 
 
 def test_nothing_judged_yields_no_tally() -> None:
-    assert tally_judged_acs([], session_id=SESSION) == {}
+    assert tally_judged_acs([], session_id=SESSION, execution_id=EXECUTION) == {}
+
+
+def test_malformed_or_spoofed_judgments_are_ignored() -> None:
+    malformed = _judged(
+        -7,
+        "succeeded",
+        execution_id="exec-foreign",
+        ac_index=999,
+        is_decomposed="yes",
+        success=False,
+    )
+
+    assert tally_judged_acs(
+        [malformed, _judged(1, "failed")],
+        session_id=SESSION,
+        execution_id=EXECUTION,
+    ) == {"ac_passed": 0, "ac_total": 1}
 
 
 @pytest.mark.asyncio
@@ -85,8 +119,29 @@ async def test_derive_reads_only_judged_attempts_of_the_execution() -> None:
 
     assert tally == {"ac_passed": 1, "ac_total": 2}
     store.query_events.assert_awaited_once_with(
-        aggregate_id=EXECUTION, event_type="execution.ac.attempt_judged", limit=5000
+        aggregate_id=EXECUTION,
+        event_type="execution.ac.attempt_judged",
+        limit=5000,
+        offset=0,
     )
+
+
+@pytest.mark.asyncio
+async def test_derive_does_not_truncate_judgments_above_5000() -> None:
+    events = [_judged(root, "succeeded") for root in range(5001)]
+    store = AsyncMock()
+
+    async def query_events(**kwargs: Any) -> list[BaseEvent]:
+        limit = kwargs.get("limit")
+        offset = kwargs.get("offset", 0)
+        return events[offset:] if limit is None else events[offset : offset + limit]
+
+    store.query_events = AsyncMock(side_effect=query_events)
+
+    assert await derive_run_ac_tally(store, session_id=SESSION, execution_id=EXECUTION) == {
+        "ac_passed": 5001,
+        "ac_total": 5001,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/tools/test_run_ac_tally.py
+++ b/tests/unit/mcp/tools/test_run_ac_tally.py
@@ -1,0 +1,97 @@
+"""``ac_passed``/``ac_total`` are derived from judged attempts, per root AC."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ouroboros.core.errors import PersistenceError
+from ouroboros.events.base import BaseEvent
+from ouroboros.mcp.tools.run_ac_tally import derive_run_ac_tally, tally_judged_acs
+
+SESSION = "orch_tally"
+EXECUTION = "exec_tally"
+
+
+def _judged(root: int, outcome: str, *, session: str = SESSION, **extra: Any) -> BaseEvent:
+    return BaseEvent(
+        type="execution.ac.attempt_judged",
+        aggregate_type="execution",
+        aggregate_id=EXECUTION,
+        data={
+            "session_id": session,
+            "root_ac_index": root,
+            "outcome": outcome,
+            "ac_text": "/Users/private/project must never leak",
+            **extra,
+        },
+    )
+
+
+def test_counts_each_root_ac_once_and_any_accepted_attempt_as_passed() -> None:
+    events = [
+        _judged(0, "failed", retry_attempt=0),
+        _judged(0, "succeeded", retry_attempt=1),
+        _judged(1, "failed"),
+        _judged(2, "blocked"),
+        _judged(3, "satisfied_externally"),
+    ]
+
+    assert tally_judged_acs(events, session_id=SESSION) == {"ac_passed": 2, "ac_total": 4}
+
+
+def test_decomposed_children_fold_into_their_root() -> None:
+    events = [
+        _judged(0, "succeeded", ac_index=5, is_decomposed_child=True),
+        _judged(0, "failed", ac_index=6, is_decomposed_child=True),
+    ]
+
+    assert tally_judged_acs(events, session_id=SESSION) == {"ac_passed": 1, "ac_total": 1}
+
+
+def test_other_sessions_and_malformed_rows_are_ignored() -> None:
+    events = [
+        _judged(0, "succeeded", session="orch_other"),
+        BaseEvent(
+            type="execution.ac.attempt_judged",
+            aggregate_type="execution",
+            aggregate_id=EXECUTION,
+            data={"session_id": SESSION, "root_ac_index": True, "outcome": "succeeded"},
+        ),
+        BaseEvent(
+            type="execution.ac.attempt_judged",
+            aggregate_type="execution",
+            aggregate_id=EXECUTION,
+            data={"session_id": SESSION, "root_ac_index": "1", "outcome": "succeeded"},
+        ),
+        _judged(1, "failed"),
+    ]
+
+    assert tally_judged_acs(events, session_id=SESSION) == {"ac_passed": 0, "ac_total": 1}
+
+
+def test_nothing_judged_yields_no_tally() -> None:
+    assert tally_judged_acs([], session_id=SESSION) == {}
+
+
+@pytest.mark.asyncio
+async def test_derive_reads_only_judged_attempts_of_the_execution() -> None:
+    store = AsyncMock()
+    store.query_events = AsyncMock(return_value=[_judged(0, "succeeded"), _judged(1, "failed")])
+
+    tally = await derive_run_ac_tally(store, session_id=SESSION, execution_id=EXECUTION)
+
+    assert tally == {"ac_passed": 1, "ac_total": 2}
+    store.query_events.assert_awaited_once_with(
+        aggregate_id=EXECUTION, event_type="execution.ac.attempt_judged", limit=5000
+    )
+
+
+@pytest.mark.asyncio
+async def test_unreadable_store_yields_no_tally_without_raising() -> None:
+    store = AsyncMock()
+    store.query_events = AsyncMock(side_effect=PersistenceError("locked"))
+
+    assert await derive_run_ac_tally(store, session_id=SESSION, execution_id=EXECUTION) == {}

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -803,6 +803,42 @@ class TestCapture:
         assert props["failure_reason_code"] == "config"
         assert props["failure_cause"] == "launch_workspace_unavailable"
 
+    @pytest.mark.parametrize(
+        ("meta", "expected"),
+        [
+            ({"ac_passed": 3, "ac_total": 4}, {"ac_passed": 3, "ac_total": 4}),
+            ({"ac_passed": 0, "ac_total": 0}, {"ac_passed": 0, "ac_total": 0}),
+            ({"ac_passed": 5, "ac_total": 4}, {}),
+            ({"ac_passed": -1, "ac_total": 4}, {}),
+            ({"ac_passed": True, "ac_total": 1}, {}),
+            ({"ac_passed": "3", "ac_total": 4}, {}),
+            ({"ac_passed": 3}, {}),
+            ({"ac_passed": 3, "ac_total": 10_001}, {}),
+        ],
+    )
+    def test_run_ac_tally_forwards_only_a_consistent_int_pair(
+        self, sent: list[dict[str, Any]], meta: dict[str, Any], expected: dict[str, int]
+    ) -> None:
+        telemetry.capture_job_outcome(
+            "job-private-id", "execute_seed", terminal_status="failed", result_meta=meta
+        )
+        telemetry.flush(timeout=2.0)
+
+        props = sent[0]["properties"]
+        assert {k: props[k] for k in ("ac_passed", "ac_total") if k in props} == expected
+
+    def test_ac_tally_is_a_run_only_dimension(self, sent: list[dict[str, Any]]) -> None:
+        telemetry.capture_job_outcome(
+            "job-private-id",
+            "evaluate",
+            terminal_status="completed",
+            result_meta={"ac_passed": 3, "ac_total": 4, "final_approved": True},
+        )
+        telemetry.flush(timeout=2.0)
+
+        props = sent[0]["properties"]
+        assert "ac_passed" not in props and "ac_total" not in props
+
     def test_unaudited_failure_cause_folds_to_unknown(self, sent: list[dict[str, Any]]) -> None:
         telemetry.capture_job_outcome(
             "job-private-id",


### PR DESCRIPTION
Refs #2390

## The one user problem
The run success metric is all-or-nothing. On the maintainer's local store (60d), 33 of 153 failed runs had accepted at least one AC and 16 had accepted every AC; in PostHog they are indistinguishable from 0/N wipeouts. Product quality cannot be read from a binary `terminal_status`.

## Supported inputs and execution conditions
- Terminal `run` outcomes (completed / failed / cancelled) from: the synchronous `ExecuteSeedHandler` path that background `ouroboros_start_execute_seed` jobs run through; `execute_seed` job terminals recovered after a restart from linked execution evidence; CLI `ooo run` (`_record_cli_run_outcome`).
- Source of truth: durable `execution.ac.attempt_judged` events for the execution, folded per `root_ac_index` (decomposed children count toward their root). Accepted = `succeeded` or `satisfied_externally`.

## Observable contract and invariants
- New `workflow_outcome` properties `ac_passed` / `ac_total`, `run` only. Counts only — never AC text, paths, commands, or output (tested: a leaking `ac_text` field in the event is ignored).
- Absent when nothing was judged (a pre-launch rejection never claims 0/0). The boundary forwards the pair only as non-negative ints with `ac_passed <= ac_total <= 10_000`; a malformed or spoofed pair drops both keys. Non-run jobs never carry it.
- Enrichment only: derivation is best-effort and never blocks or drops the outcome (unreadable store → no tally).
- `TELEMETRY.md`: table row + explanatory note (property-addition convention, same as #2342/#2375/#2387).

## Changed subsystem, boundary, owner
MCP job lifecycle telemetry (new `mcp/tools/run_ac_tally.py`; `telemetry.py` allowlist + validator; `execution_handlers.py` and `job_manager.py` inside their grandfathered budgets; `cli/commands/run.py`). No new data or security boundary. Owner: maintainer.

## Non-goals
- Changing what `terminal_status` means or adding a `partial` status.
- Dashboard tiles for the new pair (add once data lands).

## Evidence
- Local store analysis (60d): failed runs by AC tally — 0/4 ×47, 0/3 ×20, 3/4 ×19, 4/4 ×13, 0/1 ×13, 0/2 ×9, 1/4 ×7, 2/4 ×6.
- Tests: `test_run_ac_tally.py` (per-root fold, retry accepted, decomposed children, complete pagination past 5,000 events, strict durable-payload validation, nothing judged → no tally, unreadable store), `test_telemetry.py` (consistent-pair validator incl. bool/str/negative/inverted/oversized, run-only), `test_job_manager.py` (completed, linked-failure, and progress-accounting restart recovery preserve the tally), `test_run_outcome_telemetry.py` (CLI carries the pair on completed and failed).
- Local: ruff, mypy, `check-module-size.py --baseline-ref origin/main` OK; `tests/unit/mcp` + `tests/unit/cli` + telemetry: 4615 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvsR73SGeQmepCYWuaC2Ek