### PR TITLE
fix(verifier): recognize Windows executable functional checks

### DIFF
--- a/src/ouroboros/orchestrator/evidence/test_detection.py
+++ b/src/ouroboros/orchestrator/evidence/test_detection.py
@@ -509,6 +509,7 @@ _FUNCTIONAL_INTERPRETER_NAMES = frozenset(
 # anchors; the existing workspace-file and zero-exit checks still provide the
 # authority, so this does not admit arbitrary command names or narration.
 _FUNCTIONAL_EXECUTABLE_SUFFIXES = (".exe", ".cmd", ".bat", ".ps1")
+_FUNCTIONAL_POWERSHELL_NAMES = frozenset({"powershell", "powershell.exe", "pwsh", "pwsh.exe"})
 
 
 _FILE_TOKEN_RE = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_./-]*\.[A-Za-z0-9_]+")
@@ -527,12 +528,23 @@ def _functional_command_invoked_files(command: str) -> tuple[str, ...]:
     the tier entirely.
     """
     tokens = [token.strip("'\"") for token in command.split()]
+    has_powershell = any(
+        token.rsplit("/", 1)[-1].rsplit("\\", 1)[-1].lower() in _FUNCTIONAL_POWERSHELL_NAMES
+        for token in tokens
+    )
+    has_start_process = any(token.lower() == "start-process" for token in tokens)
     has_interpreter = any(
         token.rsplit("/", 1)[-1].rsplit("\\", 1)[-1] in _FUNCTIONAL_INTERPRETER_NAMES
         or token.startswith(("./", ".\\"))
         or (
             token.lower().endswith(_FUNCTIONAL_EXECUTABLE_SUFFIXES)
-            and (index == 0 or tokens[index - 1].lower() in {"-filepath", "-file", "--file"})
+            and (
+                index == 0
+                or (
+                    tokens[index - 1].lower() in {"-filepath", "-file", "--file"}
+                    and (has_powershell or has_start_process)
+                )
+            )
         )
         for index, token in enumerate(tokens)
     )

--- a/src/ouroboros/orchestrator/evidence/test_detection.py
+++ b/src/ouroboros/orchestrator/evidence/test_detection.py
@@ -503,6 +503,13 @@ _FUNCTIONAL_INTERPRETER_NAMES = frozenset(
     {"python", "python3", "node", "bash", "sh", "zsh", "ruby", "perl", "php", "deno", "bun"}
 )
 
+# Native Windows verification commonly exercises the produced artifact
+# directly (for example ``.\\hello.exe``) instead of routing it through an
+# interpreter.  Treat executable/script suffixes as functional command
+# anchors; the existing workspace-file and zero-exit checks still provide the
+# authority, so this does not admit arbitrary command names or narration.
+_FUNCTIONAL_EXECUTABLE_SUFFIXES = (".exe", ".cmd", ".bat", ".ps1")
+
 
 _FILE_TOKEN_RE = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_./-]*\.[A-Za-z0-9_]+")
 
@@ -521,8 +528,13 @@ def _functional_command_invoked_files(command: str) -> tuple[str, ...]:
     """
     tokens = [token.strip("'\"") for token in command.split()]
     has_interpreter = any(
-        token.rsplit("/", 1)[-1] in _FUNCTIONAL_INTERPRETER_NAMES or token.startswith("./")
-        for token in tokens
+        token.rsplit("/", 1)[-1].rsplit("\\", 1)[-1] in _FUNCTIONAL_INTERPRETER_NAMES
+        or token.startswith(("./", ".\\"))
+        or (
+            token.lower().endswith(_FUNCTIONAL_EXECUTABLE_SUFFIXES)
+            and (index == 0 or tokens[index - 1].lower() in {"-filepath", "-file", "--file"})
+        )
+        for index, token in enumerate(tokens)
     )
     if not has_interpreter:
         return ()

--- a/tests/unit/orchestrator/evidence/test_functional_command_tier.py
+++ b/tests/unit/orchestrator/evidence/test_functional_command_tier.py
@@ -87,6 +87,7 @@ def test_invoked_files_require_an_interpreter_and_a_file_token() -> None:
         r"Start-Process -FilePath .\hello.exe -Wait"
     )
     assert _functional_command_invoked_files("echo fake.exe") == ()
+    assert _functional_command_invoked_files("echo -FilePath fake.exe") == ()
     # Heredoc drivers reference the artifact inside their body.
     heredoc = (
         "python3 - <<'PY'\nimport subprocess, sys\n"
@@ -231,6 +232,36 @@ def test_windows_executable_functional_claim_rejects_missing_artifact(tmp_path) 
             }
         ),
         ac_content="hello.exe prints the required output",
+        execution_profile=load_profile("code"),
+        task_cwd=str(tmp_path),
+        adapter_working_directory=str(tmp_path),
+        has_success_contract=True,
+        verify_gate_active=True,
+    )
+    assert verdict.passed is False
+
+
+def test_windows_option_form_rejects_non_powershell_command(tmp_path) -> None:
+    """An option-shaped mention must not certify an artifact that was not run."""
+    artifact = tmp_path / "fake.exe"
+    artifact.write_bytes(b"MZ")
+    claim = "echo -FilePath fake.exe"
+    start, result = _codex_bash_pair(claim)
+    verdict = _verify_atomic_evidence_against_runtime_messages(
+        messages=(
+            *_edit_pair("fake.exe"),
+            start,
+            result,
+            AgentMessage(type="result", content="done"),
+        ),
+        typed_evidence=EvidenceRecord(
+            data={
+                "files_touched": ["fake.exe"],
+                "commands_run": [claim],
+                "tests_passed": [claim],
+            }
+        ),
+        ac_content="fake.exe prints the required output",
         execution_profile=load_profile("code"),
         task_cwd=str(tmp_path),
         adapter_working_directory=str(tmp_path),

--- a/tests/unit/orchestrator/evidence/test_functional_command_tier.py
+++ b/tests/unit/orchestrator/evidence/test_functional_command_tier.py
@@ -82,6 +82,11 @@ def test_invoked_files_require_an_interpreter_and_a_file_token() -> None:
     assert _functional_command_invoked_files("cp habit_tracker.py /tmp/") == ()
     assert _functional_command_invoked_files("echo ok") == ()
     assert _functional_command_invoked_files("./run.sh") == ("run.sh",)
+    assert "hello.exe" in _functional_command_invoked_files(r".\hello.exe")
+    assert "hello.exe" in _functional_command_invoked_files(
+        r"Start-Process -FilePath .\hello.exe -Wait"
+    )
+    assert _functional_command_invoked_files("echo fake.exe") == ()
     # Heredoc drivers reference the artifact inside their body.
     heredoc = (
         "python3 - <<'PY'\nimport subprocess, sys\n"
@@ -136,6 +141,103 @@ def test_claim_without_transcript_execution_does_not_support() -> None:
         _functional_command_supports_test_claim(value=CLAIM, messages=messages, task_cwd=None)
         is False
     )
+
+
+def test_windows_executable_functional_claim_is_admitted(tmp_path) -> None:
+    """A Windows artifact invoked directly is valid functional evidence."""
+    artifact = tmp_path / "hello.exe"
+    artifact.write_bytes(b"MZ")
+    claim = r".\hello.exe"
+    start, result = _codex_bash_pair(claim)
+    verdict = _verify_atomic_evidence_against_runtime_messages(
+        messages=(
+            *_edit_pair("hello.exe"),
+            start,
+            result,
+            AgentMessage(type="result", content="done"),
+        ),
+        typed_evidence=EvidenceRecord(
+            data={
+                "files_touched": ["hello.exe"],
+                "commands_run": [claim],
+                "tests_passed": [claim],
+            }
+        ),
+        ac_content="hello.exe prints the required output",
+        execution_profile=load_profile("code"),
+        task_cwd=str(tmp_path),
+        adapter_working_directory=str(tmp_path),
+        has_success_contract=True,
+        verify_gate_active=True,
+    )
+    assert verdict.passed is True, verdict.reasons
+
+
+def test_windows_powershell_wrapper_functional_claim_is_admitted(tmp_path) -> None:
+    """The native Codex PowerShell wrapper can prove a produced executable."""
+    artifact = tmp_path / "hello.exe"
+    artifact.write_bytes(b"MZ")
+    claim = r"Start-Process -FilePath .\hello.exe -Wait -PassThru"
+    wrapped = (
+        '"C:\\Users\\runner\\pwsh.exe" -NoProfile -Command '
+        "'Start-Process -FilePath .\\\\hello.exe -Wait -PassThru'"
+    )
+    start = AgentMessage(
+        type="assistant",
+        content=f"Calling tool: Bash: {wrapped}",
+        tool_name="Bash",
+        data={"tool_input": {"command": wrapped}, "tool_call_id": "item-win"},
+    )
+    result = AgentMessage(
+        type="tool_result",
+        content="hello.exe",
+        data={"tool_call_id": "item-win", "exit_code": 0, "is_error": False},
+    )
+    verdict = _verify_atomic_evidence_against_runtime_messages(
+        messages=(
+            *_edit_pair("hello.exe"),
+            start,
+            result,
+            AgentMessage(type="result", content="done"),
+        ),
+        typed_evidence=EvidenceRecord(
+            data={
+                "files_touched": ["hello.exe"],
+                "commands_run": [claim],
+                "tests_passed": [claim],
+            }
+        ),
+        ac_content="hello.exe prints the required output",
+        execution_profile=load_profile("code"),
+        task_cwd=str(tmp_path),
+        adapter_working_directory=str(tmp_path),
+        has_success_contract=True,
+        verify_gate_active=True,
+    )
+    assert verdict.passed is True, verdict.reasons
+
+
+def test_windows_executable_functional_claim_rejects_missing_artifact(tmp_path) -> None:
+    """A direct Windows command cannot prove a ghost artifact."""
+    claim = r".\missing.exe"
+    start, result = _codex_bash_pair(claim)
+    verdict = _verify_atomic_evidence_against_runtime_messages(
+        messages=(start, result, AgentMessage(type="result", content="done")),
+        typed_evidence=EvidenceRecord(
+            data={
+                "files_touched": [],
+                "commands_run": [claim],
+                "tests_passed": [claim],
+            }
+        ),
+        ac_content="hello.exe prints the required output",
+        execution_profile=load_profile("code"),
+        task_cwd=str(tmp_path),
+        adapter_working_directory=str(tmp_path),
+        has_success_contract=True,
+        verify_gate_active=True,
+    )
+    assert verdict.passed is False
 
 
 def _verdict(*, verify_gate_active: bool):


### PR DESCRIPTION
## Problem

On native Windows, Codex can validate a produced artifact by invoking it directly (`.\hello.exe` or `Start-Process -FilePath .\hello.exe`). The code-profile functional evidence tier only recognized interpreter-driven commands, so the completed command was rejected as `FABRICATION_SUSPECTED` even when the artifact existed and the correlated command exited 0.

## Change

- Recognize `.exe`, `.cmd`, `.bat`, and `.ps1` as functional command anchors when they are the command token or a PowerShell `-FilePath`/`-File` argument.
- Preserve existing workspace-file, transcript-correlation, and authoritative zero-exit requirements.
- Keep arbitrary mentions such as `echo fake.exe` rejected.
- Add regression coverage for direct Windows executable and native PowerShell wrapper forms, including a missing-artifact negative case.

## Validation

- `uv run --python 3.13 pytest tests/unit/orchestrator/evidence/test_functional_command_tier.py tests/unit/orchestrator/evidence/test_command_form_mismatch.py -q` — 75 passed.
- Additional focused orchestrator command-shape checks — 23 passed.
- Ruff check and format check passed.
- Native Windows Codex orchestrator artifact probe — 5/5 executions succeeded (all exit code 0).

Refs #2394
