### PR TITLE
fix(install): keep Python version probes working on Windows PowerShell

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -372,9 +372,18 @@ function Test-PythonAtLeast([string]$Exe) {
     # print a diagnostic instead of running Python; skip them before invoking
     # the native command so Windows PowerShell does not surface NativeCommandError.
     if ($found -match '\\WindowsApps\\(?:python|python3)(?:\.exe)?$') { return $false }
-    # The Microsoft Store alias python.exe/python3.exe prints a hint and fails
-    # here, so it counts as absent instead of as an interpreter.
-    $out = (& $found -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>$null) -join ''
+    # Avoid embedded quotes: Windows PowerShell 5.1 strips them from native arguments.
+    # This optional probe may emit stderr, which 5.1 turns into NativeCommandError
+    # under Stop even with 2>$null. Judge the exit code and stdout instead.
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        $out = (& $found -c 'import sys; print(*sys.version_info[:2], sep=chr(46))' 2>$null) -join ''
+    } catch {
+        return $false
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
     if ($LASTEXITCODE -ne 0 -or -not ($out -match '^\d+\.\d+$')) { return $false }
     return ([version]$out -ge $MinPython)
 }

--- a/tests/unit/scripts/test_install_ps1_python.py
+++ b/tests/unit/scripts/test_install_ps1_python.py
@@ -1,0 +1,151 @@
+"""Run the installer's optional Python probe through real Windows native processes.
+
+Only the two functions under test are loaded; installing packages and changing
+user configuration are deliberately outside this harness. Other platforms and
+unavailable shells skip these tests.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import venv
+
+import pytest
+
+INSTALL_PS1 = Path(__file__).resolve().parents[3] / "scripts" / "install.ps1"
+pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="requires native Windows")
+
+_PROBE_SCRIPT = r"""
+[Console]::OutputEncoding = New-Object System.Text.UTF8Encoding($false)
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+if ($env:OOO_TEST_LEGACY -eq '1') { $PSNativeCommandArgumentPassing = 'Legacy' }
+$tokens = $null
+$parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $env:OOO_TEST_INSTALLER, [ref]$tokens, [ref]$parseErrors)
+if ($parseErrors.Count) { throw ($parseErrors -join '; ') }
+foreach ($name in @('Get-CommandPath', 'Test-PythonAtLeast')) {
+    $functions = @($ast.FindAll({ param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -eq $name
+    }, $true))
+    if ($functions.Count -ne 1) { throw "Expected exactly one $name function" }
+    . ([scriptblock]::Create($functions[0].Extent.Text))
+}
+$MinPython = [version]$env:OOO_TEST_MIN_PYTHON
+$errorsBefore = $Error.Count
+$answer = Test-PythonAtLeast $env:OOO_TEST_PYTHON
+[pscustomobject]@{
+    result = $answer
+    is_boolean = ($answer -is [bool])
+    error_preference = [string]$ErrorActionPreference
+    errors_added = ($Error.Count - $errorsBefore)
+} | ConvertTo-Json -Compress
+"""
+
+
+@pytest.fixture(params=["powershell.exe", "pwsh.exe", "pwsh-legacy"])
+def shell(request: pytest.FixtureRequest) -> tuple[str, bool]:
+    legacy = request.param == "pwsh-legacy"
+    executable = shutil.which("pwsh.exe" if legacy else request.param)
+    if executable is None:
+        pytest.skip(f"{request.param} not installed")
+    return executable, legacy
+
+
+def _probe(
+    shell: tuple[str, bool],
+    executable: str | Path,
+    minimum: str = "3.12",
+    extra_env: dict[str, str] | None = None,
+) -> dict:
+    # Pass paths through the environment and code as UTF-16LE so the harness
+    # does not introduce a second layer of native argument quoting.
+    env = {key: value for key, value in os.environ.items() if not key.startswith("PYTHON")}
+    env.update(
+        OOO_TEST_INSTALLER=str(INSTALL_PS1),
+        OOO_TEST_PYTHON=str(executable),
+        OOO_TEST_MIN_PYTHON=minimum,
+        OOO_TEST_LEGACY="1" if shell[1] else "0",
+    )
+    env.update(extra_env or {})
+    encoded = base64.b64encode(_PROBE_SCRIPT.encode("utf-16-le")).decode("ascii")
+    completed = subprocess.run(
+        [shell[0], "-NoProfile", "-NonInteractive", "-EncodedCommand", encoded],
+        env=env,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    result = json.loads(completed.stdout)
+    assert result["is_boolean"], result
+    assert result["error_preference"] == "Stop", result
+    return result
+
+
+@pytest.mark.parametrize(
+    ("minimum", "expected"),
+    [
+        ("3.12", True),
+        (f"{sys.version_info.major}.{sys.version_info.minor}", True),
+        (f"{sys.version_info.major}.{sys.version_info.minor + 1}", False),
+    ],
+    ids=["supported", "equal-minimum", "too-old"],
+)
+def test_real_python_version(shell: tuple[str, bool], minimum: str, expected: bool) -> None:
+    assert _probe(shell, sys.executable, minimum)["result"] is expected
+
+
+def test_real_python_path_with_spaces_and_unicode(shell: tuple[str, bool], tmp_path: Path) -> None:
+    python_dir = tmp_path / "Python 설치 경로"
+    venv.EnvBuilder(with_pip=False).create(python_dir)
+    assert _probe(shell, python_dir / "Scripts" / "python.exe")["result"] is True
+
+
+def test_missing_python_is_optional(shell: tuple[str, bool], tmp_path: Path) -> None:
+    assert _probe(shell, tmp_path / "missing-python.exe")["result"] is False
+
+
+def test_python_start_failure_is_optional(shell: tuple[str, bool], tmp_path: Path) -> None:
+    invalid_executable = tmp_path / "broken-python.exe"
+    invalid_executable.write_bytes(b"not a Windows executable")
+    assert _probe(shell, invalid_executable)["result"] is False
+
+
+def test_python_stderr_and_nonzero_exit_are_optional(
+    shell: tuple[str, bool], tmp_path: Path
+) -> None:
+    # CPython really fails during startup when its standard library is absent.
+    missing_home = tmp_path / "missing-python-home"
+    assert (
+        _probe(shell, sys.executable, extra_env={"PYTHONHOME": str(missing_home)})["result"]
+        is False
+    )
+
+
+def test_python_stderr_with_successful_exit(shell: tuple[str, bool], tmp_path: Path) -> None:
+    (tmp_path / "sitecustomize.py").write_text(
+        "import sys\nsys.stderr.write('startup diagnostic\\n')\n", encoding="utf-8"
+    )
+    assert _probe(shell, sys.executable, extra_env={"PYTHONPATH": str(tmp_path)})["result"] is True
+
+
+def test_windows_store_alias_is_skipped(shell: tuple[str, bool], tmp_path: Path) -> None:
+    # Resolution-only fixture: an invalid executable proves the existing alias
+    # guard returns before invocation, without opening the user's Store app.
+    alias = tmp_path / "WindowsApps" / "python.exe"
+    alias.parent.mkdir()
+    alias.write_bytes(b"must not execute")
+    result = _probe(shell, alias)
+    assert result["result"] is False
+    assert result["errors_added"] == 0


### PR DESCRIPTION
## Summary

The Windows installer can finish installing Ouroboros and then abort before configuring integrations because PowerShell 5.1 strips embedded double quotes from its Python version probe. PowerShell 7's Legacy mode instead rejects a working interpreter and invokes an unnecessary Python-install fallback.

Use a quote-free Python expression and keep stderr/invocation failure handling inside the optional probe. The existing exit-code, output-format, and minimum-version checks remain in place.

## Review boundary

- **User problem:** The optional Python check blocks installation or misidentifies an installed interpreter.
- **Inputs and execution conditions:** Native Windows PowerShell 5.1 and PowerShell 7 (default/Legacy argument passing), real Python executables, version thresholds, executable paths with spaces/Unicode, missing commands, WindowsApps aliases, startup diagnostics and failures.
- **Promised contract:** Return a boolean reflecting a successful, parseable, sufficiently recent interpreter. Unusable interpreters return false for the existing fallback; stderr alone does not reject a successful probe. Restore the caller's error policy.
- **Implementation boundary and owner:** `Test-PythonAtLeast` in the existing Windows installer and its script tests, owned by installer maintainers. No new subsystem or configuration changes.
- **Non-goals:** Repository-wide quoting cleanup, Windows/WSL support-policy changes, MCP registration/lifecycle changes, or changes to required package/setup error handling.
- **Evidence:** Tests load the actual functions from the installer AST and invoke real PowerShell/Python processes. Package installation and user configuration are not run by these tests.

## Test plan

Executed on Windows PowerShell **5.1.26100.9444**, PowerShell **7.6.5**, and Python **3.12.13**:

- `python -m pytest tests/unit/scripts/test_install_ps1_python.py -v`: **13 failed / 14 passed** on base `97098488`; **27 passed** with this fix.
- `python -m pytest tests/unit/scripts/test_install_ps1_python.py tests/unit/scripts/test_install_ps1.py -v`: **32 passed**.
- `ruff check src/ tests/` and `ruff format --check src/ tests/`: passed.
- `python -m mypy --platform linux src/ouroboros`: passed, **635 source files**.
- Additional local checks: 8/8 probes with PowerShell 7's `PSNativeCommandUseErrorActionPreference=$true` passed. A hermetic whole-script flow smoke passed 15/15 cases, including successful/failed optional fallback and fatal package-install failure. That smoke replaced external installation commands; it was **not** a fresh network/package-install end-to-end test.

Validation limits:
- The new behavioral tests require native Windows and skip unavailable shells; the current Linux CI does **not** exercise the Windows argument boundary.
- Native-Windows MyPy reports an existing `hermes/artifacts.py:205` undefined-name error. The broader local pytest attempt, using the documented MCP/e2e exclusions, stops during collection on the existing `fcntl` import in `scripts/sync-plugin-version.py`. The affected files are unchanged from the base commit; neither check is reported as passing.
- Bridge TypeScript was not run locally because Bun is unavailable. Repository CI remains responsible for the Linux full-suite and Bridge checks.

## Related issues

Fixes #2397.

The WindowsApps alias guard from #2392 is preserved; #2393 covers that related alias issue.

Prepared with Codex assistance; the commands and results above were executed locally.

## Maintainer follow-up

Exact HEAD `ab13e7749651dbdb81edb8b2f2c7f5896b6334f4` also rejects regex-valid version strings that cannot be represented by `System.Version`. The probe now uses `Version.TryParse`, and a real-Python `sitecustomize` regression verifies that an unrepresentable version returns `false` without changing the caller error policy.

Additional verification:
- focused Linux suite: 4 passed, 31 skipped (native-Windows cases skipped)
- portable PowerShell 7.6.6 adversarial probe: unrepresentable version returned boolean false; normal Python returned boolean true; caller error policy remained `Stop`
